### PR TITLE
update to use v2 imports

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X github.com/scaleway/terraform-provider-scaleway/scaleway.version={{.Version}}'
+    - '-s -w -X github.com/scaleway/terraform-provider-scaleway/v2/scaleway.version={{.Version}}'
   goos:
     - freebsd
     - windows

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/scaleway/terraform-provider-scaleway
+module github.com/scaleway/terraform-provider-scaleway/v2
 
 require (
 	github.com/aws/aws-sdk-go v1.42.25

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/scaleway/terraform-provider-scaleway/scaleway/v2"
+	"github.com/scaleway/terraform-provider-scaleway/v2/scaleway"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/scaleway/terraform-provider-scaleway/scaleway"
+	"github.com/scaleway/terraform-provider-scaleway/scaleway/v2"
 )
 
 func main() {


### PR DESCRIPTION
The major version of the module has been tagged as a `v2` module, but the `go.mod` wasn't updated.