### PR TITLE
Increase resource size limit (volume+server)

### DIFF
--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -83,8 +83,8 @@ func resourceScalewayServer() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 								value := v.(int)
-								if value > 150 {
-									errors = append(errors, fmt.Errorf("%q needs to be less than 150", k))
+								if value > 250 {
+									errors = append(errors, fmt.Errorf("%q needs to be less than 250", k))
 								}
 								return
 							},

--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -83,8 +83,8 @@ func resourceScalewayServer() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 								value := v.(int)
-								if value > 250 {
-									errors = append(errors, fmt.Errorf("%q needs to be less than 250", k))
+								if value > 300 {
+									errors = append(errors, fmt.Errorf("%q needs to be less than 300", k))
 								}
 								return
 							},

--- a/scaleway/resource_volume.go
+++ b/scaleway/resource_volume.go
@@ -32,8 +32,8 @@ func resourceScalewayVolume() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(int)
-					if value < 1 || value > 250 {
-						errors = append(errors, fmt.Errorf("%q be more than 1 and less than 250", k))
+					if value < 1 || value > 300 {
+						errors = append(errors, fmt.Errorf("%q be more than 1 and less than 300", k))
 					}
 					return
 				},

--- a/scaleway/resource_volume.go
+++ b/scaleway/resource_volume.go
@@ -32,8 +32,8 @@ func resourceScalewayVolume() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(int)
-					if value < 1 || value > 150 {
-						errors = append(errors, fmt.Errorf("%q be more than 1 and less than 150", k))
+					if value < 1 || value > 250 {
+						errors = append(errors, fmt.Errorf("%q be more than 1 and less than 250", k))
 					}
 					return
 				},


### PR DESCRIPTION
from 150 to 250, because it is supported by the API, and `fr-sefam-devops` has a disk of 200Gb.