### PR TITLE
fix(domain-record): Add dns_zone to tfstate when using terraform import

### DIFF
--- a/scaleway/resource_domain_record.go
+++ b/scaleway/resource_domain_record.go
@@ -338,6 +338,7 @@ func resourceScalewayDomainRecordRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	d.SetId(record.ID)
+	_ = d.Set("dns_zone", dnsZone)
 	_ = d.Set("name", record.Name)
 	_ = d.Set("type", record.Type.String())
 	_ = d.Set("data", flattenDomainData(record.Data, record.Type))


### PR DESCRIPTION
Related to https://github.com/scaleway/terraform-provider-scaleway/issues/1023

When importing a domain record, it goes into the first `if` : https://github.com/scaleway/terraform-provider-scaleway/blob/master/scaleway/resource_domain_record.go#L267

By the end, the `dnsZone` that is parsed is never set : https://github.com/scaleway/terraform-provider-scaleway/blob/master/scaleway/resource_domain_record.go#L340

I suggest here setting the `dns_zone` at the end, feedback welcome if you see other ways to fix this issue.

Tested locally on Terraform 1.0.7.