### PR TITLE
fix: increase rdb instance creation timeout to 15m

### DIFF
--- a/scaleway/resource_rdb_instance.go
+++ b/scaleway/resource_rdb_instance.go
@@ -188,7 +188,7 @@ func resourceScalewayRdbInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	_, err = rdbAPI.WaitForInstance(&rdb.WaitForInstanceRequest{
 		Region:        region,
 		InstanceID:    res.ID,
-		Timeout:       scw.TimeDurationPtr(defaultInstanceServerWaitTimeout),
+		Timeout:       scw.TimeDurationPtr(defaultRdbInstanceTimeout),
 		RetryInterval: DefaultWaitRetryInterval,
 	}, scw.WithContext(ctx))
 	if err != nil {


### PR DESCRIPTION
Update the instance creation timeout to match the RDB one instead of InstanceServer