### PR TITLE
ci(nightly): Some products are not tested

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,10 +12,13 @@ jobs:
       matrix:
         products:
           - Account
+          - AppleSilicon
           - Baremetal
           - Instance
+          - Iot
           - K8S
           - Lb
+          - Marketplace
           - Object
           - Rdb
           - Registry

--- a/scaleway/data_source_rdb_instance_test.go
+++ b/scaleway/data_source_rdb_instance_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccScalewayDataSourceRDBInstance_Basic(t *testing.T) {
+func TestAccScalewayDataSourceRdbInstance_Basic(t *testing.T) {
 	tt := NewTestTools(t)
 	defer tt.Cleanup()
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
```bash
$ grep -r "func TestAccScaleway" scaleway/  | cut -d " " -f 2 |cut -d "(" -f 1 | sed -e 's/TestAccScaleway//' -e "s/DataSource//" |sort |grep -v -e "^Account" -e "^Baremetal" -e "^Instance" -e "^K8S" -e "^Lb" -e "^Object" -e "^Rdb" -e "^Registry" -e "^VPC"
IotDevice_Minimal         
IotHub_Minimal
IotNetwork_Minimal      
IotRoute_Minimal                 
MarketplaceImage_Basic
RDBInstance_Basic
```