### PR TITLE
feat(rdb): add scaleway_rdb_user_resource_beta

### DIFF
--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -201,6 +201,7 @@ func Provider() terraform.ResourceProvider {
 			"scaleway_lb_frontend_beta":              resourceScalewayLbFrontendBeta(),
 			"scaleway_registry_namespace_beta":       resourceScalewayRegistryNamespaceBeta(),
 			"scaleway_rdb_instance_beta":             resourceScalewayRdbInstanceBeta(),
+			"scaleway_rdb_user_beta":                 resourceScalewayRdbUserBeta(),
 			"scaleway_object_bucket":                 resourceScalewayObjectBucket(),
 			"scaleway_user_data":                     resourceScalewayUserData(),
 			"scaleway_server":                        resourceScalewayServer(),

--- a/scaleway/resource_rdb_instance_beta.go
+++ b/scaleway/resource_rdb_instance_beta.go
@@ -51,14 +51,14 @@ func resourceScalewayRdbInstanceBeta() *schema.Resource {
 			},
 			"user_name": {
 				Type:        schema.TypeString,
-				Required:    true,
 				ForceNew:    true,
+				Optional:    true,
 				Description: "Identifier for the first user of the database instance",
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Required:    true,
 				Sensitive:   true,
+				Optional:    true,
 				Description: "Password for the first user of the database instance",
 			},
 			"tags": {

--- a/scaleway/resource_rdb_user_beta.go
+++ b/scaleway/resource_rdb_user_beta.go
@@ -88,7 +88,7 @@ func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) erro
 
 	res, err := rdbAPI.ListUsers(&rdb.ListUsersRequest{
 		Region:     region,
-		InstanceID: expandID(instanceId),
+		InstanceID: instanceId,
 		Name:       &userName,
 	})
 
@@ -97,6 +97,7 @@ func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	var user = res.Users[0]
+	_ = d.Set("instance_id", fmt.Sprintf("%s/%s", region, instanceId))
 	_ = d.Set("name", user.Name)
 	_ = d.Set("password", d.Get("password").(string)) // password are immutable
 	_ = d.Set("is_admin", user.IsAdmin)

--- a/scaleway/resource_rdb_user_beta.go
+++ b/scaleway/resource_rdb_user_beta.go
@@ -55,10 +55,10 @@ func resourceScalewayRdbUserBetaCreate(d *schema.ResourceData, m interface{}) er
 	if err != nil {
 		return err
 	}
-	instanceId := d.Get("instance_id").(string)
+	instanceID := d.Get("instance_id").(string)
 	createReq := &rdb.CreateUserRequest{
 		Region:     region,
-		InstanceID: expandID(instanceId),
+		InstanceID: expandID(instanceID),
 		Name:       d.Get("name").(string),
 		Password:   d.Get("password").(string),
 		IsAdmin:    d.Get("is_admin").(bool),
@@ -69,7 +69,7 @@ func resourceScalewayRdbUserBetaCreate(d *schema.ResourceData, m interface{}) er
 		return err
 	}
 
-	d.SetId(resourceScalewayRdbUserBetaID(region, expandID(instanceId), res.Name))
+	d.SetId(resourceScalewayRdbUserBetaID(region, expandID(instanceID), res.Name))
 
 	return resourceScalewayRdbUserBetaRead(d, m)
 }
@@ -80,7 +80,7 @@ func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) erro
 		return err
 	}
 
-	_, instanceId, userName, err := resourceScalewayRdbUserBetaParseId(d.Id())
+	_, instanceID, userName, err := resourceScalewayRdbUserBetaParseId(d.Id())
 
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) erro
 
 	res, err := rdbAPI.ListUsers(&rdb.ListUsersRequest{
 		Region:     region,
-		InstanceID: instanceId,
+		InstanceID: instanceID,
 		Name:       &userName,
 	})
 
@@ -101,11 +101,11 @@ func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	var user = res.Users[0]
-	d.Set("instance_id", fmt.Sprintf("%s/%s", region, instanceId))
+	d.Set("instance_id", fmt.Sprintf("%s/%s", region, instanceID))
 	d.Set("name", user.Name)
 	d.Set("is_admin", user.IsAdmin)
 
