### PR TITLE
chore: Enable cassette recording while playing acceptance tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,10 @@ jobs:
         run: go test -v ./... -timeout=1h -run TestAccScaleway${{ matrix.products }}*
         env:
           TF_LOG: DEBUG
+          # https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html#running-acceptance-tests
           TF_ACC: 1
+          # Enable recording with the cassette system. By doing so, we ensure that real HTTPS requests are made.
+          TF_UPDATE_CASSETTES: true
           SCW_DEBUG: 1
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}


### PR DESCRIPTION
I think I found out why the nightly test crashes, I think it's because of the cassettes.
https://github.com/scaleway/terraform-provider-scaleway/blob/master/.github/workflows/nightly.yml

basically here I don't indicate that I'm recording, so even if I'm in acceptance test mode, the cassettes interact with the real client.
So I think the best way to solve the problem is during the nightly to activate the recording of cassettes.