### PR TITLE
Update registry_namespace.md

### DIFF
--- a/docs/resources/registry_namespace.md
+++ b/docs/resources/registry_namespace.md
@@ -15,7 +15,7 @@ For more information see [the documentation](https://developers.scaleway.com/en/
 
 ```hcl
 resource "scaleway_registry_namespace" "main" {
-  name        = "main_cr"
+  name        = "main-cr"
   description = "Main container registry"
   is_public   = false
 }


### PR DESCRIPTION
Fix typo in the name argument example.

I have a non-obvious error in the return `Namespace already exist`. While no namespace exists and the problem seems to be that the underscore is not allowed in the name. Replacing it with a dash works.