### PR TITLE
doc(guides): fix version argument in v1 to v2 migration guide

### DIFF
--- a/docs/guides/migration_guide_v2.md
+++ b/docs/guides/migration_guide_v2.md
@@ -21,20 +21,34 @@ If you are following these recommendations, update the version constraints in yo
 Update to latest `1.X` version:
 
 ```hcl
-provider "scaleway" {
-  # ... other configuration ...
+terraform {
+  required_providers {
+    scaleway = {
+      source = "scaleway/scaleway"
+      version = "~> 1.17"
+    }
+  }
+}
 
-  version = "~> 1.11"
+provider "scaleway" {
+  # ...
 }
 ```
 
 Update to latest 2.X version:
 
 ```hcl
-provider "scaleway" {
-  # ... other configuration ...
+terraform {
+  required_providers {
+    scaleway = {
+      source = "scaleway/scaleway"
+      version = "~> 2.0"
+    }
+  }
+}
 
-  version = "~> 2.0"
+provider "scaleway" {
+  # ...
 }
 ```
 


### PR DESCRIPTION
The `provider.version` meta-argument is deprecated, the `required_provider` block need to be used instead. ([doc](https://www.terraform.io/docs/configuration/providers.html#version-an-older-way-to-manage-provider-versions))