### PR TITLE
test: simplify the test to avoid random results with cassete recording

### DIFF
--- a/scaleway/resource_instance_placement_group_test.go
+++ b/scaleway/resource_instance_placement_group_test.go
@@ -51,19 +51,11 @@ func TestAccScalewayInstancePlacementGroup_Basic(t *testing.T) {
 			{
 				Config: `
 					resource "scaleway_instance_placement_group" "base" {}
-
-					resource "scaleway_instance_placement_group" "scaleway" {
-						policy_mode = "enforced"
-						policy_type = "low_latency"
-					}`,
+					`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayInstancePlacementGroupExists(tt, "scaleway_instance_placement_group.base"),
-					testAccCheckScalewayInstancePlacementGroupExists(tt, "scaleway_instance_placement_group.scaleway"),
 					resource.TestCheckResourceAttr("scaleway_instance_placement_group.base", "policy_mode", "optional"),
 					resource.TestCheckResourceAttr("scaleway_instance_placement_group.base", "policy_type", "max_availability"),
-					resource.TestCheckResourceAttr("scaleway_instance_placement_group.scaleway", "policy_mode", "enforced"),
-					resource.TestCheckResourceAttr("scaleway_instance_placement_group.scaleway", "policy_type", "low_latency"),
-					resource.TestCheckResourceAttr("scaleway_instance_placement_group.scaleway", "policy_respected", "true"),
 				),
 			},
 			{
@@ -72,16 +64,22 @@ func TestAccScalewayInstancePlacementGroup_Basic(t *testing.T) {
 						policy_mode = "enforced"
 						policy_type = "low_latency"
 					}
-			
-					resource "scaleway_instance_placement_group" "scaleway" {}`,
+					`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayInstancePlacementGroupExists(tt, "scaleway_instance_placement_group.base"),
-					testAccCheckScalewayInstancePlacementGroupExists(tt, "scaleway_instance_placement_group.scaleway"),
 					resource.TestCheckResourceAttr("scaleway_instance_placement_group.base", "policy_mode", "enforced"),
 					resource.TestCheckResourceAttr("scaleway_instance_placement_group.base", "policy_type", "low_latency"),
 					resource.TestCheckResourceAttr("scaleway_instance_placement_group.base", "policy_respected", "true"),
-					resource.TestCheckResourceAttr("scaleway_instance_placement_group.scaleway", "policy_mode", "optional"),
-					resource.TestCheckResourceAttr("scaleway_instance_placement_group.scaleway", "policy_type", "max_availability"),
+				),
+			},
+			{
+				Config: `
+					resource "scaleway_instance_placement_group" "base" {}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayInstancePlacementGroupExists(tt, "scaleway_instance_placement_group.base"),
+					resource.TestCheckResourceAttr("scaleway_instance_placement_group.base", "policy_mode", "optional"),
+					resource.TestCheckResourceAttr("scaleway_instance_placement_group.base", "policy_type", "max_availability"),
 				),
 			},
 		},

--- a/scaleway/testdata/instance-placement-group-basic.cassette.yaml
+++ b/scaleway/testdata/instance-placement-group-basic.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-pg-romantic-torvalds","project":"9af7216e-7b97-404d-8ada-9f379eb39ae5","policy_mode":"enforced","policy_type":"low_latency"}'
+    body: '{"name":"tf-pg-stupefied-neumann","project":"a57bd23d-c866-49eb-a6ac-438f85c22957","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
@@ -13,377 +13,9 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
-      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "312"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:34 GMT
-      Location:
-      - https://par1-cmp-prd-api01.internal.scaleway.com/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d655a58a-baa2-4c35-a76e-8ae372734d28
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"name":"tf-pg-wonderful-franklin","project":"9af7216e-7b97-404d-8ada-9f379eb39ae5","policy_mode":"optional","policy_type":"max_availability"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups
-    method: POST
-  response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "318"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:34 GMT
-      Location:
-      - https://par1-cmp-prd-api01.internal.scaleway.com/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 404f4784-c5fe-4591-847d-b609221972d9
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "318"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0473e264-2dfe-49f1-a8b9-25ce8500fec6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
-      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "312"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cb3a77ad-be8a-4abe-af82-76cb37fb4002
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "318"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fde83863-0e3c-461d-a1be-004d179133e0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
-      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "312"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7101c569-2e46-477a-a787-0b0a87537ee3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "318"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0be3ce9c-3d84-4f01-be94-39bdbd2d10fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
-      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "312"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08486b5c-127b-44f5-afed-c244fef79d9e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
-      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "312"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 136754cd-acd0-425c-808a-19c2e735cb1d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "318"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4f196d3b-c2f8-4387-a5a2-dd375a0c741d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"policy_mode":"optional","policy_type":"max_availability"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: PATCH
-  response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
       "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -393,7 +25,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 11 May 2021 15:24:35 GMT
+      - Thu, 20 May 2021 18:45:27 GMT
+      Location:
+      - https://par1-cmp-prd-api01.internal.scaleway.com/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +37,151 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f12e4cf5-1998-4363-bc66-239431f16894
+      - d482c537-6d12-4647-81b1-c8b34b487c3d
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: GET
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
+      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0e9677e1-607c-4014-9ad6-6bba1521ff54
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: GET
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
+      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3378dd93-0222-4837-a741-630832f3cd92
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: GET
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
+      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a8d6724-092c-407b-abb3-19ff8463cc35
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: GET
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
+      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bed9dfc7-c7cb-48ac-bb6d-d9d5ef0c9855
     status: 200 OK
     code: 200
     duration: ""
