### PR TITLE
Fix(AppleSilicon): fix Apple Silicon read

### DIFF
--- a/scaleway/resource_apple_silicon_server.go
+++ b/scaleway/resource_apple_silicon_server.go
@@ -101,7 +101,7 @@ func resourceScalewayAppleSiliconServerCreate(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 
-	return resourceScalewayRdbInstanceRead(ctx, d, meta)
+	return resourceScalewayAppleSiliconServerRead(ctx, d, meta)
 }
 
 func resourceScalewayAppleSiliconServerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
After a create, the callback for reading was the one of RDB instead of Apple Silicon :)
