### PR TITLE
Rdb: Allow RDB instance upgrade to HA without replacing the resource

### DIFF
--- a/scaleway/resource_rdb_instance_beta.go
+++ b/scaleway/resource_rdb_instance_beta.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"io/ioutil"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
@@ -267,6 +268,10 @@ func resourceScalewayRdbInstanceBetaUpdate(d *schema.ResourceData, m interface{}
 		if err != nil {
 			return err
 		}
+
+		// Wait for the instance to settle after upgrading
+		time.Sleep(30 * time.Second)
+
 	}
 
 	if d.HasChange("password") {

--- a/scaleway/resource_rdb_instance_beta.go
+++ b/scaleway/resource_rdb_instance_beta.go
@@ -51,11 +51,14 @@ func resourceScalewayRdbInstanceBeta() *schema.Resource {
 			"user_name": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Identifier for the first user of the database instance",
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
+				ForceNew:    true,
 				Description: "Password for the first user of the database instance",
 			},
 			"tags": {

--- a/scaleway/resource_rdb_instance_beta.go
+++ b/scaleway/resource_rdb_instance_beta.go
@@ -236,7 +236,7 @@ func resourceScalewayRdbInstanceBetaUpdate(d *schema.ResourceData, m interface{}
 	if err != nil {
 		return err
 	}
-	var upgradeInstanceRequests []rdb.UpgradeInstanceRequest
+	upgradeInstanceRequests := []rdb.UpgradeInstanceRequest(nil)
 	if d.HasChange("node_type") {
 		upgradeInstanceRequests = append(upgradeInstanceRequests,
 			rdb.UpgradeInstanceRequest{

--- a/scaleway/resource_rdb_instance_beta.go
+++ b/scaleway/resource_rdb_instance_beta.go
@@ -58,7 +58,6 @@ func resourceScalewayRdbInstanceBeta() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,
-				ForceNew:    true,
 				Description: "Password for the first user of the database instance",
 			},
 			"tags": {
@@ -269,6 +268,21 @@ func resourceScalewayRdbInstanceBetaUpdate(d *schema.ResourceData, m interface{}
 			return err
 		}
 	}
+
+	if d.HasChange("password") {
+		req := &rdb.UpdateUserRequest{
+			Region:     region,
+			InstanceID: ID,
+			Name:       d.Get("user_name").(string),
+			Password:   scw.StringPtr(d.Get("password").(string)),
+		}
+
+		_, err = rdbAPI.UpdateUser(req)
+		if err != nil {
+			return err
+		}
+	}
+
 	return resourceScalewayRdbInstanceBetaRead(d, m)
 }
 

--- a/scaleway/resource_rdb_instance_beta_test.go
+++ b/scaleway/resource_rdb_instance_beta_test.go
@@ -86,7 +86,7 @@ func TestAccScalewayRdbInstanceBeta(t *testing.T) {
 						is_ha_cluster = true
 						disable_backup = false
 						user_name = "my_initial_user"
-						password = "thiZ_is_v&ry_s3cret"
+						password = "thiZ_is_v&ry_s8cret"
 						tags = [ "terraform-test", "scaleway_rdb_instance_beta", "minimal" ]
 					}
 				`,
@@ -98,7 +98,7 @@ func TestAccScalewayRdbInstanceBeta(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "is_ha_cluster", "true"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "disable_backup", "false"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "user_name", "my_initial_user"),
-					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "password", "thiZ_is_v&ry_s3cret"),
+					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "password", "thiZ_is_v&ry_s8cret"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "tags.0", "terraform-test"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "tags.1", "scaleway_rdb_instance_beta"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "tags.2", "minimal"),

--- a/scaleway/resource_rdb_instance_beta_test.go
+++ b/scaleway/resource_rdb_instance_beta_test.go
@@ -53,7 +53,7 @@ func TestAccScalewayRdbInstanceBeta(t *testing.T) {
 						name = "test-rdb"
 						node_type = "db-dev-s"
 						engine = "PostgreSQL-11"
-						is_ha_cluster = true
+						is_ha_cluster = false
 						disable_backup = true
 						user_name = "my_initial_user"
 						password = "thiZ_is_v&ry_s3cret"
@@ -65,7 +65,7 @@ func TestAccScalewayRdbInstanceBeta(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "name", "test-rdb"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "node_type", "db-dev-s"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "engine", "PostgreSQL-11"),
-					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "is_ha_cluster", "true"),
+					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "is_ha_cluster", "false"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "disable_backup", "true"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "user_name", "my_initial_user"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance_beta.main", "password", "thiZ_is_v&ry_s3cret"),


### PR DESCRIPTION
This is to allow converting an RDB instance to HA without recreating the resource.

This PR also contains minor fixes to the user_name and password fields which cannot be modified using the RDB instance API.

I plan on creating dedicated resources to manage users and databases in an upcoming PR.

To test I modified the acceptance test to also include an HA upgrade. This change will increase the test runtime by about 10 minutes, we can revert it if that’s too much of a time penalty. 

The whole test suite timed-out because of an unrelated issue, so I ran the Rdb acceptance tests only with the following:

```
~/github/terraform-provider-scaleway/scaleway% time TF_ACC=1 go test -v . -run "TestAccScalewayRdb*" -timeout=30m 
=== RUN   TestAccScalewayRdbInstanceBeta
=== PAUSE TestAccScalewayRdbInstanceBeta
=== CONT  TestAccScalewayRdbInstanceBeta
--- PASS: TestAccScalewayRdbInstanceBeta (947.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	947.610s
TF_ACC=1 go test -v . -run "TestAccScalewayRdb*" -timeout=30m  5,87s user 1,47s system 0% cpu 15:49,36 total
```