### PR TITLE
Revert "chore: remove usage of getokexists"

### DIFF
--- a/scaleway/resource_k8s_cluster.go
+++ b/scaleway/resource_k8s_cluster.go
@@ -283,8 +283,8 @@ func resourceScalewayK8SClusterCreate(ctx context.Context, d *schema.ResourceDat
 
 	req.AutoscalerConfig = autoscalerReq
 
-	autoUpgradeEnable, okAutoUpgradeEnable := d.GetOk("auto_upgrade.0.enable")
-	autoUpgradeStartHour, okAutoUpgradeStartHour := d.GetOk("auto_upgrade.0.maintenance_window_start_hour")
+	autoUpgradeEnable, okAutoUpgradeEnable := d.GetOkExists("auto_upgrade.0.enable")
+	autoUpgradeStartHour, okAutoUpgradeStartHour := d.GetOkExists("auto_upgrade.0.maintenance_window_start_hour")
 	autoUpgradeDay, okAutoUpgradeDay := d.GetOk("auto_upgrade.0.maintenance_window_day")
 
 	if okAutoUpgradeEnable {


### PR DESCRIPTION
Reverts scaleway/terraform-provider-scaleway#629

The GetOkExists method should be replaced by a propre replacement when available, we should keep the deprecate method meanwhile