### PR TITLE
tests(instance/snapshot): fix 'Computed attributes cannot be set, but…

### DIFF
--- a/scaleway/resource_instance_snapshot_test.go
+++ b/scaleway/resource_instance_snapshot_test.go
@@ -46,7 +46,6 @@ func TestAccScalewayInstanceSnapshot_Server(t *testing.T) {
 
 					resource "scaleway_instance_snapshot" "main" {
 						volume_id = scaleway_instance_server.main.root_volume.0.volume_id
-						type = "l_ssd"
 					}`,
 			},
 		},


### PR DESCRIPTION
… a value was set for "type"'

In fact the [API](https://developers.scaleway.com/en/products/instance/api/#post-f271c8) does not list the type as a argument for the snapshot creation.

```bash
$ TF_ACC=1 go test -a  ./scaleway -v -run=TestAccScalewayInstanceSnapshot_Server -timeout=20m -parallel=5                                                                                                                                                                                                                                         
=== RUN   TestAccScalewayInstanceSnapshot_Server 
--- PASS: TestAccScalewayInstanceSnapshot_ServerWithBlockVolume (0.63s)
PASS
```