### PR TITLE
chore: disable fail-fast on github actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   nightly:
     strategy:
+      fail-fast: false
       matrix:
         products:
           - Account


### PR DESCRIPTION
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast