### PR TITLE
fix(Instance/Volume): size_in_db should not be set when importing volume

### DIFF
--- a/scaleway/resource_instance_volume.go
+++ b/scaleway/resource_instance_volume.go
@@ -134,7 +134,12 @@ func resourceScalewayInstanceVolumeRead(ctx context.Context, d *schema.ResourceD
 	_ = d.Set("project_id", res.Volume.Project)
 	_ = d.Set("zone", string(zone))
 	_ = d.Set("type", res.Volume.VolumeType.String())
-	_ = d.Set("size_in_gb", int(res.Volume.Size/scw.GB))
+
+	_, fromVolume := d.GetOk("from_volume_id")
+	_, fromSnapshot := d.GetOk("from_snapshot_id")
+	if !fromSnapshot && !fromVolume {
+		_ = d.Set("size_in_gb", int(res.Volume.Size/scw.GB))
+	}
 
 	if res.Volume.Server != nil {
 		_ = d.Set("server_id", res.Volume.Server.ID)

--- a/scaleway/testdata/instance-volume-from-volume.cassette.yaml
+++ b/scaleway/testdata/instance-volume-from-volume.cassette.yaml
@@ -2,33 +2,33 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-vol-zen-mcnulty","project":"951df375-e094-4d26-97c1-ba548eeb9c42","volume_type":"l_ssd","size":20000000000}'
+    body: '{"name":"tf-vol-festive-jones","project":"9af7216e-7b97-404d-8ada-9f379eb39ae5","volume_type":"l_ssd","size":20000000000}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume": {"id": "d3eb24d5-2592-4438-b2f1-0a5f6d6d117a", "name": "tf-vol-zen-mcnulty",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:19.412173+00:00", "modification_date":
-      "2020-10-16T08:58:19.412173+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "f1321985-83a8-4102-9429-8ccff84fb635", "name": "tf-vol-festive-jones",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.074527+00:00", "modification_date":
+      "2021-05-17T10:01:07.074527+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "428"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:19 GMT
+      - Mon, 17 May 2021 10:01:06 GMT
       Location:
-      - https://par1-cmp-prd-api02.internal.scaleway.com/volumes/d3eb24d5-2592-4438-b2f1-0a5f6d6d117a
+      - https://par1-cmp-prd-api01.internal.scaleway.com/volumes/f1321985-83a8-4102-9429-8ccff84fb635
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -38,7 +38,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73cf6398-a722-4245-86fe-d1324f9ee07e
+      - 850ab329-2e0d-4c26-9a6f-5a8bbddd5c01
     status: 201 Created
     code: 201
     duration: ""
@@ -47,25 +47,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d3eb24d5-2592-4438-b2f1-0a5f6d6d117a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1321985-83a8-4102-9429-8ccff84fb635
     method: GET
   response:
-    body: '{"volume": {"id": "d3eb24d5-2592-4438-b2f1-0a5f6d6d117a", "name": "tf-vol-zen-mcnulty",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:19.412173+00:00", "modification_date":
-      "2020-10-16T08:58:19.412173+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "f1321985-83a8-4102-9429-8ccff84fb635", "name": "tf-vol-festive-jones",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.074527+00:00", "modification_date":
+      "2021-05-17T10:01:07.074527+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "428"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:19 GMT
+      - Mon, 17 May 2021 10:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -75,38 +75,38 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b0bfb23-344c-45b8-a6d3-aea4a1ba988a
+      - 1e1c002d-5a5b-432b-a3b9-e459f2b74553
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-vol-determined-matsumoto","project":"951df375-e094-4d26-97c1-ba548eeb9c42","volume_type":"l_ssd","base_volume":"d3eb24d5-2592-4438-b2f1-0a5f6d6d117a"}'
+    body: '{"name":"tf-vol-youthful-jepsen","project":"9af7216e-7b97-404d-8ada-9f379eb39ae5","volume_type":"l_ssd","base_volume":"f1321985-83a8-4102-9429-8ccff84fb635"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume": {"id": "a5e7c6ee-9e74-4a69-b756-161040bd5e9b", "name": "tf-vol-determined-matsumoto",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:20.076683+00:00", "modification_date":
-      "2020-10-16T08:58:20.076683+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3", "name": "tf-vol-youthful-jepsen",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.316807+00:00", "modification_date":
+      "2021-05-17T10:01:07.316807+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "437"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:20 GMT
+      - Mon, 17 May 2021 10:01:07 GMT
       Location:
-      - https://par1-cmp-prd-api01.internal.scaleway.com/volumes/a5e7c6ee-9e74-4a69-b756-161040bd5e9b
+      - https://par1-cmp-prd-api01.internal.scaleway.com/volumes/e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -116,7 +116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4f93462-b641-4656-a020-af81fcbfaa5e
+      - 56d2f9b7-8fbf-49f8-bf21-d92cc890455f
     status: 201 Created
     code: 201
     duration: ""
@@ -125,25 +125,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5e7c6ee-9e74-4a69-b756-161040bd5e9b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3
     method: GET
   response:
-    body: '{"volume": {"id": "a5e7c6ee-9e74-4a69-b756-161040bd5e9b", "name": "tf-vol-determined-matsumoto",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:20.076683+00:00", "modification_date":
-      "2020-10-16T08:58:20.076683+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3", "name": "tf-vol-youthful-jepsen",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.316807+00:00", "modification_date":
+      "2021-05-17T10:01:07.316807+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "437"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:20 GMT
+      - Mon, 17 May 2021 10:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -153,7 +153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd572406-6bb4-4ab2-8165-178d6d774474
+      - b4261a82-471d-4003-84dd-96a2be8e96a3
     status: 200 OK
     code: 200
     duration: ""
@@ -162,25 +162,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d3eb24d5-2592-4438-b2f1-0a5f6d6d117a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1321985-83a8-4102-9429-8ccff84fb635
     method: GET
   response:
-    body: '{"volume": {"id": "d3eb24d5-2592-4438-b2f1-0a5f6d6d117a", "name": "tf-vol-zen-mcnulty",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:19.412173+00:00", "modification_date":
-      "2020-10-16T08:58:19.412173+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "f1321985-83a8-4102-9429-8ccff84fb635", "name": "tf-vol-festive-jones",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.074527+00:00", "modification_date":
+      "2021-05-17T10:01:07.074527+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "428"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:20 GMT
+      - Mon, 17 May 2021 10:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -190,7 +190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7adb0498-1bf9-4f77-96e1-236ae224056b
+      - 1157f9f7-8fe1-4fe0-ba1c-d102576a7eee
     status: 200 OK
     code: 200
     duration: ""
@@ -199,25 +199,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5e7c6ee-9e74-4a69-b756-161040bd5e9b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3
     method: GET
   response:
-    body: '{"volume": {"id": "a5e7c6ee-9e74-4a69-b756-161040bd5e9b", "name": "tf-vol-determined-matsumoto",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:20.076683+00:00", "modification_date":
-      "2020-10-16T08:58:20.076683+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3", "name": "tf-vol-youthful-jepsen",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.316807+00:00", "modification_date":
+      "2021-05-17T10:01:07.316807+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "437"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:20 GMT
+      - Mon, 17 May 2021 10:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -227,7 +227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91c96a19-db4f-42b6-9734-5a32f97a57b6
+      - 9d92ff55-1efd-43b1-8ac2-b099d5c7718c
     status: 200 OK
     code: 200
     duration: ""
@@ -236,25 +236,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d3eb24d5-2592-4438-b2f1-0a5f6d6d117a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1321985-83a8-4102-9429-8ccff84fb635
     method: GET
   response:
-    body: '{"volume": {"id": "d3eb24d5-2592-4438-b2f1-0a5f6d6d117a", "name": "tf-vol-zen-mcnulty",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:19.412173+00:00", "modification_date":
-      "2020-10-16T08:58:19.412173+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "f1321985-83a8-4102-9429-8ccff84fb635", "name": "tf-vol-festive-jones",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.074527+00:00", "modification_date":
+      "2021-05-17T10:01:07.074527+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "428"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:21 GMT
+      - Mon, 17 May 2021 10:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -264,7 +264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5adbe2f-ad3f-413f-8196-e3a0b7b6438b
+      - a5e8d613-0949-4f43-820c-c058a1099c93
     status: 200 OK
     code: 200
     duration: ""
@@ -273,25 +273,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5e7c6ee-9e74-4a69-b756-161040bd5e9b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3
     method: GET
   response:
-    body: '{"volume": {"id": "a5e7c6ee-9e74-4a69-b756-161040bd5e9b", "name": "tf-vol-determined-matsumoto",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:20.076683+00:00", "modification_date":
-      "2020-10-16T08:58:20.076683+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3", "name": "tf-vol-youthful-jepsen",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.316807+00:00", "modification_date":
+      "2021-05-17T10:01:07.316807+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "437"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:21 GMT
+      - Mon, 17 May 2021 10:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -301,7 +301,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae0474aa-e725-49d8-978f-30a46ce03b3e
+      - de5747e6-0e79-4874-b93a-0ffca30feac9
     status: 200 OK
     code: 200
     duration: ""
@@ -310,25 +310,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5e7c6ee-9e74-4a69-b756-161040bd5e9b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3
     method: GET
   response:
-    body: '{"volume": {"id": "a5e7c6ee-9e74-4a69-b756-161040bd5e9b", "name": "tf-vol-determined-matsumoto",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:20.076683+00:00", "modification_date":
-      "2020-10-16T08:58:20.076683+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3", "name": "tf-vol-youthful-jepsen",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.316807+00:00", "modification_date":
+      "2021-05-17T10:01:07.316807+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "437"
+      - "432"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:22 GMT
+      - Mon, 17 May 2021 10:01:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -338,7 +338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17759be3-3a43-4f65-a0d4-7cc70b302f0d
+      - bdbc0bc5-5fa7-463d-8ffe-95f1501ad438
     status: 200 OK
     code: 200
     duration: ""
@@ -347,9 +347,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a5e7c6ee-9e74-4a69-b756-161040bd5e9b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3
     method: DELETE
   response:
     body: ""
@@ -359,7 +359,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:22 GMT
+      - Mon, 17 May 2021 10:01:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -369,7 +369,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4574e76b-9849-4031-a270-393613ddc0d2
+      - 7409c60d-d7cb-4696-9ec7-98d9de5d02ca
     status: 204 No Content
     code: 204
     duration: ""
@@ -378,25 +378,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d3eb24d5-2592-4438-b2f1-0a5f6d6d117a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1321985-83a8-4102-9429-8ccff84fb635
     method: GET
   response:
-    body: '{"volume": {"id": "d3eb24d5-2592-4438-b2f1-0a5f6d6d117a", "name": "tf-vol-zen-mcnulty",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "951df375-e094-4d26-97c1-ba548eeb9c42",
-      "project": "951df375-e094-4d26-97c1-ba548eeb9c42", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2020-10-16T08:58:19.412173+00:00", "modification_date":
-      "2020-10-16T08:58:19.412173+00:00", "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "f1321985-83a8-4102-9429-8ccff84fb635", "name": "tf-vol-festive-jones",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2021-05-17T10:01:07.074527+00:00", "modification_date":
+      "2021-05-17T10:01:07.074527+00:00", "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "428"
+      - "430"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:22 GMT
+      - Mon, 17 May 2021 10:01:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -406,7 +406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d38e335f-27cd-4649-bb1a-530bdd62c8ae
+      - e3e42f8b-25c4-49d0-8cbd-b3a199e11a59
     status: 200 OK
     code: 200
     duration: ""
@@ -415,9 +415,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.2; darwin; amd64) terraform-provider/develop-tftest
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d3eb24d5-2592-4438-b2f1-0a5f6d6d117a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1321985-83a8-4102-9429-8ccff84fb635
     method: DELETE
   response:
     body: ""
@@ -427,7 +427,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 16 Oct 2020 08:58:22 GMT
+      - Mon, 17 May 2021 10:01:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -437,7 +437,75 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36e31ea8-d3db-4a9d-8746-fdaad7c801db
+      - bafec2a4-0407-4ee7-90c6-48345df24818
     status: 204 No Content
     code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1321985-83a8-4102-9429-8ccff84fb635
+    method: GET
+  response:
+    body: '{"type": "unknown_resource", "message": "Volume ''f1321985-83a8-4102-9429-8ccff84fb635''
+      not found."}'
+    headers:
+      Content-Length:
+      - "99"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 May 2021 10:01:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 21c3dbf9-e20f-4655-94b2-a2f29108eea8
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3
+    method: GET
+  response:
+    body: '{"type": "unknown_resource", "message": "Volume ''e3ddc9cf-ee14-4fdf-8963-f5b7efae77e3''
+      not found."}'
+    headers:
+      Content-Length:
+      - "99"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 May 2021 10:01:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86b1c368-de5f-42d3-9e0f-5685f879ad78
+    status: 404 Not Found
+    code: 404
     duration: ""


### PR DESCRIPTION
When creating a volume from a snapshot or with a copy: the attribute "size_in_db" should not be read as it's conflicting with this feature

The test was failing:
```bash
resource_instance_volume_test.go:89: Step 1/1 error: After applying this test step, the plan was not empty.                                                                                                                               
        stdout:                                                                                                        
                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                              
        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place
                                                         
        Terraform will perform the following actions:    
                                                          
        # scaleway_instance_volume.test2 will be updated in-place
          ~ resource "scaleway_instance_volume" "test2" {
                id              = "fr-par-1/ac5b205e-a19f-48a5-a7a0-2161b3736cf3"                                      
                name            = "tf-vol-wizardly-kilby"
              - size_in_gb      = 20 -> null                                                                           
                # (5 unchanged attributes hidden)
            }                              
                                                  
        Plan: 0 to add, 1 to change, 0 to destroy.
```

Now
```bash
--- PASS: TestAccScalewayInstanceVolume_FromVolume (1.91s)                                                             
PASS                                                                                                                   
ok      github.com/scaleway/terraform-provider-scaleway/scaleway        1.922s    
```

        