### PR TITLE
doc(README): fix Slack links (registering + terraform channel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 - [Provider Documentation Website](https://www.terraform.io/docs/providers/scaleway/index.html)
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
-- Slack: [Scaleway-community Slack (#terraform)](https://app.slack.com/client/T7YEXCR7X/C015RD31DNK)
+- Slack: [Scaleway-community Slack][slack-scaleway] ([#terraform][slack-terraform])
+
+[slack-scaleway]: https://slack.scaleway.com/
+[slack-terraform]: https://scaleway-community.slack.com/app_redirect?channel=terraform
 
 <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
 


### PR DESCRIPTION
Hello !

It looks like the existing Slack link in the README is not usable: I get a default Slack login page upon visiting the link.

I found a link to Scaleway's Community Slack and replaced the existing one, as well as edit the link under `#terraform` to fit with the pattern I found in https://github.com/scaleway/scaleway-sdk-go#reach-us 