-	d.SetId(resourceScalewayRdbUserBetaID(region, instanceId, user.Name))
+	d.SetId(resourceScalewayRdbUserBetaID(region, instanceID, user.Name))
 
 	return nil
 }

--- a/scaleway/resource_rdb_user_beta.go
+++ b/scaleway/resource_rdb_user_beta.go
@@ -80,7 +80,7 @@ func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) erro
 		return err
 	}
 
-	_, instanceID, userName, err := resourceScalewayRdbUserBetaParseId(d.Id())
+	instanceID, userName, err := resourceScalewayRdbUserBetaParseID(d.Id())
 
 	if err != nil {
 		return err
@@ -116,7 +116,7 @@ func resourceScalewayRdbUserBetaUpdate(d *schema.ResourceData, m interface{}) er
 		return err
 	}
 
-	_, instanceID, userName, err := resourceScalewayRdbUserBetaParseId(d.Id())
+	instanceID, userName, err := resourceScalewayRdbUserBetaParseID(d.Id())
 
 	if err != nil {
 		return err
@@ -149,7 +149,7 @@ func resourceScalewayRdbUserBetaDelete(d *schema.ResourceData, m interface{}) er
 		return err
 	}
 
-	_, instanceID, userName, err := resourceScalewayRdbUserBetaParseId(d.Id())
+	instanceID, userName, err := resourceScalewayRdbUserBetaParseID(d.Id())
 
 	if err != nil {
 		return err
@@ -176,10 +176,10 @@ func resourceScalewayRdbUserBetaID(region scw.Region, instanceID string, userNam
 
 // Extract instance ID and username from the resource identifier.
 // The resource identifier format is "Region/InstanceId/UserName"
-func resourceScalewayRdbUserBetaParseId(resourceId string) (region string, instanceID string, userName string, err error) {
+func resourceScalewayRdbUserBetaParseID(resourceId string) (instanceID string, userName string, err error) {
 	idParts := strings.Split(resourceId, "/")
 	if len(idParts) != 3 {
-		return "", "", "", fmt.Errorf("can't parse user resource id: %s", resourceId)
+		return "", "", fmt.Errorf("can't parse user resource id: %s", resourceId)
 	}
-	return idParts[0], idParts[1], idParts[2], nil
+	return idParts[1], idParts[2], nil
 }

--- a/scaleway/resource_rdb_user_beta.go
+++ b/scaleway/resource_rdb_user_beta.go
@@ -101,7 +101,7 @@ func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	var user = res.Users[0]
-	d.Set("instance_id", fmt.Sprintf("%s/%s", region, instanceID))
+	d.Set("instance_id", newRegionalID(region, instanceID))
 	d.Set("name", user.Name)
 	d.Set("is_admin", user.IsAdmin)
 

--- a/scaleway/resource_rdb_user_beta.go
+++ b/scaleway/resource_rdb_user_beta.go
@@ -1,0 +1,141 @@
+package scaleway
+
+import (
+	"io/ioutil"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func resourceScalewayRdbUserBeta() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceScalewayRdbUserBetaCreate,
+		Read:   resourceScalewayRdbUserBetaRead,
+		Update: resourceScalewayRdbUserBetaUpdate,
+		Delete: resourceScalewayRdbUserBetaDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Instance on which the user is created",
+				DiffSuppressFunc: diffSuppressFuncLocality,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "Database user name",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "Database user password",
+			},
+			"is_admin": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "Give admin permissions to database user",
+			},
+			// Common
+			"region":          regionSchema(),
+		},
+	}
+}
+
+func resourceScalewayRdbUserBetaCreate(d *schema.ResourceData, m interface{}) error {
+	rdbAPI, region, err := rdbAPIWithRegion(d, m)
+	if err != nil {
+		return err
+	}
+
+	createReq := &rdb.CreateUserRequest{
+		Region:         region,
+		InstanceID:     d.Get("instance_id").(string),
+		Name:           d.Get("name").(string),
+		Password:       d.Get("password").(string),
+		IsAdmin:        d.Get("is_admin").(bool),
+	}
+
+	res, err := rdbAPI.CreateUser(createReq)
+	if err != nil {
+		return err
+	}
+
+	return resourceScalewayRdbUserBetaRead(d, m)
+}
+
+func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) error {
+	rdbAPI, region, err := rdbAPIWithRegion(d, m)
+	if err != nil {
+		return err
+	}
+
+	res, err := rdbAPI.ListUsers(&rdb.ListUsersRequest{
+		Region:     region,
+		InstanceID: d.Get("instance_id").(string),
+		Name:       d.Get("name").(string),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	user = res[0]
+	_ = d.Set("name", user.Name)
+	_ = d.Set("password", d.Get("password").(string))   // password are immutable
+	_ = d.Set("is_admin", user.IsAdmin)
+
+	return nil
+}
+
+func resourceScalewayRdbUserBetaUpdate(d *schema.ResourceData, m interface{}) error {
+	rdbAPI, region, err := rdbAPIWithRegion(d, m)
+	if err != nil {
+		return err
+	}
+
+	req := &rdb.UpdateUserRequest{
+		Region:     region,
+		InstanceID: d.Get("instance_id").(string),
+	}
+
+	if d.HasChange("password") {
+		req.Password = scw.StringPtr(d.Get("password").(string))
+	}
+	if d.HasChange("is_admin") {
+		req.IsAdmin = scw.BoolPtr(d.Get("is_admin").(bool))
+	}
+
+	_, err = rdbAPI.UpdateUser(req)
+	if err != nil {
+		return err
+	}
+
+	return resourceScalewayRdbUserBetaRead(d, m)
+}
+
+func resourceScalewayRdbUserBetaDelete(d *schema.ResourceData, m interface{}) error {
+	rdbAPI, region, err := rdbAPIWithRegion(d, m)
+	if err != nil {
+		return err
+	}
+
+	err = rdbAPI.DeleteUser(&rdb.DeleteUserRequest{
+		Region:     region,
+		InstanceID: d.Get("instance_id").(string),
+		Name:       d.Get("name").(string),
+	})
+
+	if err != nil && !is404Error(err) {
+		return err
+	}
+
+	return nil
+}

--- a/scaleway/resource_rdb_user_beta.go
+++ b/scaleway/resource_rdb_user_beta.go
@@ -93,6 +93,10 @@ func resourceScalewayRdbUserBetaRead(d *schema.ResourceData, m interface{}) erro
 	})
 
 	if err != nil {
+		if is404Error(err) {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/scaleway/resource_rdb_user_beta_test.go
+++ b/scaleway/resource_rdb_user_beta_test.go
@@ -21,8 +21,8 @@ func TestAccScalewayRdbUserBeta(t *testing.T) {
 	resourceName := "scaleway_rdb_user_beta.db_user"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckScalewayRdbInstanceBetaDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -36,7 +36,7 @@ func TestAccScalewayRdbUserBeta(t *testing.T) {
 			{
 				Config: testAccScalewayRdbUserConfig(rName, "tata", "false"),
 				Check: resource.ComposeTestCheckFunc(
-				testAccCheckRdbUserBetaExists("scaleway_rdb_instance_beta.main", resourceName),
+					testAccCheckRdbUserBetaExists("scaleway_rdb_instance_beta.main", resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "tata"),
 					resource.TestCheckResourceAttr(resourceName, "is_admin", "false"),
 				),
@@ -58,15 +58,20 @@ func testAccCheckRdbUserBetaExists(instance string, user string) resource.TestCh
 			return fmt.Errorf("resource not found: %s", user)
 		}
 
-		rdbAPI, region, instanceID, err := rdbAPIWithRegionAndID(testAccProvider.Meta(), instanceResource.Primary.ID)
+		rdbAPI, region, _, err := rdbAPIWithRegionAndID(testAccProvider.Meta(), instanceResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, instanceId, userName, err := resourceScalewayRdbUserBetaParseId(userResource.Primary.ID)
 		if err != nil {
 			return err
 		}
 
 		users, err := rdbAPI.ListUsers(&rdb.ListUsersRequest{
-			InstanceID: instanceID,
+			InstanceID: instanceId,
 			Region:     region,
-			Name:       &userResource.Primary.ID,
+			Name:       &userName,
 		})
 
 		if len(users.Users) != 1 {

--- a/scaleway/resource_rdb_user_beta_test.go
+++ b/scaleway/resource_rdb_user_beta_test.go
@@ -63,7 +63,7 @@ func testAccCheckRdbUserBetaExists(instance string, user string) resource.TestCh
 			return err
 		}
 
-		_, instanceId, userName, err := resourceScalewayRdbUserBetaParseId(userResource.Primary.ID)
+		instanceId, userName, err := resourceScalewayRdbUserBetaParseID(userResource.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/scaleway/resource_rdb_user_beta_test.go
+++ b/scaleway/resource_rdb_user_beta_test.go
@@ -1,0 +1,89 @@
+package scaleway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
+)
+
+// TODO: refactor
+func init() {
+	resource.AddTestSweepers("scaleway_rdb_user_beta", &resource.Sweeper{
+		Name: "scaleway_rdb_user_beta",
+		F:    testSweepRDBInstance,
+	})
+}
+
+func TestAccScalewayRdbUserBeta(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: testAccCheckScalewayRdbInstanceBetaDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource scaleway_rdb_instance_beta main {
+    name = "test-terraform"
+    node_type = "db-dev-s"
+    engine = "PostgreSQL-12"
+    is_ha_cluster = false
+    user_name = "toto"
+    password = "Tata#Titi42"
+    tags = [ "terraform-test", "scaleway_rdb_user_beta", "minimal" ]
+}
+
+resource scaleway_rdb_user_beta db_user {
+  instance_id = scaleway_rdb_instance_beta.main.id
+  name = "titi"
+  password = "R34lP4sSw#Rd"
+  is_admin = true
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdbUserBetaExists("scaleway_rdb_instance_beta.main", "scaleway_rdb_user_beta.db_user"),
+					resource.TestCheckResourceAttr("scaleway_rdb_user_beta.db_user", "name", "titi"),
+					resource.TestCheckResourceAttr("scaleway_rdb_user_beta.db_user", "is_admin", "true"),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccCheckRdbUserBetaExists(instance string, user string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		instanceResource, ok := s.RootModule().Resources[instance]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", instance)
+		}
+
+		userResource, ok := s.RootModule().Resources[user]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", user)
+		}
+
+		rdbAPI, region, instanceID, err := rdbAPIWithRegionAndID(testAccProvider.Meta(), instanceResource.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		users, err := rdbAPI.ListUsers(&rdb.ListUsersRequest{
+			InstanceID: instanceID,
+			Region:     region,
+			Name:       &userResource.Primary.ID,
+		})
+
+		if len(users.Users) != 1 {
+			return fmt.Errorf("No user found")
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/scaleway/resource_rdb_user_beta_test.go
+++ b/scaleway/resource_rdb_user_beta_test.go
@@ -93,8 +93,6 @@ resource scaleway_rdb_instance_beta main {
     node_type = "db-dev-s"
     engine = "PostgreSQL-12"
     is_ha_cluster = false
-    user_name = "toto"
-    password = "Tata#Titi42"
     tags = [ "terraform-test", "scaleway_rdb_user_beta", "minimal" ]
 }`, rName)
 }

--- a/website/docs/r/rdb_instance_beta.html.markdown
+++ b/website/docs/r/rdb_instance_beta.html.markdown
@@ -12,7 +12,7 @@ description: |-
 Creates and manages Scaleway Database Instances. For more information, see [the documentation](https://developers.scaleway.com/en/products/rdb/api).
 
 ## Examples
-    
+
 ### Basic
 
 ```hcl
@@ -39,13 +39,11 @@ The following arguments are supported:
 
 ~> **Important:** Updates to `engine` will recreate the Database Instance.
 
-- `user_name` - (Required) Identifier for the first user of the database instance.
+- `user_name` - (Optional) Identifier for the first user of the database instance.
 
 ~> **Important:** Updates to `user_name` will recreate the Database Instance.
 
-- `password` - (Required) Password for the first user of the database instance.
-
-~> **Important:** Updates to `password` will recreate the Database Instance.
+- `password` - (Optional) Password for the first user of the database instance.
 
 - `is_ha_cluster` - (Optional) Enable or disable high availability for the database instance.
 
@@ -69,7 +67,7 @@ In addition to all arguments above, the following attributes are exported:
 - `id` - The ID of the Database Instance.
 - `endpoint_ip` - The IP of the Database Instance.
 - `endpoint_port` - The port of the Database Instance.
-- `read_replicas` - List of read replicas of the database instance. 
+- `read_replicas` - List of read replicas of the database instance.
   - `ip` - IP of the replica.
   - `port` - Port of the replica.
   - `name` - Name of the replica.

--- a/website/docs/r/rdb_user_beta.html.markdown
+++ b/website/docs/r/rdb_user_beta.html.markdown
@@ -16,11 +16,16 @@ Creates and manages Scaleway Database Users. For more information, see [the docu
 ### Basic
 
 ```hcl
+resource "random_password" "db_password" {
+  length = 16
+  special = true
+}
+
 resource scaleway_rdb_user_beta db_admin {
-  	instance_id = scaleway_rdb_instance_beta.main.id
-  	name = "titi"
-  	password = "R34lP4sSw#Rd"
-  	is_admin = true
+  instance_id = scaleway_rdb_instance_beta.main.id
+  name = "titi"
+  password = random_password.db_password.result
+  is_admin = true
 }
 ```
 

--- a/website/docs/r/rdb_user_beta.html.markdown
+++ b/website/docs/r/rdb_user_beta.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "scaleway"
+page_title: "Scaleway: scaleway_rdb_user_beta"
+description: |-
+  Manages Scaleway Database Users.
+---
+
+# scaleway_rdb_user_beta
+
+-> **Note:** This terraform resource is flagged beta and might include breaking change in future releases.
+
+Creates and manages Scaleway Database Users. For more information, see [the documentation](https://developers.scaleway.com/en/products/rdb/api).
+
+## Examples
+
+### Basic
+
+```hcl
+resource scaleway_rdb_user_beta db_admin {
+  	instance_id = scaleway_rdb_instance_beta.main.id
+  	name = "titi"
+  	password = "R34lP4sSw#Rd"
+  	is_admin = true
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+- `instance_id` - (Required) The instance on which to create the user.
+
+~> **Important:** Updates to `instance_id` will recreate the Database User.
+
+- `name` - (Required) Database User name.
+
+~> **Important:** Updates to `name` will recreate the Database User.
+
+- `password` - (Required) Database User password.
+
+- `is_admin` - (Optional) Grand admin permissions to the Database User.
+
+## Import
+
+Database User can be imported using `{region}/{instance_id}/{name}`, e.g.
+```bash
+$ terraform import scaleway_rdb_user_beta.admin fr-par/11111111-1111-1111-1111-111111111111/admin
+```

--- a/website/scaleway.erb
+++ b/website/scaleway.erb
@@ -181,6 +181,9 @@
             <li>
               <a href="/docs/providers/scaleway/r/rdb_instance_beta.html">scaleway_rdb_instance_beta</a>
             </li>
+            <li>
+               <a href="/docs/providers/scaleway/r/rdb_user_beta.html">scaleway_rdb_user_beta</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
This is to add a resource to manage RDB database users.

This allows to manage users admin permissions and passwords on RDB instances.

I've run the acceptance tests I've added:

```
17:12 paul@sca1 ~/github/terraform-provider-scaleway/scaleway% time TF_ACC=1 go test -v . -run "TestAccScalewayRdbUser*" -timeout=10m -count=1
=== RUN   TestAccScalewayRdbUserBeta
=== PAUSE TestAccScalewayRdbUserBeta
=== CONT  TestAccScalewayRdbUserBeta
--- PASS: TestAccScalewayRdbUserBeta (214.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-scaleway/scaleway	214.609s
TF_ACC=1 go test -v . -run "TestAccScalewayRdbUser*" -timeout=10m -count=1  6,05s user 0,81s system 3% cpu 3:37,17 total
```

Next step will be to allow creating instances without setting a user and password, so users can be fully managed using this type of resource.