### PR TITLE
doc: Documenting how to configure s3 backend with env vars

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -182,3 +182,10 @@ terraform {
 
 Beware as no locking mechanism are yet supported.
 Using scaleway object storage as terraform backend is not suitable if you work in a team with a risk of simultaneous access to the same plan.
+
+Note: For security reason it's not recommended to store secrets in terraform files. If you want to configure the backend with environnment var, you need to use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` [source](https://www.terraform.io/docs/backends/types/s3.html#access_key).
+
+```bash
+export AWS_ACCESS_KEY_ID=$SCW_ACCESS_KEY
+export AWS_SECRET_ACCESS_KEY=$SCW_SECRET_KEY
+```


### PR DESCRIPTION
Fix the following error if only `SCW_ACCESS_KEY` and `SCW_SECRET_KEY` are configured

```
$ terraform init                         
                                                                                                                       
Initializing the backend...                                                                                            
Backend configuration changed!                                                                                         
                                                                                                                       
Terraform has detected that the configuration specified for the backend  
has changed. Terraform will now check for existing state in the backends.      
                                                                                                                       
                                                                                                                       
                                                           
Error: error configuring S3 Backend: no valid credential sources for S3 Backend found.                                 
                                                                                                                       
Please see https://www.terraform.io/docs/backends/types/s3.html                                     
for more information about providing credentials.                                                                      
                                                                                                                       
Error: NoCredentialProviders: no valid providers in chain. Deprecated.                                                 
        For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```