### PR TITLE
test(s3/cors): Setting an empty allowed origin is not allowed

### DIFF
--- a/scaleway/resource_object_bucket_test.go
+++ b/scaleway/resource_object_bucket_test.go
@@ -3,6 +3,7 @@ package scaleway
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -344,27 +345,7 @@ func TestAccScalewayObjectBucket_Cors_EmptyOrigin(t *testing.T) {
 							max_age_seconds = 3000
 						}
 					}`, bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayObjectBucketExists(tt, resourceName),
-					testAccCheckScalewayObjectBucketCors(tt,
-						resourceName,
-						[]*s3.CORSRule{
-							{
-								AllowedHeaders: []*string{scw.StringPtr("*")},
-								AllowedMethods: []*string{scw.StringPtr("PUT"), scw.StringPtr("POST")},
-								AllowedOrigins: []*string{scw.StringPtr("")},
-								ExposeHeaders:  []*string{scw.StringPtr("x-amz-server-side-encryption"), scw.StringPtr("ETag")},
-								MaxAgeSeconds:  scw.Int64Ptr(3000),
-							},
-						},
-					),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "acl"},
+				ExpectError: regexp.MustCompile("error putting S3 CORS"),
 			},
 		},
 	})

--- a/scaleway/testdata/object-bucket-cors-empty-origin.cassette.yaml
+++ b/scaleway/testdata/object-bucket-cors-empty-origin.cassette.yaml
@@ -6,20 +6,20 @@ interactions:
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;host;x-amz-acl;x-amz-content-sha256;x-amz-date,
-        Signature=423d4125affaf54cee9ef7d76e144645874d094e60cde1703d7ce4e2c4759cd7
+        Signature=7593cf5c5f6dc8ef03d42e6817b014d1b0f8337dd1541b5f7d4c43ddf1fe511e
       Content-Length:
       - "150"
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Acl:
       - private
       X-Amz-Content-Sha256:
       - 2cb57fad7b7168921a4c94426cfcb9ee2953f126430595df844e22d50f029060
       X-Amz-Date:
-      - 20201203T142438Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/
+      - 20210518T131658Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/
     method: PUT
   response:
     body: ""
@@ -29,13 +29,13 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Thu, 03 Dec 2020 14:24:39 GMT
+      - Tue, 18 May 2021 13:16:59 GMT
       Location:
-      - /test-acc-scaleway-object-bucket-cors-empty-origin
+      - /test-acc-scaleway-object-bucket-cors-empty-origin-jsh
       X-Amz-Id-2:
-      - tx9d92ed5988fd4a3ea28e6-005fc8f526
+      - txb756a8e8f44441c282aa9-0060a3be4a
       X-Amz-Request-Id:
-      - tx9d92ed5988fd4a3ea28e6-005fc8f526
+      - txb756a8e8f44441c282aa9-0060a3be4a
     status: 200 OK
     code: 200
     duration: ""
@@ -44,20 +44,20 @@ interactions:
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-md5;host;x-amz-acl;x-amz-content-sha256;x-amz-date,
-        Signature=8b3ce119c83756ee359daadac6db32a91d85ce532949d70b86946f084cb1c433
+        Signature=8016b60c56a84e8137d0dbf28884cd185aaa8abb9a6551fbf7e9ce698b479a16
       Content-Md5:
       - 1B2M2Y8AsgTpgAmY7PhCfg==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Acl:
       - private
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20201203T142439Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?acl=
+      - 20210518T131659Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?acl=
     method: PUT
   response:
     body: ""
@@ -67,587 +67,587 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Thu, 03 Dec 2020 14:24:39 GMT
+      - Tue, 18 May 2021 13:16:59 GMT
       X-Amz-Id-2:
-      - tx59b419f3b7024f4cae617-005fc8f527
+      - tx415d831eb43f441c84965-0060a3be4b
       X-Amz-Request-Id:
-      - tx59b419f3b7024f4cae617-005fc8f527
+      - tx415d831eb43f441c84965-0060a3be4b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=6b0e806f3726fc59e261e4ab0c4ec630378ff18590ffda3d3c5bccc3bc46c7a1
+        Signature=62dc1dc33a93912b90a04976fdbbf32d3bddc2b07aafda11024c626fe9695aa2
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142439Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131659Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txa065e4ed979147f5a2768-005fc8f527</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx71ba9e6ea0bf408f8d6c8-0060a3be4b</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:24:39 GMT
+      - Tue, 18 May 2021 13:16:59 GMT
       X-Amz-Id-2:
-      - txa065e4ed979147f5a2768-005fc8f527
+      - tx71ba9e6ea0bf408f8d6c8-0060a3be4b
       X-Amz-Request-Id:
-      - txa065e4ed979147f5a2768-005fc8f527
+      - tx71ba9e6ea0bf408f8d6c8-0060a3be4b
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=6b0e806f3726fc59e261e4ab0c4ec630378ff18590ffda3d3c5bccc3bc46c7a1
+        Signature=62dc1dc33a93912b90a04976fdbbf32d3bddc2b07aafda11024c626fe9695aa2
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142439Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131659Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx9070a7d4403b4b8cb8f70-005fc8f529</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx165ff16eb2aa482cabd22-0060a3be4d</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:24:41 GMT
+      - Tue, 18 May 2021 13:17:01 GMT
       X-Amz-Id-2:
-      - tx9070a7d4403b4b8cb8f70-005fc8f529
+      - tx165ff16eb2aa482cabd22-0060a3be4d
       X-Amz-Request-Id:
-      - tx9070a7d4403b4b8cb8f70-005fc8f529
+      - tx165ff16eb2aa482cabd22-0060a3be4d
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=6b0e806f3726fc59e261e4ab0c4ec630378ff18590ffda3d3c5bccc3bc46c7a1
+        Signature=62dc1dc33a93912b90a04976fdbbf32d3bddc2b07aafda11024c626fe9695aa2
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142439Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131659Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx837b149926404bf589610-005fc8f52d</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txc7a248e320ea444fae68e-0060a3be51</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:24:45 GMT
+      - Tue, 18 May 2021 13:17:05 GMT
       X-Amz-Id-2:
-      - tx837b149926404bf589610-005fc8f52d
+      - txc7a248e320ea444fae68e-0060a3be51
       X-Amz-Request-Id:
-      - tx837b149926404bf589610-005fc8f52d
+      - txc7a248e320ea444fae68e-0060a3be51
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=6b0e806f3726fc59e261e4ab0c4ec630378ff18590ffda3d3c5bccc3bc46c7a1
+        Signature=62dc1dc33a93912b90a04976fdbbf32d3bddc2b07aafda11024c626fe9695aa2
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142439Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131659Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx21069913319041618a6bb-005fc8f536</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx9c55ab2d6f104ba0a3fe3-0060a3be59</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:24:54 GMT
+      - Tue, 18 May 2021 13:17:13 GMT
       X-Amz-Id-2:
-      - tx21069913319041618a6bb-005fc8f536
+      - tx9c55ab2d6f104ba0a3fe3-0060a3be59
       X-Amz-Request-Id:
-      - tx21069913319041618a6bb-005fc8f536
+      - tx9c55ab2d6f104ba0a3fe3-0060a3be59
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=1c78cc6bcc607371ecba89863a9ca8a12742561ae379af675f8c50d32ae0f348
+        Signature=2d12559f4d05bea9a194c7cc0a39ff0ed30c8a65aa93fa3736efbf4987f0c69a
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142454Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131713Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx21f42b067ed649eaba1cd-005fc8f536</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx426ad08978dc4ebc93920-0060a3be59</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:24:54 GMT
+      - Tue, 18 May 2021 13:17:14 GMT
       X-Amz-Id-2:
-      - tx21f42b067ed649eaba1cd-005fc8f536
+      - tx426ad08978dc4ebc93920-0060a3be59
       X-Amz-Request-Id:
-      - tx21f42b067ed649eaba1cd-005fc8f536
+      - tx426ad08978dc4ebc93920-0060a3be59
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=1c78cc6bcc607371ecba89863a9ca8a12742561ae379af675f8c50d32ae0f348
+        Signature=2d12559f4d05bea9a194c7cc0a39ff0ed30c8a65aa93fa3736efbf4987f0c69a
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142454Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131713Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txdf0171d71f4f41289e057-005fc8f538</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx240013d31d72408d957c6-0060a3be5c</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:24:56 GMT
+      - Tue, 18 May 2021 13:17:16 GMT
       X-Amz-Id-2:
-      - txdf0171d71f4f41289e057-005fc8f538
+      - tx240013d31d72408d957c6-0060a3be5c
       X-Amz-Request-Id:
-      - txdf0171d71f4f41289e057-005fc8f538
+      - tx240013d31d72408d957c6-0060a3be5c
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=1c78cc6bcc607371ecba89863a9ca8a12742561ae379af675f8c50d32ae0f348
+        Signature=2d12559f4d05bea9a194c7cc0a39ff0ed30c8a65aa93fa3736efbf4987f0c69a
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142454Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131713Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txa66725d63495420788d90-005fc8f53c</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx335e3cb188734b4cb1d43-0060a3be60</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:00 GMT
+      - Tue, 18 May 2021 13:17:20 GMT
       X-Amz-Id-2:
-      - txa66725d63495420788d90-005fc8f53c
+      - tx335e3cb188734b4cb1d43-0060a3be60
       X-Amz-Request-Id:
-      - txa66725d63495420788d90-005fc8f53c
+      - tx335e3cb188734b4cb1d43-0060a3be60
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=1c78cc6bcc607371ecba89863a9ca8a12742561ae379af675f8c50d32ae0f348
+        Signature=2d12559f4d05bea9a194c7cc0a39ff0ed30c8a65aa93fa3736efbf4987f0c69a
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142454Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131713Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txa16e9638daa944fe9b64e-005fc8f544</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txe4b0867e05604bbab320a-0060a3be68</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:08 GMT
+      - Tue, 18 May 2021 13:17:28 GMT
       X-Amz-Id-2:
-      - txa16e9638daa944fe9b64e-005fc8f544
+      - txe4b0867e05604bbab320a-0060a3be68
       X-Amz-Request-Id:
-      - txa16e9638daa944fe9b64e-005fc8f544
+      - txe4b0867e05604bbab320a-0060a3be68
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=349f832fde84d6e49d98dd23a9dc4afde1a53cbc9457e6592f3574df90d01c50
+        Signature=1e74a0b76a83fc7f163d519208b41d8f3e99afc2f62ef509b8258c70d66d15ce
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142508Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131728Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txf0d50e3c69d14f9488560-005fc8f544</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txde18f2cf205e4ab0b61ea-0060a3be68</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:08 GMT
+      - Tue, 18 May 2021 13:17:28 GMT
       X-Amz-Id-2:
-      - txf0d50e3c69d14f9488560-005fc8f544
+      - txde18f2cf205e4ab0b61ea-0060a3be68
       X-Amz-Request-Id:
-      - txf0d50e3c69d14f9488560-005fc8f544
+      - txde18f2cf205e4ab0b61ea-0060a3be68
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=349f832fde84d6e49d98dd23a9dc4afde1a53cbc9457e6592f3574df90d01c50
+        Signature=1e74a0b76a83fc7f163d519208b41d8f3e99afc2f62ef509b8258c70d66d15ce
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142508Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131728Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txe48064276ac843689eb9c-005fc8f546</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx163cb9041c3a497184c50-0060a3be6a</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:10 GMT
+      - Tue, 18 May 2021 13:17:30 GMT
       X-Amz-Id-2:
-      - txe48064276ac843689eb9c-005fc8f546
+      - tx163cb9041c3a497184c50-0060a3be6a
       X-Amz-Request-Id:
-      - txe48064276ac843689eb9c-005fc8f546
+      - tx163cb9041c3a497184c50-0060a3be6a
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=349f832fde84d6e49d98dd23a9dc4afde1a53cbc9457e6592f3574df90d01c50
+        Signature=1e74a0b76a83fc7f163d519208b41d8f3e99afc2f62ef509b8258c70d66d15ce
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142508Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131728Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx10a0dacbf1464efc912f6-005fc8f54a</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txe24f0252b6ca426791b1b-0060a3be6e</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:14 GMT
+      - Tue, 18 May 2021 13:17:34 GMT
       X-Amz-Id-2:
-      - tx10a0dacbf1464efc912f6-005fc8f54a
+      - txe24f0252b6ca426791b1b-0060a3be6e
       X-Amz-Request-Id:
-      - tx10a0dacbf1464efc912f6-005fc8f54a
+      - txe24f0252b6ca426791b1b-0060a3be6e
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=349f832fde84d6e49d98dd23a9dc4afde1a53cbc9457e6592f3574df90d01c50
+        Signature=1e74a0b76a83fc7f163d519208b41d8f3e99afc2f62ef509b8258c70d66d15ce
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142508Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131728Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txc5e5dda2601244c7a36d1-005fc8f552</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txb1012a0c66c34cfd831e6-0060a3be76</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:23 GMT
+      - Tue, 18 May 2021 13:17:42 GMT
       X-Amz-Id-2:
-      - txc5e5dda2601244c7a36d1-005fc8f552
+      - txb1012a0c66c34cfd831e6-0060a3be76
       X-Amz-Request-Id:
-      - txc5e5dda2601244c7a36d1-005fc8f552
+      - txb1012a0c66c34cfd831e6-0060a3be76
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=4e66b9b21f44cd213763318200d6eb7fe8232e19826e8500b6ad30595c5db3ef
+        Signature=8b815806ad0528287ce0bf3271ea153010cf38c44df3e5b7295ca5427723cb1e
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142523Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131743Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txcb235cf7858043808eb5c-005fc8f553</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx36a27fc0197043af8bba2-0060a3be77</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:23 GMT
+      - Tue, 18 May 2021 13:17:44 GMT
       X-Amz-Id-2:
-      - txcb235cf7858043808eb5c-005fc8f553
+      - tx36a27fc0197043af8bba2-0060a3be77
       X-Amz-Request-Id:
-      - txcb235cf7858043808eb5c-005fc8f553
+      - tx36a27fc0197043af8bba2-0060a3be77
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=4e66b9b21f44cd213763318200d6eb7fe8232e19826e8500b6ad30595c5db3ef
+        Signature=8b815806ad0528287ce0bf3271ea153010cf38c44df3e5b7295ca5427723cb1e
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142523Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131743Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txc6aa3fdf0b7c443087e3e-005fc8f555</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txb027f2f72ba3409d8fe85-0060a3be7a</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:25 GMT
+      - Tue, 18 May 2021 13:17:46 GMT
       X-Amz-Id-2:
-      - txc6aa3fdf0b7c443087e3e-005fc8f555
+      - txb027f2f72ba3409d8fe85-0060a3be7a
       X-Amz-Request-Id:
-      - txc6aa3fdf0b7c443087e3e-005fc8f555
+      - txb027f2f72ba3409d8fe85-0060a3be7a
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=4e66b9b21f44cd213763318200d6eb7fe8232e19826e8500b6ad30595c5db3ef
+        Signature=8b815806ad0528287ce0bf3271ea153010cf38c44df3e5b7295ca5427723cb1e
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142523Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131743Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx751c0f0be350427db2da4-005fc8f559</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txa36c38d0726c4a5a8213a-0060a3be7e</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:29 GMT
+      - Tue, 18 May 2021 13:17:50 GMT
       X-Amz-Id-2:
-      - tx751c0f0be350427db2da4-005fc8f559
+      - txa36c38d0726c4a5a8213a-0060a3be7e
       X-Amz-Request-Id:
-      - tx751c0f0be350427db2da4-005fc8f559
+      - txa36c38d0726c4a5a8213a-0060a3be7e
     status: 500 Internal Server Error
     code: 500
     duration: ""
 - request:
-    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
+    body: <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedHeader>*</AllowedHeader><AllowedMethod>PUT</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedOrigin></AllowedOrigin><ExposeHeader>x-amz-server-side-encryption</ExposeHeader><ExposeHeader>ETag</ExposeHeader><MaxAgeSeconds>3000</MaxAgeSeconds></CORSRule></CORSConfiguration>
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
         SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date,
-        Signature=4e66b9b21f44cd213763318200d6eb7fe8232e19826e8500b6ad30595c5db3ef
+        Signature=8b815806ad0528287ce0bf3271ea153010cf38c44df3e5b7295ca5427723cb1e
       Content-Length:
       - "365"
       Content-Md5:
-      - VfPkaWFowrvJ8tkwt9YPfw==
+      - doCaNFYhpSrVvrLN1cQaiQ==
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
-      - 312bcd4b993bead7d20d3aa4c8767025620c21df8a0bd6f5dfbf55279797b8d2
+      - 62ab1c45dea8e5ff7f728bddc81ca0c025fba503d0afd2a0f282657162c2dcbe
       X-Amz-Date:
-      - 20201203T142523Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/?cors=
+      - 20210518T131743Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/?cors=
     method: PUT
   response:
     body: |-
       <?xml version='1.0' encoding='UTF-8'?>
-      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>tx2b65a9c0d45f4574a4891-005fc8f561</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
+      <Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message><RequestId>txa0bfa0cc378e4a31b6a91-0060a3be86</RequestId><Reason>'NoneType' object has no attribute 'count'</Reason></Error>
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Thu, 03 Dec 2020 14:25:37 GMT
+      - Tue, 18 May 2021 13:17:58 GMT
       X-Amz-Id-2:
-      - tx2b65a9c0d45f4574a4891-005fc8f561
+      - txa0bfa0cc378e4a31b6a91-0060a3be86
       X-Amz-Request-Id:
-      - tx2b65a9c0d45f4574a4891-005fc8f561
+      - txa0bfa0cc378e4a31b6a91-0060a3be86
     status: 500 Internal Server Error
     code: 500
     duration: ""
@@ -656,15 +656,15 @@ interactions:
     form: {}
     headers:
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=SCW8XT5JRAV4B0WQSHPE/20201203/fr-par/s3/aws4_request,
-        SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=da8dccf6b1251f912f98b940a9bdcf3edf7d40ab91f8186782c8dcaaa3b307ca
+      - AWS4-HMAC-SHA256 Credential=SCWJ9FJYVF1SPS9HX0VZ/20210518/fr-par/s3/aws4_request,
+        SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=5568e7b986cfdde4e8e103bfb394c640f7ed8ed737f642b38279d27ce98b74ab
       User-Agent:
-      - aws-sdk-go/1.34.32 (go1.15.5; darwin; amd64)
+      - aws-sdk-go/1.38.22 (go1.15.11; linux; amd64)
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       X-Amz-Date:
-      - 20201203T142538Z
-    url: https://test-acc-scaleway-object-bucket-cors-empty-origin.s3.fr-par.scw.cloud/
+      - 20210518T131758Z
+    url: https://test-acc-scaleway-object-bucket-cors-empty-origin-jsh.s3.fr-par.scw.cloud/
     method: DELETE
   response:
     body: ""
@@ -674,11 +674,11 @@ interactions:
       Content-Type:
       - text/html; charset=UTF-8
       Date:
-      - Thu, 03 Dec 2020 14:25:38 GMT
+      - Tue, 18 May 2021 13:17:59 GMT
       X-Amz-Id-2:
-      - tx0e92ff92e07847c1a0905-005fc8f562
+      - tx0627cac6adff4b5ab61c0-0060a3be86
       X-Amz-Request-Id:
-      - tx0e92ff92e07847c1a0905-005fc8f562
+      - tx0627cac6adff4b5ab61c0-0060a3be86
     status: 204 No Content
     code: 204
     duration: ""


### PR DESCRIPTION
Confirmed with s3cmd: 

```bash
$ s3cmd  setcors cors.xml s3://test-cors-jsh-2
WARNING: Retrying failed request: /?cors (500 (InternalError): We encountered an internal error. Please try again.)
WARNING: Waiting 3 sec...
WARNING: Retrying failed request: /?cors (500 (InternalError): We encountered an internal error. Please try again.)
WARNING: Waiting 6 sec...
```
With the following cors.xml
```xml
<CORSConfiguration>
     <CORSRule>
       <AllowedOrigin></AllowedOrigin>
       <AllowedMethod>GET</AllowedMethod>
       <MaxAgeSeconds>3000</MaxAgeSeconds>
       <ExposeHeader>Etag</ExposeHeader>
     </CORSRule>
</CORSConfiguration>
```
Note: [s3 api](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CORSRule.html) require  AllowedOrigins to be required - 