### PR TITLE
Add missing mac_address attribute in the instance_private_nic documentation

### DIFF
--- a/docs/resources/instance_private_nic.md
+++ b/docs/resources/instance_private_nic.md
@@ -30,6 +30,7 @@ The following arguments are required:
 In addition to all above arguments, the following attributes are exported:
 
 - `id` - The ID of the private NIC.
+- ``mac_address` - The MAC address of the private NIC.
 
 ## Import
 


### PR DESCRIPTION
As per the [test][1], the `scaleway_instance_private_nic` has a `mac_address` attribute that is missing from the documentation.

[1]: https://github.com/scaleway/terraform-provider-scaleway/blob/831de93490ddc5de298c009c7217027e3ff34dd7/scaleway/resource_instance_private_nic_test.go#L45