### PR TITLE
fix (k8s): Added ForceNew on cluster_id nodepool

### DIFF
--- a/scaleway/resource_k8s_pool.go
+++ b/scaleway/resource_k8s_pool.go
@@ -28,6 +28,7 @@ func resourceScalewayK8SPool() *schema.Resource {
 			"cluster_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The ID of the cluster on which this pool will be created",
 			},
 			"name": {


### PR DESCRIPTION
Added ForceNew, on cluster_id to force node-pool destroy/recreated when cluster is detroyed/recreated