### PR TITLE
feat(k8s): change default runtime to containerd

### DIFF
--- a/scaleway/resource_k8s_pool.go
+++ b/scaleway/resource_k8s_pool.go
@@ -83,7 +83,7 @@ func resourceScalewayK8SPool() *schema.Resource {
 			"container_runtime": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     k8s.RuntimeDocker.String(),
+				Default:     k8s.RuntimeContainerd.String(),
 				ForceNew:    true,
 				Description: "Container runtime for the pool",
 				ValidateFunc: validation.StringInSlice([]string{


### PR DESCRIPTION
BREAKING CHANGE: default runtime for k8s pool is now containerd instead of docker
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>