### PR TITLE
doc: fix typo tarraform -> terraform

### DIFF
--- a/docs/resources/vpc_private_network.md
+++ b/docs/resources/vpc_private_network.md
@@ -14,7 +14,7 @@ For more information, see [the documentation](https://developers.scaleway.com/en
 ```hcl
 resource "scaleway_vpc_private_network" "pn_priv" {
     name = "subnet_demo"
-    tags = ["demo", "tarraform"]
+    tags = ["demo", "terraform"]
 }
 ```
 


### PR DESCRIPTION
Small typo in the vpc_private_network resource doc.