### PR TITLE
docs(resources): add missing quotes to examples

### DIFF
--- a/docs/resources/iot_device.md
+++ b/docs/resources/iot_device.md
@@ -16,12 +16,12 @@ Creates and manages Scaleway IoT Hub Instances. For more information, see [the d
 ### Basic
 
 ```hcl
-resource scaleway_iot_hub main {
+resource "scaleway_iot_hub" "main" {
     name         = "test-iot"
     product_plan = "plan_shared"
 }
 
-resource scaleway_iot_device main {
+resource "scaleway_iot_device" "main" {
     hub_id = scaleway_iot_hub.main.id
     name   = "test-iot"
 }
@@ -30,16 +30,16 @@ resource scaleway_iot_device main {
 ### With custom certificate
 
 ```hcl
-resource scaleway_iot_hub main {
+resource "scaleway_iot_hub" "main" {
     name         = "test-iot"
     product_plan = "plan_shared"
 }
 
-data local_file device_cert {
+data "local_file" "device_cert" {
     filename = "device-certificate.pem"
 }
 
-resource scaleway_iot_device main {
+resource "scaleway_iot_device" "main" {
     hub_id = scaleway_iot_hub.main.id
     name   = "test-iot"
     certificate {

--- a/docs/resources/iot_hub.md
+++ b/docs/resources/iot_hub.md
@@ -16,7 +16,7 @@ Creates and manages Scaleway IoT Hub Instances. For more information, see [the d
 ### Basic
 
 ```hcl
-resource scaleway_iot_hub main {
+resource "scaleway_iot_hub" "main" {
     name = "test-iot"
     product_plan = "plan_shared"
 }

--- a/docs/resources/lb_private_network.md
+++ b/docs/resources/lb_private_network.md
@@ -14,20 +14,20 @@ For more information, see [the documentation](https://developers.scaleway.com/en
 ### Basic
 
 ```hcl
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name = "test-lb-pn"
 }
 
-resource scaleway_lb_ip ip01 {}
+resource "scaleway_lb_ip" "ip01" {}
 
-resource scaleway_lb lb01 {
+resource "scaleway_lb" "lb01" {
   ip_id = scaleway_lb_ip.ip01.id
   name = "test-lb"
   type = "lb-s"
   release_ip = true
 }
 
-resource scaleway_lb_private_network lb01pn01 {
+resource "scaleway_lb_private_network" "lb01pn01" {
   lb_id = scaleway_lb.lb01.id
   private_network_id = scaleway_vpc_private_network.pn01.id
   static_config = ["172.16.0.100", "172.16.0.101"]

--- a/docs/resources/rdb_acl.md
+++ b/docs/resources/rdb_acl.md
@@ -14,7 +14,7 @@ For more information, see [the documentation](https://developers.scaleway.com/en
 ### Basic
 
 ```hcl
-resource scaleway_rdb_acl main {
+resource "scaleway_rdb_acl" "main" {
   instance_id = scaleway_rdb_instance.main.id
   acl_rules {
     ip = "1.2.3.4/32"

--- a/docs/resources/vpc_gateway_network.md
+++ b/docs/resources/vpc_gateway_network.md
@@ -13,24 +13,24 @@ For more information, see [the documentation](https://developers.scaleway.com/en
 ## Example
 
 ```hcl
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name = "pn_test_network"
 }
 
-resource scaleway_vpc_public_gateway_ip gw01 {
+resource "scaleway_vpc_public_gateway_ip" "gw01" {
 }
 
-resource scaleway_vpc_public_gateway_dhcp dhcp01 {
+resource "scaleway_vpc_public_gateway_dhcp" "dhcp01" {
   subnet = "192.168.1.0/24"
 }
 
-resource scaleway_vpc_public_gateway pg01 {
+resource "scaleway_vpc_public_gateway" "pg01" {
   name = "foobar"
   type = "VPC-GW-S"
   ip_id = scaleway_vpc_public_gateway_ip.gw01.id
 }
 
-resource scaleway_vpc_gateway_network main {
+resource "scaleway_vpc_gateway_network" "main" {
   gateway_id = scaleway_vpc_public_gateway.pg01.id
   private_network_id = scaleway_vpc_private_network.pn01.id
   dhcp_id = scaleway_vpc_public_gateway_dhcp.dhcp01.id

--- a/docs/resources/vpc_public_gateway_pat_rule.md
+++ b/docs/resources/vpc_public_gateway_pat_rule.md
@@ -12,26 +12,26 @@ For more information, see [the documentation](https://developers.scaleway.com/en
 ## Example
 
 ```hcl
-resource scaleway_vpc_public_gateway pg01 {
+resource "scaleway_vpc_public_gateway" "pg01" {
   type = "VPC-GW-S"
 }
 
-resource scaleway_vpc_public_gateway_dhcp dhcp01 {
+resource "scaleway_vpc_public_gateway_dhcp" "dhcp01" {
   subnet = "192.168.1.0/24"
 }
 
-resource scaleway_vpc_private_network pn01 {
+resource "scaleway_vpc_private_network" "pn01" {
   name = "pn_test_network"
 }
 
-resource scaleway_vpc_gateway_network gn01 {
+resource "scaleway_vpc_gateway_network" "gn01" {
   gateway_id = scaleway_vpc_public_gateway.pg01.id
   private_network_id = scaleway_vpc_private_network.pn01.id
   dhcp_id = scaleway_vpc_public_gateway_dhcp.dhcp01.id
   cleanup_dhcp = true
 }
 
-resource scaleway_vpc_public_gateway_pat_rule main {
+resource "scaleway_vpc_public_gateway_pat_rule" "main" {
   gateway_id = scaleway_vpc_public_gateway.pg01.id
   private_ip = scaleway_vpc_public_gateway_dhcp.dhcp01.address
   private_port = 42


### PR DESCRIPTION
Hi !

Some resources in the documentation where not _copy-pastable_ due to missing quotes.
I know this isn't much regarding the overall amount of documentation related to the provider, yet I do really much like to simply "^C^V" the examples to draft my terraform manifests.

I think I've "corrected" every non-syntax compliant example in `hcl` :)