@@ -416,22 +194,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
     method: PATCH
   response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "enforced",
       "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "313"
+      - "312"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 11 May 2021 15:24:35 GMT
+      - Thu, 20 May 2021 18:45:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -441,7 +219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1caf003-fbd8-4606-82ae-983dc8e0506a
+      - bf6dc42d-c322-4c22-9298-80d6f6324c6d
     status: 200 OK
     code: 200
     duration: ""
@@ -452,12 +230,158 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
     method: GET
   response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "enforced",
+      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "312"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbee6b24-1ad6-4119-9928-8c5f5030d665
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: GET
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "enforced",
+      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "312"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9db125e5-2fcf-49d8-9a00-53c73b2b46e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: GET
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "enforced",
+      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "312"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86faff59-fc1b-4956-9584-41844f6062bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: GET
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "enforced",
+      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "312"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5dede69-2aae-4296-8ac3-cc9e254e7cb4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"policy_mode":"optional","policy_type":"max_availability"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: PATCH
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
       "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -467,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 11 May 2021 15:24:35 GMT
+      - Thu, 20 May 2021 18:45:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -477,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c05150c-6ec6-4ecf-b869-44dd9e9cc9d3
+      - e523a16e-a52e-40e3-ba4d-3aa60bf27cbc
     status: 200 OK
     code: 200
     duration: ""
@@ -488,84 +412,12 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
     method: GET
   response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
-      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "313"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad6c25af-6db6-43c7-99c3-d375ef90f9e0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
-      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "313"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5cbc02b1-724e-49f4-b7da-7e3d8d482b4c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
       "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -575,7 +427,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 11 May 2021 15:24:35 GMT
+      - Thu, 20 May 2021 18:45:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -585,7 +437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f00fd5c8-d6da-4b08-a740-9d1e733f5570
+      - 1ba6fcf0-0da7-4350-a538-069f2231d7a3
     status: 200 OK
     code: 200
     duration: ""
@@ -596,48 +448,12 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
     method: GET
   response:
-    body: '{"placement_group": {"id": "b6feaaf1-a255-40c6-90d0-d74d58e45f64", "name":
-      "tf-pg-wonderful-franklin", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "enforced",
-      "policy_type": "low_latency", "policy_respected": true, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "313"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee1fa85c-f246-46e3-a314-b726a8723ea9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: GET
-  response:
-    body: '{"placement_group": {"id": "fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6", "name":
-      "tf-pg-romantic-torvalds", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
-      "project": "9af7216e-7b97-404d-8ada-9f379eb39ae5", "policy_mode": "optional",
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
       "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -647,7 +463,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 11 May 2021 15:24:35 GMT
+      - Thu, 20 May 2021 18:45:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -657,7 +473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ec60150-75bb-46fd-8032-5bea149c75ef
+      - bf0fe96d-b990-4046-b8e3-63d54029a5e3
     status: 200 OK
     code: 200
     duration: ""
@@ -668,7 +484,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
+    method: GET
+  response:
+    body: '{"placement_group": {"id": "36a3d9f8-c226-4fe0-9991-adb047523e80", "name":
+      "tf-pg-stupefied-neumann", "organization": "9af7216e-7b97-404d-8ada-9f379eb39ae5",
+      "project": "a57bd23d-c866-49eb-a6ac-438f85c22957", "policy_mode": "optional",
+      "policy_type": "max_availability", "policy_respected": true, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 May 2021 18:45:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59689e13-f91a-4b33-a2d9-bc049c6876a9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
     method: DELETE
   response:
     body: ""
@@ -678,7 +530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 11 May 2021 15:24:36 GMT
+      - Thu, 20 May 2021 18:45:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -688,7 +540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 108b4b9b-9b30-4db4-a1f6-2adf0c082fe8
+      - 8abd8361-1669-4660-abb9-7c08fdc36dcb
     status: 204 No Content
     code: 204
     duration: ""
@@ -699,41 +551,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be596a69-6ce3-43a7-b1fd-57700841f303
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/b6feaaf1-a255-40c6-90d0-d74d58e45f64
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/36a3d9f8-c226-4fe0-9991-adb047523e80
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"b6feaaf1-a255-40c6-90d0-d74d58e45f64\"
+    body: '{"type": "unknown_resource", "message": "\"36a3d9f8-c226-4fe0-9991-adb047523e80\"
       not found"}'
     headers:
       Content-Length:
@@ -743,7 +564,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 11 May 2021 15:24:36 GMT
+      - Thu, 20 May 2021 18:45:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -753,41 +574,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa9501e4-412d-4dcc-828c-633b5793768e
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.15.11; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6
-    method: GET
-  response:
-    body: '{"type": "unknown_resource", "message": "\"fc3aa6eb-dd7a-42a9-8a9d-e85ca00be9a6\"
-      not found"}'
-    headers:
-      Content-Length:
-      - "93"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 11 May 2021 15:24:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e0670034-0e64-4d86-9d1f-a2aca70a0992
+      - 54ff99c0-4dc8-40bd-89fc-8460b9d65779
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
Like https://github.com/scaleway/terraform-provider-scaleway/commit/c5df89b4bc70e01021c099dcd4de01b2dfb4d7da
cassette seems to have some difficulties to match the right requests.

In the previous configuration the test was doing 2 stuffs at the same time.
* Update a placement group with default values to enforced
* Downgrade an enforced placement group to default 

Let's do this in 3 steps with the same placements group.