### PR TITLE
doc(instance): fix typo in security_group doc

### DIFF
--- a/website/docs/d/instance_security_group.html.markdown
+++ b/website/docs/d/instance_security_group.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Gets information about a Security Group.
 ---
 
-# scaleway_security_group
+# scaleway_instance_security_group
 
 Gets information about a Security Group.
 


### PR DESCRIPTION
Fix typo in scaleway_instance_security_group documentation title.