### PR TITLE
feat(provider): add profile name from configuration file support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -178,6 +178,33 @@ If it fails to detect credentials inline, or in the environment, Terraform will 
 You can optionally specify a different location with `SCW_CONFIG_PATH` environment variable.
 You can find more information about this configuration [in the documentation](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md#scaleway-config).
 
+This method also supports a `profile` configuration:
+
+Example:
+
+If your shared configuration file contains:
+
+```yaml
+profiles:
+  myProfile:
+    access_key: xxxxxxxxxxxxxxxxxxxx
+    secret_key: xxxxxxxx-xxx-xxxx-xxxx-xxxxxxxxxxx
+    default_organization_id: xxxxxxxx-xxx-xxxx-xxxx-xxxxxxxxxxx 
+    default_project_id: xxxxxxxx-xxx-xxxx-xxxx-xxxxxxxxxxx
+    default_zone: fr-par-1
+    default_region: fr-par
+    api_url: https://api.scaleway.com
+    insecure: false
+```
+
+You can invoke and use this profile in the provider declaration:
+
+```hcl
+provider "scaleway" {
+  profile = "myProfile"
+}
+```
+
 ## Arguments Reference
 
 In addition to [generic provider arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g. `alias` and `version`), the following arguments are supported in the Scaleway provider block:

--- a/docs/index.md
+++ b/docs/index.md
@@ -191,7 +191,7 @@ profiles:
     secret_key: xxxxxxxx-xxx-xxxx-xxxx-xxxxxxxxxxx
     default_organization_id: xxxxxxxx-xxx-xxxx-xxxx-xxxxxxxxxxx 
     default_project_id: xxxxxxxx-xxx-xxxx-xxxx-xxxxxxxxxxx
-    default_zone: fr-par-1
+    default_zone: fr-par-2
     default_region: fr-par
     api_url: https://api.scaleway.com
     insecure: false
@@ -201,7 +201,12 @@ You can invoke and use this profile in the provider declaration:
 
 ```hcl
 provider "scaleway" {
+  alias   = "p2"
   profile = "myProfile"
+}
+
+resource "scaleway_instance_ip" "server_ip" {
+  provider = scaleway.p2
 }
 ```
 

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -235,7 +235,7 @@ func loadProfile(d *schema.ResourceData) (*scw.Profile, error) {
 	if d != nil {
 		if profileName, exist := d.GetOk("profile"); exist {
 			profileFromConfig, err := config.GetProfile(profileName.(string))
-			if err != nil {
+			if err == nil {
 				providerProfile = profileFromConfig
 			}
 		}

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -233,6 +233,12 @@ func loadProfile(d *schema.ResourceData) (*scw.Profile, error) {
 
 	providerProfile := &scw.Profile{}
 	if d != nil {
+		if profileName, exist := d.GetOk("profile"); exist {
+			profileFromConfig, err := config.GetProfile(profileName.(string))
+			if err != nil {
+				providerProfile = profileFromConfig
+			}
+		}
 		if accessKey, exist := d.GetOk("access_key"); exist {
 			providerProfile.AccessKey = scw.StringPtr(accessKey.(string))
 		}
@@ -250,9 +256,6 @@ func loadProfile(d *schema.ResourceData) (*scw.Profile, error) {
 		}
 		if apiURL, exist := d.GetOk("api_url"); exist {
 			providerProfile.APIURL = scw.StringPtr(apiURL.(string))
-		}
-		if profileName, exist := d.GetOk("profile"); exist {
-			providerProfile, err = config.GetProfile(profileName.(string))
 		}
 	}
 

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -39,6 +39,11 @@ func Provider(config *ProviderConfig) plugin.ProviderFunc {
 					Description:  "The Scaleway secret Key.",
 					ValidateFunc: validationUUID(),
 				},
+				"profile": {
+					Type:        schema.TypeString,
+					Optional:    true, // To allow user to use `access_key`, `secret_key`, `project_id`...
+					Description: "The Scaleway profile to use.",
+				},
 				"project_id": {
 					Type:         schema.TypeString,
 					Optional:     true, // To allow user to use organization instead of project
@@ -245,6 +250,9 @@ func loadProfile(d *schema.ResourceData) (*scw.Profile, error) {
 		}
 		if apiURL, exist := d.GetOk("api_url"); exist {
 			providerProfile.APIURL = scw.StringPtr(apiURL.(string))
+		}
+		if profileName, exist := d.GetOk("profile"); exist {
+			providerProfile, err = config.GetProfile(profileName.(string))
 		}
 	}
 


### PR DESCRIPTION
## Why?
With the arrival of the new project functionality on the platform, I ended up needing to use two authenticated `scaleway` providers on two different projects within the same Terraform project.

My intention here is to provide a way to easily manage multiple profiles declared in the Scaleway CLI static configuration file in the same way as with [the AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#shared-credentials-file) 

### Real use case example

```hcl
terraform {
  required_providers {
    scaleway = {
      source  = "local/scaleway/scaleway"
      version = "~> 2.1.0"
    }
  }

  required_version = ">= 0.13"
}

provider "scaleway" {
  profile = "myProjectProfile"
}

provider "scaleway" {
  alias   = "dns"
  profile = "myDnsProfile"
}

resource "scaleway_domain_record" "project_domain_record" {
  provider = scaleway.dns
  name     = "scaleway_test"
  type     = "A"
  data     = scaleway_instance_ip.server_ip.address
  dns_zone = "projects.mydomain.io"
}

resource "scaleway_instance_ip" "server_ip" {}

# ... and my other project dedicated resources...
```

> Don't hesitate to tell me if I forgot to update any other file, I would love to be able to use this feature from the official version of the provider. Hopefully this will help other users of the platform too 🤗 


