### PR TITLE
fix(instance/volume): Wait for the volume after resizing it

### DIFF
--- a/scaleway/resource_instance_volume.go
+++ b/scaleway/resource_instance_volume.go
@@ -171,15 +171,6 @@ func resourceScalewayInstanceVolumeUpdate(ctx context.Context, d *schema.Resourc
 		if oldSize, newSize := d.GetChange("size_in_gb"); oldSize.(int) > newSize.(int) {
 			return diag.FromErr(fmt.Errorf("block volumes cannot be resized down"))
 		}
-		_, err := instanceAPI.WaitForVolume(&instance.WaitForVolumeRequest{
-			VolumeID:      id,
-			Zone:          zone,
-			RetryInterval: DefaultWaitRetryInterval,
-		}, scw.WithContext(ctx))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
 		volumeSizeInBytes := scw.Size(uint64(d.Get("size_in_gb").(int)) * gb)
 		_, err = instanceAPI.UpdateVolume(&instance.UpdateVolumeRequest{
 			VolumeID: id,
@@ -188,6 +179,14 @@ func resourceScalewayInstanceVolumeUpdate(ctx context.Context, d *schema.Resourc
 		}, scw.WithContext(ctx))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("couldn't resize volume: %s", err))
+		}
+		_, err := instanceAPI.WaitForVolume(&instance.WaitForVolumeRequest{
+			VolumeID:      id,
+			Zone:          zone,
+			RetryInterval: DefaultWaitRetryInterval,
+		}, scw.WithContext(ctx))
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/scaleway/resource_instance_volume.go
+++ b/scaleway/resource_instance_volume.go
@@ -179,6 +179,7 @@ func resourceScalewayInstanceVolumeUpdate(ctx context.Context, d *schema.Resourc
 		if err != nil {
 			return diag.FromErr(err)
 		}
+
 		volumeSizeInBytes := scw.Size(uint64(d.Get("size_in_gb").(int)) * gb)
 		_, err = instanceAPI.UpdateVolume(&instance.UpdateVolumeRequest{
 			VolumeID: id,

--- a/scaleway/testdata/instance-volume-resize-block.cassette.yaml
+++ b/scaleway/testdata/instance-volume-resize-block.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-vol-heuristic-turing","project":"9af7216e-7b97-404d-8ada-9f379eb39ae5","volume_type":"b_ssd","size":20000000000}'
+    body: '{"name":"tf-vol-funny-bhaskara","project":"a57bd23d-c866-49eb-a6ac-438f85c22957","volume_type":"b_ssd","size":20000000000}'
     form: {}
     headers:
       Content-Type:
@@ -13,22 +13,22 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:26.843537+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:18 GMT
+      - Wed, 19 May 2021 14:38:31 GMT
       Location:
-      - https://par1-cmp-prd-api01.internal.scaleway.com/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+      - https://par1-cmp-prd-api02.internal.scaleway.com/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -38,7 +38,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ba6b882-b3af-49e4-af72-634d9b8732bf
+      - 0cc70ebe-778b-445d-a0cb-2fa1aa903b3e
     status: 201 Created
     code: 201
     duration: ""
@@ -49,23 +49,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:26.843537+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:18 GMT
+      - Wed, 19 May 2021 14:38:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -75,7 +75,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 744ddf08-788e-41fc-a9f1-2c45417b54c7
+      - 6c7b600a-d63f-4b10-bb3b-56ef10d84948
     status: 200 OK
     code: 200
     duration: ""
@@ -86,23 +86,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:26.843537+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:18 GMT
+      - Wed, 19 May 2021 14:38:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -112,7 +112,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54d055e8-7e19-4038-8a76-2a8f30a3df8f
+      - dd2fcae2-74b6-4a7d-a005-c9280f226931
     status: 200 OK
     code: 200
     duration: ""
@@ -123,23 +123,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:26.843537+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:19 GMT
+      - Wed, 19 May 2021 14:38:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -149,7 +149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68ef9d00-037c-4621-afc0-e41dc26c6750
+      - bdb1b516-90ca-416f-8ddb-6747af7b5dce
     status: 200 OK
     code: 200
     duration: ""
@@ -160,23 +160,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:26.843537+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "431"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:19 GMT
+      - Wed, 19 May 2021 14:38:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -186,7 +186,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 905f810a-7f9f-49bc-9475-98b27e087c7d
+      - 831c9ca1-63f0-425a-8c06-417a56ad89a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
+    method: GET
+  response:
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:26.843537+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 May 2021 14:38:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8950e9d4-e64b-4403-90c6-a153a8707d84
     status: 200 OK
     code: 200
     duration: ""
@@ -199,23 +236,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: PATCH
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:20.055988+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "432"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:20 GMT
+      - Wed, 19 May 2021 14:38:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -225,7 +262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8261ea16-edc6-4f21-8457-8fd7468b67e4
+      - f9b51cd8-5805-4069-8366-25063cb322a6
     status: 202 Accepted
     code: 202
     duration: ""
@@ -236,23 +273,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:20.055988+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "432"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:20 GMT
+      - Wed, 19 May 2021 14:38:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -262,7 +299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e04792af-b329-4de8-ade2-7fc4b0c6242f
+      - fd8be105-6fc3-4e0f-bae5-1a0dfed56ca7
     status: 200 OK
     code: 200
     duration: ""
@@ -273,23 +310,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:20.055988+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "432"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:25 GMT
+      - Wed, 19 May 2021 14:38:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -299,7 +336,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d6d83d8-5ddf-4d2e-8b9f-422bee11604e
+      - 51a341eb-4b43-4364-ba1f-a317607a4ff2
     status: 200 OK
     code: 200
     duration: ""
@@ -310,23 +347,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:20.055988+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "432"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:30 GMT
+      - Wed, 19 May 2021 14:38:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -336,7 +373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55fc2b75-938e-4dfe-bc76-946edafeb423
+      - f4fcee2f-1072-4e46-8138-7eaea8800136
     status: 200 OK
     code: 200
     duration: ""
@@ -347,23 +384,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:35 GMT
+      - Wed, 19 May 2021 14:38:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -373,7 +410,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b06f83f0-b8cc-40b1-bcae-afaa9434e796
+      - 19e39520-a0ea-46d4-9449-ded01159e8b7
     status: 200 OK
     code: 200
     duration: ""
@@ -384,23 +421,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:35 GMT
+      - Wed, 19 May 2021 14:38:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -410,7 +447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff40558d-fd69-4549-8d4e-18ce648047ab
+      - 8ea7d866-9c47-400b-a91c-675961a6c2bb
     status: 200 OK
     code: 200
     duration: ""
@@ -421,23 +458,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:35 GMT
+      - Wed, 19 May 2021 14:39:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -447,7 +484,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d303880d-df34-4d75-ae02-e4048868da2b
+      - 919d659e-acc9-44e7-bd2c-933ed555b4ae
     status: 200 OK
     code: 200
     duration: ""
@@ -458,23 +495,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:36 GMT
+      - Wed, 19 May 2021 14:39:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -484,7 +521,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0989d11-62ec-4806-a886-88d09b9d1458
+      - 985db8cd-f242-4d95-9f73-cffad7686f12
     status: 200 OK
     code: 200
     duration: ""
@@ -495,23 +532,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
       "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
-      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
-      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "433"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:35 GMT
+      - Wed, 19 May 2021 14:39:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -521,7 +558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aab494ad-d1ba-4565-987c-fb46eeb89d2b
+      - 2f7ae00c-2847-4ce8-961b-0fcf56071d96
     status: 200 OK
     code: 200
     duration: ""
@@ -532,7 +569,229 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
+    method: GET
+  response:
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:38:33.416985+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "430"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 May 2021 14:39:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c1fa7f8-8baf-434b-b9a2-efafe584aee0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
+    method: GET
+  response:
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:39:22.631003+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 May 2021 14:39:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9440a8bf-4799-4fe9-8c2b-d760e1b7958c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
+    method: GET
+  response:
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:39:22.631003+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 May 2021 14:39:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0065040-5462-4362-9c3d-838c1282b632
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
+    method: GET
+  response:
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:39:22.631003+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 May 2021 14:39:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c20a4cf-26fd-4152-9d70-64ba4e023fb8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
+    method: GET
+  response:
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:39:22.631003+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 May 2021 14:39:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ff455e6-1538-4dc4-ab95-6404383a2a88
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
+    method: GET
+  response:
+    body: '{"volume": {"id": "cbcc503a-a61f-4b2f-a34d-f7b78f77f500", "name": "tf-vol-funny-bhaskara",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-19T14:38:26.843537+00:00", "modification_date":
+      "2021-05-19T14:39:22.631003+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 May 2021 14:39:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f56bd938-fc67-41d5-9bcb-03254a9a0886
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: DELETE
   response:
     body: ""
@@ -542,7 +801,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:36 GMT
+      - Wed, 19 May 2021 14:39:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -552,7 +811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dc99bfe-4d2d-4c13-aa45-b806d7f7a14e
+      - 498e0677-8568-4585-abcb-577ef92a5ddf
     status: 204 No Content
     code: 204
     duration: ""
@@ -563,10 +822,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cbcc503a-a61f-4b2f-a34d-f7b78f77f500
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "Volume ''319d7d2b-6c99-420a-974f-2e7cf838f14d''
+    body: '{"type": "unknown_resource", "message": "Volume ''cbcc503a-a61f-4b2f-a34d-f7b78f77f500''
       not found."}'
     headers:
       Content-Length:
@@ -576,7 +835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 17 May 2021 09:39:36 GMT
+      - Wed, 19 May 2021 14:39:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -586,7 +845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7595b765-1e90-4bf8-b1e5-dec16aa82c3e
+      - a65b088a-c5ef-47ca-a5f8-168fa7c58c9b
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-volume-resize-block.cassette.yaml
+++ b/scaleway/testdata/instance-volume-resize-block.cassette.yaml
@@ -2,33 +2,33 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-vol-distracted-gagarin","project":"951df375-e094-4d26-97c1-ba548eeb9c42","volume_type":"b_ssd","size":20000000000}'
+    body: '{"name":"tf-vol-heuristic-turing","project":"9af7216e-7b97-404d-8ada-9f379eb39ae5","volume_type":"b_ssd","size":20000000000}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:28.195859+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "435"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:28 GMT
+      - Mon, 17 May 2021 09:39:18 GMT
       Location:
-      - https://par1-cmp-prd-api02.internal.scaleway.com/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+      - https://par1-cmp-prd-api01.internal.scaleway.com/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -38,7 +38,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 855a86b3-d962-434a-a894-265ac27a48b3
+      - 7ba6b882-b3af-49e4-af72-634d9b8732bf
     status: 201 Created
     code: 201
     duration: ""
@@ -47,25 +47,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:28.195859+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "435"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:28 GMT
+      - Mon, 17 May 2021 09:39:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -75,7 +75,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ccf831f-0ff5-46a5-8248-423c6f7f6f56
+      - 744ddf08-788e-41fc-a9f1-2c45417b54c7
     status: 200 OK
     code: 200
     duration: ""
@@ -84,25 +84,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:28.195859+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "435"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:28 GMT
+      - Mon, 17 May 2021 09:39:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -112,7 +112,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89b499ae-5375-4ba6-9b1f-79ebb47de172
+      - 54d055e8-7e19-4038-8a76-2a8f30a3df8f
     status: 200 OK
     code: 200
     duration: ""
@@ -121,25 +121,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:28.195859+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "435"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:29 GMT
+      - Mon, 17 May 2021 09:39:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -149,7 +149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbc67169-925e-4e55-8de7-101f4c6b2d8d
+      - 68ef9d00-037c-4621-afc0-e41dc26c6750
     status: 200 OK
     code: 200
     duration: ""
@@ -158,25 +158,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:28.195859+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:18.693365+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "435"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:29 GMT
+      - Mon, 17 May 2021 09:39:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -186,7 +186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e7299e1-af07-4f20-8acf-e876ae3550ce
+      - 905f810a-7f9f-49bc-9475-98b27e087c7d
     status: 200 OK
     code: 200
     duration: ""
@@ -197,25 +197,25 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: PATCH
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:38.091407+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:20.055988+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "434"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:38 GMT
+      - Mon, 17 May 2021 09:39:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -225,7 +225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2763457-1f09-4ecc-b5a1-54c9e1a12daf
+      - 8261ea16-edc6-4f21-8457-8fd7468b67e4
     status: 202 Accepted
     code: 202
     duration: ""
@@ -234,25 +234,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:38.091407+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:20.055988+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "434"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:39 GMT
+      - Mon, 17 May 2021 09:39:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -262,7 +262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91ec65fe-bda2-4a75-9f93-68390aed512a
+      - e04792af-b329-4de8-ade2-7fc4b0c6242f
     status: 200 OK
     code: 200
     duration: ""
@@ -271,25 +271,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:38.091407+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:20.055988+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "434"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:40 GMT
+      - Mon, 17 May 2021 09:39:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -299,7 +299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7a5c182-4a10-4d91-beab-bdcd526e8eb7
+      - 8d6d83d8-5ddf-4d2e-8b9f-422bee11604e
     status: 200 OK
     code: 200
     duration: ""
@@ -308,25 +308,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:38.091407+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "resizing", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:20.055988+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "434"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:41 GMT
+      - Mon, 17 May 2021 09:39:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -336,7 +336,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 572cb0da-a558-4e95-a4e5-cc6e147d9106
+      - 55fc2b75-938e-4dfe-bc76-946edafeb423
     status: 200 OK
     code: 200
     duration: ""
@@ -345,25 +345,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"volume": {"id": "23d5edf2-6d2b-47c3-9013-9f9e872cbcba", "name": "tf-vol-distracted-gagarin",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 30000000000,
-      "state": "resizing", "creation_date": "2021-02-15T11:31:28.195859+00:00", "modification_date":
-      "2021-02-15T11:31:38.091407+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "434"
+      - "433"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:43 GMT
+      - Mon, 17 May 2021 09:39:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -373,7 +373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 073e0cf8-a333-4cb0-9a73-f531a4be8263
+      - b06f83f0-b8cc-40b1-bcae-afaa9434e796
     status: 200 OK
     code: 200
     duration: ""
@@ -382,9 +382,157 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    method: GET
+  response:
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "433"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 May 2021 09:39:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff40558d-fd69-4549-8d4e-18ce648047ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    method: GET
+  response:
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "433"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 May 2021 09:39:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d303880d-df34-4d75-ae02-e4048868da2b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    method: GET
+  response:
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "433"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 May 2021 09:39:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0989d11-62ec-4806-a886-88d09b9d1458
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
+    method: GET
+  response:
+    body: '{"volume": {"id": "319d7d2b-6c99-420a-974f-2e7cf838f14d", "name": "tf-vol-heuristic-turing",
+      "volume_type": "b_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 30000000000,
+      "state": "available", "creation_date": "2021-05-17T09:39:18.693365+00:00", "modification_date":
+      "2021-05-17T09:39:33.998586+00:00", "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "433"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 May 2021 09:39:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aab494ad-d1ba-4565-987c-fb46eeb89d2b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: DELETE
   response:
     body: ""
@@ -394,7 +542,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:44 GMT
+      - Mon, 17 May 2021 09:39:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -404,7 +552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7938602b-f926-451d-ba8a-ffb66252d031
+      - 5dc99bfe-4d2d-4c13-aa45-b806d7f7a14e
     status: 204 No Content
     code: 204
     duration: ""
@@ -413,12 +561,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.7; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/23d5edf2-6d2b-47c3-9013-9f9e872cbcba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/319d7d2b-6c99-420a-974f-2e7cf838f14d
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "Volume ''23d5edf2-6d2b-47c3-9013-9f9e872cbcba''
+    body: '{"type": "unknown_resource", "message": "Volume ''319d7d2b-6c99-420a-974f-2e7cf838f14d''
       not found."}'
     headers:
       Content-Length:
@@ -428,7 +576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 15 Feb 2021 11:31:45 GMT
+      - Mon, 17 May 2021 09:39:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -438,7 +586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c89ea70d-35bf-4096-9e34-458fd07f59ec
+      - 7595b765-1e90-4bf8-b1e5-dec16aa82c3e
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
The test was failing although the volume was properly resized.

The provider was waiting **before** resizing the volume.

```bash
--- PASS: TestAccScalewayInstanceVolume_ResizeBlock (18.26s)                                                           
PASS                                                                                                                   
ok      github.com/scaleway/terraform-provider-scaleway/scaleway        18.271s  
```