### PR TITLE
chore: update go version to enable darwin/arm64 (m1) support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -7,7 +7,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Archive from @bflad

You may have noticed that Go 1.16 released yesterday and includes support for the new Apple M1 (“silicon”) hardware via a new release platform: darwin/arm64. If you are using goreleaser for provider releases, allow it to use the latest goreleaser version (most common), and update the release process to use Go 1.16, it will automatically include the new platform in releases. The Terraform Registry should ingress and serve them just fine, but please note that native Terraform CLI support for darwin/arm64 can be tracked in https://github.com/hashicorp/terraform/issues/27257 which will be updated with our timelines to prevent confusing errors for practitioners while the provider ecosystem starts rolling out this new platform.
One caveat to the typical goreleaser configuration for releases is that if you do not update to Go 1.16, it will still try to build on the unsupported platform (for the older Go versions). Example error:
```
   ⨯ release failed after 16.92s error=failed to build for darwin_arm64: # github.com/example/terraform-provider-example
/opt/hostedtoolcache/go/1.15.8/x64/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/tmp/go-link-710842256/go.o: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
```

You can choose one of these options remediate this:
Update the provider codebase and .github/workflows/release.yml to Go 1.16
Pin the goreleaser version in your .github/workflows/release.yml to v0.155.0

```yaml
      -
        name: Run GoReleaser
        uses: goreleaser/goreleaser-action@v2
        with:
          version: v0.155.0
          args: ...
```

Ignore the new platform in .goreleaser.yml under builds

```yaml
ignore:
  - goos: darwin
    goarch: arm64
```