### PR TITLE
fix(k8s): return error code from k8sGetLatestVersionFromMinor call

### DIFF
--- a/scaleway/resource_k8s_cluster.go
+++ b/scaleway/resource_k8s_cluster.go
@@ -368,7 +368,7 @@ func resourceScalewayK8SClusterCreate(ctx context.Context, d *schema.ResourceDat
 	if versionIsOnlyMinor {
 		version, err = k8sGetLatestVersionFromMinor(ctx, k8sAPI, region, version)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("minor version x.y must be used with auto upgrade enabled"))
+			return diag.FromErr(err)
 		}
 	}
 


### PR DESCRIPTION
The `k8sGetLatestVersionFromMinor` call is the first interaction with the scaleway API when auto_update is enabled and the version is set to a x.y minor version. 
But a possible error message from the API call is never logged. So if you have a typo in your credentials or forgot to add the project_id to the provider, you are confronted with the error message "minor version x.y must be used with auto upgrade enable".

This PR just reports the error from `k8sGetLatestVersionFromMinor` to the user.