### PR TITLE
chore(vpcgw): migrate from v1beta1 to v1

### DIFF
--- a/scaleway/data_source_vpc_public_gateway.go
+++ b/scaleway/data_source_vpc_public_gateway.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/helpers_vpcgw.go
+++ b/scaleway/helpers_vpcgw.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/resource_vpc_gateway_network.go
+++ b/scaleway/resource_vpc_gateway_network.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/resource_vpc_gateway_network_test.go
+++ b/scaleway/resource_vpc_gateway_network_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/resource_vpc_public_gateway.go
+++ b/scaleway/resource_vpc_public_gateway.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/resource_vpc_public_gateway_dhcp.go
+++ b/scaleway/resource_vpc_public_gateway_dhcp.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/resource_vpc_public_gateway_dhcp_test.go
+++ b/scaleway/resource_vpc_public_gateway_dhcp_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 )
 
 func TestAccScalewayVPCPublicGatewayDHCP_Basic(t *testing.T) {

--- a/scaleway/resource_vpc_public_gateway_ip.go
+++ b/scaleway/resource_vpc_public_gateway_ip.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/resource_vpc_public_gateway_ip_test.go
+++ b/scaleway/resource_vpc_public_gateway_ip_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/resource_vpc_public_gateway_pat_rule.go
+++ b/scaleway/resource_vpc_public_gateway_pat_rule.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/resource_vpc_public_gateway_pat_rule_test.go
+++ b/scaleway/resource_vpc_public_gateway_pat_rule_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 )
 
 func TestAccScalewayVPCPublicGatewayPATRule_Basic(t *testing.T) {

--- a/scaleway/resource_vpc_public_gateway_test.go
+++ b/scaleway/resource_vpc_public_gateway_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1beta1"
+	vpcgw "github.com/scaleway/scaleway-sdk-go/api/vpcgw/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 

--- a/scaleway/testdata/data-source-vpc-public-gateway-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-vpc-public-gateway-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"message":"{\"type\": \"server_error\", \"message\": \"Internal error\"}"}'
@@ -45,7 +45,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:01.546239Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -78,7 +78,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:01.584414Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:01.584414Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -144,7 +144,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -177,7 +177,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -210,7 +210,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -243,7 +243,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
     method: GET
   response:
     body: '{"gateways":[{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}],"total_count":1}'
@@ -276,7 +276,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -309,7 +309,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -342,7 +342,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
     method: GET
   response:
     body: '{"gateways":[{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}],"total_count":1}'
@@ -375,7 +375,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -408,7 +408,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -441,7 +441,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
     method: GET
   response:
     body: '{"gateways":[{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}],"total_count":1}'
@@ -474,7 +474,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -507,7 +507,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -540,7 +540,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -573,7 +573,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
     method: GET
   response:
     body: '{"gateways":[{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}],"total_count":1}'
@@ -606,7 +606,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -639,7 +639,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -672,7 +672,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways?name=TestAccScalewayDataSourceVPCPublicGateway_Basic&order_by=created_at_asc&status=unknown
     method: GET
   response:
     body: '{"gateways":[{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}],"total_count":1}'
@@ -705,7 +705,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -738,7 +738,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -771,7 +771,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.546239Z","updated_at":"2022-01-27T14:16:02.168157Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"TestAccScalewayDataSourceVPCPublicGateway_Basic","tags":[],"ip":{"id":"f963bc49-5a12-4689-9600-d73b712e7c28","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.532679Z","updated_at":"2022-01-27T14:16:01.532679Z","tags":[],"address":"51.158.98.245","reverse":"245-98-158-51.instances.scw.cloud","gateway_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -804,7 +804,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -835,7 +835,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"gateway","resource_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","type":"not_found"}'
@@ -868,7 +868,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"gateway","resource_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","type":"not_found"}'
@@ -901,7 +901,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/d073e732-5ec6-40a1-8b80-847efe53dbc5
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"gateway","resource_id":"d073e732-5ec6-40a1-8b80-847efe53dbc5","type":"not_found"}'

--- a/scaleway/testdata/data-source-vpc-public-gateway-dhcp-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-vpc-public-gateway-dhcp-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -43,7 +43,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -76,7 +76,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -109,7 +109,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -142,7 +142,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -175,7 +175,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -208,7 +208,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -241,7 +241,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -274,7 +274,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -307,7 +307,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -340,7 +340,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: GET
   response:
     body: '{"id":"edcc9c46-25b0-46e8-9de7-21a0a766e678","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.799974Z","updated_at":"2022-01-27T14:15:53.799974Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -373,7 +373,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/edcc9c46-25b0-46e8-9de7-21a0a766e678
     method: DELETE
   response:
     body: ""

--- a/scaleway/testdata/data-source-vpc-public-gateway-ip-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-vpc-public-gateway-ip-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -43,7 +43,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -76,7 +76,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -109,7 +109,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -142,7 +142,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -175,7 +175,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -208,7 +208,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -241,7 +241,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -274,7 +274,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -307,7 +307,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -340,7 +340,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"id":"ccae8e47-6429-42d6-a23a-70c6851f079c","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.161005Z","updated_at":"2022-01-27T14:15:55.161005Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -373,7 +373,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: DELETE
   response:
     body: ""
@@ -404,7 +404,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"ip","resource_id":"ccae8e47-6429-42d6-a23a-70c6851f079c","type":"not_found"}'
@@ -437,7 +437,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/ccae8e47-6429-42d6-a23a-70c6851f079c
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"ip","resource_id":"ccae8e47-6429-42d6-a23a-70c6851f079c","type":"not_found"}'

--- a/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
     body: '{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
@@ -80,7 +80,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
     body: '{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
@@ -113,7 +113,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips/3aab9221-60c8-416a-9c4a-904a75277536
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/3aab9221-60c8-416a-9c4a-904a75277536
     method: GET
   response:
     body: '{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
@@ -146,7 +146,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps/d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6
     method: GET
   response:
     body: '{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
@@ -181,7 +181,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:54:09.937350Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -214,7 +214,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:54:09.997309Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -247,7 +247,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:54:10.141601Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -515,7 +515,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:54:11.540043Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -548,7 +548,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:54:11.540043Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -583,7 +583,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:10.995215Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -616,7 +616,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:11.055824Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:10.995215Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -781,7 +781,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -814,7 +814,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
     method: GET
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -847,7 +847,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -880,7 +880,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
     method: GET
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -913,7 +913,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
     method: GET
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -946,7 +946,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -981,7 +981,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
     body: '{"id":"9a3c56d6-6a71-4dc0-8842-df4173555179","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","created_at":"2022-01-27T15:58:12.345067Z","updated_at":"2022-01-27T15:58:12.345067Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -1014,7 +1014,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1047,7 +1047,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
     method: GET
   response:
     body: '{"id":"9a3c56d6-6a71-4dc0-8842-df4173555179","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","created_at":"2022-01-27T15:58:12.345067Z","updated_at":"2022-01-27T15:58:12.345067Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -1113,7 +1113,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps/d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6
     method: GET
   response:
     body: '{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
@@ -1179,7 +1179,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips/3aab9221-60c8-416a-9c4a-904a75277536
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/3aab9221-60c8-416a-9c4a-904a75277536
     method: GET
   response:
     body: '{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"}'
@@ -1212,7 +1212,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1278,7 +1278,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1344,7 +1344,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
     method: GET
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -1377,7 +1377,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
     method: GET
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -1410,7 +1410,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
     method: GET
   response:
     body: '{"id":"9a3c56d6-6a71-4dc0-8842-df4173555179","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","created_at":"2022-01-27T15:58:12.345067Z","updated_at":"2022-01-27T15:58:12.345067Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -1476,7 +1476,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1509,7 +1509,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
     method: GET
   response:
     body: '{"id":"9a3c56d6-6a71-4dc0-8842-df4173555179","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","created_at":"2022-01-27T15:58:12.345067Z","updated_at":"2022-01-27T15:58:12.345067Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -1542,7 +1542,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips/3aab9221-60c8-416a-9c4a-904a75277536
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/3aab9221-60c8-416a-9c4a-904a75277536
     method: GET
   response:
     body: '{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"}'
@@ -1575,7 +1575,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1608,7 +1608,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps/d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6
     method: GET
   response:
     body: '{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
@@ -1707,7 +1707,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
     method: GET
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -1740,7 +1740,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
     method: GET
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -1773,7 +1773,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
     method: GET
   response:
     body: '{"id":"9a3c56d6-6a71-4dc0-8842-df4173555179","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","created_at":"2022-01-27T15:58:12.345067Z","updated_at":"2022-01-27T15:58:12.345067Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -1806,7 +1806,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1839,7 +1839,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a3c56d6-6a71-4dc0-8842-df4173555179
     method: DELETE
   response:
     body: ""
@@ -1870,7 +1870,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1903,7 +1903,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1969,7 +1969,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76
     method: GET
   response:
     body: '{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:56:17.464533Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"ready","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -2035,7 +2035,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/fd2f24b3-f811-4686-b766-ce91970c1c76?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2066,7 +2066,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:58:16.198910Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"detaching","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2132,7 +2132,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps/d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6
     method: DELETE
   response:
     body: '{"message":"resource is not found","resource":"dhcp","resource_id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","type":"not_found"}'
@@ -2165,7 +2165,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2
     method: GET
   response:
     body: '{"id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.937350Z","updated_at":"2022-01-27T15:56:17.523811Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3aab9221-60c8-416a-9c4a-904a75277536","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.489560Z","updated_at":"2022-01-27T15:54:09.489560Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","zone":"nl-ams-1"},"gateway_networks":[{"id":"fd2f24b3-f811-4686-b766-ce91970c1c76","created_at":"2022-01-27T15:56:10.995215Z","updated_at":"2022-01-27T15:58:16.198910Z","gateway_id":"f9f470c3-91b4-4986-b4d2-1ddf3dea5af2","private_network_id":"e4c2e52f-093c-41c7-b6a3-1a05dd82aafe","mac_address":"02:00:00:00:75:62","enable_masquerade":true,"status":"detaching","dhcp":{"id":"d0e0bc8b-8dca-4c71-8a3a-7f25f10859c6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:54:09.058941Z","updated_at":"2022-01-27T15:54:09.058941Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2198,7 +2198,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/f9f470c3-91b4-4986-b4d2-1ddf3dea5af2?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -2229,7 +2229,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips/3aab9221-60c8-416a-9c4a-904a75277536
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/3aab9221-60c8-416a-9c4a-904a75277536
     method: DELETE
   response:
     body: ""

--- a/scaleway/testdata/rdb-instance-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network.cassette.yaml
@@ -1439,7 +1439,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
     body: '{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
@@ -1472,7 +1472,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps/9f762490-fac5-48bc-ab2e-fef3905d7586
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9f762490-fac5-48bc-ab2e-fef3905d7586
     method: GET
   response:
     body: '{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
@@ -1507,7 +1507,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
     body: '{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
@@ -1540,7 +1540,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips/7a3efa1d-dcec-4283-86ef-2cd660a160f9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/7a3efa1d-dcec-4283-86ef-2cd660a160f9
     method: GET
   response:
     body: '{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
@@ -1575,7 +1575,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T15:58:20.354512Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1608,7 +1608,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T15:58:20.407156Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1641,7 +1641,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T15:58:20.407156Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1674,7 +1674,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T15:58:20.590336Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1707,7 +1707,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T15:58:21.184405Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1742,7 +1742,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:20.947043Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -1775,7 +1775,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:20.993111Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:20.947043Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1808,7 +1808,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1841,7 +1841,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
     method: GET
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -1874,7 +1874,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -1907,7 +1907,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
     method: GET
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -1940,7 +1940,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
     method: GET
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -1973,7 +1973,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2008,7 +2008,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
     body: '{"id":"9a96aea6-e7a2-444c-b609-30769671b15d","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","created_at":"2022-01-27T16:02:22.003233Z","updated_at":"2022-01-27T16:02:22.003233Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -2041,7 +2041,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2074,7 +2074,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
     method: GET
   response:
     body: '{"id":"9a96aea6-e7a2-444c-b609-30769671b15d","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","created_at":"2022-01-27T16:02:22.003233Z","updated_at":"2022-01-27T16:02:22.003233Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -2173,7 +2173,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps/9f762490-fac5-48bc-ab2e-fef3905d7586
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9f762490-fac5-48bc-ab2e-fef3905d7586
     method: GET
   response:
     body: '{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
@@ -2239,7 +2239,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips/7a3efa1d-dcec-4283-86ef-2cd660a160f9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/7a3efa1d-dcec-4283-86ef-2cd660a160f9
     method: GET
   response:
     body: '{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"}'
@@ -2272,7 +2272,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2338,7 +2338,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2404,7 +2404,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
     method: GET
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -2437,7 +2437,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
     method: GET
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -2470,7 +2470,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
     method: GET
   response:
     body: '{"id":"9a96aea6-e7a2-444c-b609-30769671b15d","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","created_at":"2022-01-27T16:02:22.003233Z","updated_at":"2022-01-27T16:02:22.003233Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -2503,7 +2503,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2569,7 +2569,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2602,7 +2602,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps/9f762490-fac5-48bc-ab2e-fef3905d7586
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9f762490-fac5-48bc-ab2e-fef3905d7586
     method: GET
   response:
     body: '{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
@@ -2635,7 +2635,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips/7a3efa1d-dcec-4283-86ef-2cd660a160f9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/7a3efa1d-dcec-4283-86ef-2cd660a160f9
     method: GET
   response:
     body: '{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"}'
@@ -2668,7 +2668,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
     method: GET
   response:
     body: '{"id":"9a96aea6-e7a2-444c-b609-30769671b15d","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","created_at":"2022-01-27T16:02:22.003233Z","updated_at":"2022-01-27T16:02:22.003233Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -2767,7 +2767,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
     method: GET
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -2833,7 +2833,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
     method: GET
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -2866,7 +2866,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
     method: GET
   response:
     body: '{"id":"9a96aea6-e7a2-444c-b609-30769671b15d","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","created_at":"2022-01-27T16:02:22.003233Z","updated_at":"2022-01-27T16:02:22.003233Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
@@ -2899,7 +2899,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -2932,7 +2932,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/9a96aea6-e7a2-444c-b609-30769671b15d
     method: DELETE
   response:
     body: ""
@@ -2994,7 +2994,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -3027,7 +3027,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -3093,7 +3093,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d
     method: GET
   response:
     body: '{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:00:27.460225Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"ready","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
@@ -3126,7 +3126,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3190,7 +3190,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:02:26.003322Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"detaching","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -3223,7 +3223,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/dhcps/9f762490-fac5-48bc-ab2e-fef3905d7586
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/9f762490-fac5-48bc-ab2e-fef3905d7586
     method: DELETE
   response:
     body: '{"message":"resource is not found","resource":"dhcp","resource_id":"9f762490-fac5-48bc-ab2e-fef3905d7586","type":"not_found"}'
@@ -3289,7 +3289,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3
     method: GET
   response:
     body: '{"id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:20.354512Z","updated_at":"2022-01-27T16:00:27.512835Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"7a3efa1d-dcec-4283-86ef-2cd660a160f9","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.756564Z","updated_at":"2022-01-27T15:58:19.756564Z","tags":[],"address":"51.15.119.135","reverse":"135-119-15-51.instances.scw.cloud","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","zone":"nl-ams-1"},"gateway_networks":[{"id":"f138fc9f-eeb6-4000-9bd0-d6ccbcabba2d","created_at":"2022-01-27T16:00:20.947043Z","updated_at":"2022-01-27T16:02:26.003322Z","gateway_id":"c9bcab41-ebb8-455b-9b0e-9b4b42911bd3","private_network_id":"f0a04236-4545-4223-a0dc-e4979c23b90b","mac_address":"02:00:00:00:75:65","enable_masquerade":true,"status":"detaching","dhcp":{"id":"9f762490-fac5-48bc-ab2e-fef3905d7586","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T15:58:19.250162Z","updated_at":"2022-01-27T15:58:19.250162Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"nl-ams-1"}'
@@ -3322,7 +3322,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/c9bcab41-ebb8-455b-9b0e-9b4b42911bd3?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3353,7 +3353,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/nl-ams-1/ips/7a3efa1d-dcec-4283-86ef-2cd660a160f9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/7a3efa1d-dcec-4283-86ef-2cd660a160f9
     method: DELETE
   response:
     body: ""

--- a/scaleway/testdata/vpc-gateway-network-basic.cassette.yaml
+++ b/scaleway/testdata/vpc-gateway-network-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
     body: '{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -78,7 +78,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
     method: GET
   response:
     body: '{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -146,7 +146,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
     body: '{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -179,7 +179,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
     method: GET
   response:
     body: '{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -212,7 +212,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
     method: GET
   response:
     body: '{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -245,7 +245,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
     method: GET
   response:
     body: '{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -311,7 +311,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
     method: GET
   response:
     body: '{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -344,7 +344,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
     method: GET
   response:
     body: '{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -412,7 +412,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:15:55.883697Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -445,7 +445,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:15:55.883697Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -478,7 +478,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:15:55.920246Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -511,7 +511,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:15:56.067828Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -544,7 +544,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:15:56.530920Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -579,7 +579,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:17:56.350696Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -612,7 +612,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:17:56.396132Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:17:56.350696Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -645,7 +645,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -678,7 +678,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -711,7 +711,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -744,7 +744,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -810,7 +810,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -876,7 +876,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
     method: GET
   response:
     body: '{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"}'
@@ -909,7 +909,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
     method: GET
   response:
     body: '{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -942,7 +942,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -975,7 +975,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1008,7 +1008,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -1041,7 +1041,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -1074,7 +1074,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
     method: GET
   response:
     body: '{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"}'
@@ -1107,7 +1107,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
     method: GET
   response:
     body: '{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -1140,7 +1140,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1206,7 +1206,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1239,7 +1239,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -1272,7 +1272,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -1305,7 +1305,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1338,7 +1338,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3
     method: GET
   response:
     body: '{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:18:02.697490Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"ready","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -1371,7 +1371,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/e1afc2dc-f694-4946-a07f-de102dcf94d3?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -1402,7 +1402,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:19:59.327701Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"detaching","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1435,7 +1435,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/37401384-e3f6-4179-a912-df0fcc6f61c0
     method: DELETE
   response:
     body: '{"message":"resource is not found","resource":"dhcp","resource_id":"37401384-e3f6-4179-a912-df0fcc6f61c0","type":"not_found"}'
@@ -1501,7 +1501,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
     method: GET
   response:
     body: '{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"}'
@@ -1534,7 +1534,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:19:59.327701Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"detaching","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1567,7 +1567,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033
     method: GET
   response:
     body: '{"id":"362847fc-3644-45c9-8351-14064b498033","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.883697Z","updated_at":"2022-01-27T14:18:02.753767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"cd0fa4c5-e417-49ec-8744-551606cce52f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:54.502935Z","updated_at":"2022-01-27T14:15:54.502935Z","tags":[],"address":"163.172.143.70","reverse":"70-143-172-163.instances.scw.cloud","gateway_id":"362847fc-3644-45c9-8351-14064b498033","zone":"fr-par-1"},"gateway_networks":[{"id":"e1afc2dc-f694-4946-a07f-de102dcf94d3","created_at":"2022-01-27T14:17:56.350696Z","updated_at":"2022-01-27T14:19:59.327701Z","gateway_id":"362847fc-3644-45c9-8351-14064b498033","private_network_id":"b12155ee-f014-42bc-ab99-513a71b8ed8e","mac_address":"02:00:00:00:d4:e6","enable_masquerade":true,"status":"detaching","dhcp":{"id":"37401384-e3f6-4179-a912-df0fcc6f61c0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:53.776019Z","updated_at":"2022-01-27T14:15:53.776019Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1600,7 +1600,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/362847fc-3644-45c9-8351-14064b498033?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -1662,7 +1662,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/cd0fa4c5-e417-49ec-8744-551606cce52f
     method: DELETE
   response:
     body: ""

--- a/scaleway/testdata/vpc-gateway-network-without-dhcp.cassette.yaml
+++ b/scaleway/testdata/vpc-gateway-network-without-dhcp.cassette.yaml
@@ -45,7 +45,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:15:55.771814Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -78,7 +78,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:15:55.807714Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -146,7 +146,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:15:55.807714Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -247,7 +247,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:15:56.331614Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -282,7 +282,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
     body: '{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:00.407150Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -315,7 +315,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:16:00.447683Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:00.407150Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -348,7 +348,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:16:06.539101Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -381,7 +381,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
     method: GET
   response:
     body: '{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -414,7 +414,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:16:06.539101Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -447,7 +447,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
     method: GET
   response:
     body: '{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -480,7 +480,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
     method: GET
   response:
     body: '{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -513,7 +513,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
     method: GET
   response:
     body: '{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -579,7 +579,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:16:06.539101Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -612,7 +612,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:16:06.539101Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -645,7 +645,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
     method: GET
   response:
     body: '{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -678,7 +678,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
     method: GET
   response:
     body: '{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -711,7 +711,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:16:06.539101Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -744,7 +744,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
     method: GET
   response:
     body: '{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:16:06.493660Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -808,7 +808,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:16:06.539101Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:18:02.560101Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"detaching","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -841,7 +841,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac
     method: GET
   response:
     body: '{"id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.771814Z","updated_at":"2022-01-27T14:16:06.539101Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1e786a03-e0fe-44ce-a40d-66a9c9000755","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:55.754606Z","updated_at":"2022-01-27T14:15:55.754606Z","tags":[],"address":"163.172.147.71","reverse":"71-147-172-163.instances.scw.cloud","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","zone":"fr-par-1"},"gateway_networks":[{"id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","created_at":"2022-01-27T14:16:00.407150Z","updated_at":"2022-01-27T14:18:02.560101Z","gateway_id":"513bfedf-c1d4-4194-b601-a20b1ef8b9ac","private_network_id":"3c7fa6c7-b8ce-4291-a8ff-7644294aef01","mac_address":"02:00:00:00:d4:e5","enable_masquerade":true,"status":"detaching","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -874,7 +874,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/513bfedf-c1d4-4194-b601-a20b1ef8b9ac?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -936,7 +936,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/fc890710-4dad-4712-b94b-5ecdbdd7da75
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"fc890710-4dad-4712-b94b-5ecdbdd7da75","type":"not_found"}'

--- a/scaleway/testdata/vpc-public-gateway-attach-to-ip.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-attach-to-ip.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
     body: '{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -43,7 +43,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
     method: GET
   response:
     body: '{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -78,7 +78,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.897778Z","updated_at":"2022-01-27T14:15:59.897778Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
     method: GET
   response:
     body: '{"id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.897778Z","updated_at":"2022-01-27T14:15:59.944812Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -144,7 +144,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
     method: GET
   response:
     body: '{"id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.897778Z","updated_at":"2022-01-27T14:16:00.086878Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -177,7 +177,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
     method: GET
   response:
     body: '{"id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.897778Z","updated_at":"2022-01-27T14:16:00.430205Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -210,7 +210,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
     method: GET
   response:
     body: '{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"}'
@@ -243,7 +243,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
     method: GET
   response:
     body: '{"id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.897778Z","updated_at":"2022-01-27T14:16:00.430205Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -276,7 +276,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
     method: GET
   response:
     body: '{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"}'
@@ -309,7 +309,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
     method: GET
   response:
     body: '{"id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.897778Z","updated_at":"2022-01-27T14:16:00.430205Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -342,7 +342,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
     method: GET
   response:
     body: '{"id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.897778Z","updated_at":"2022-01-27T14:16:00.430205Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:59.722943Z","updated_at":"2022-01-27T14:15:59.722943Z","tags":[],"address":"51.158.78.116","reverse":"116-78-158-51.instances.scw.cloud","gateway_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -375,7 +375,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -406,7 +406,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
     method: DELETE
   response:
     body: ""
@@ -437,7 +437,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9dee4172-9aed-4bbd-bf07-0da9ca6d894a
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"ip","resource_id":"9dee4172-9aed-4bbd-bf07-0da9ca6d894a","type":"not_found"}'
@@ -470,7 +470,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/940d72c5-0df0-4a2a-a020-70629b5b3bee
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"gateway","resource_id":"940d72c5-0df0-4a2a-a020-70629b5b3bee","type":"not_found"}'

--- a/scaleway/testdata/vpc-public-gateway-basic.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:00.918448Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"public-gateway-test","tags":[],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -43,7 +43,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:00.949483Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"public-gateway-test","tags":[],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -76,7 +76,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:00.949483Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"public-gateway-test","tags":[],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -109,7 +109,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:01.086758Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"public-gateway-test","tags":[],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -142,7 +142,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:01.488573Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test","tags":[],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -175,7 +175,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:01.488573Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test","tags":[],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -208,7 +208,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:01.488573Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test","tags":[],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -243,7 +243,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: PATCH
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:02.511614Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test-new","tags":["tag0","tag1"],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":["1.2.3.4","4.3.2.1"],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -276,7 +276,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:02.543382Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"public-gateway-test-new","tags":["tag0","tag1"],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":["1.2.3.4","4.3.2.1"],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -309,7 +309,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:02.676746Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test-new","tags":["tag0","tag1"],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":["1.2.3.4","4.3.2.1"],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -342,7 +342,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:02.676746Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test-new","tags":["tag0","tag1"],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":["1.2.3.4","4.3.2.1"],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -375,7 +375,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:02.676746Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test-new","tags":["tag0","tag1"],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":["1.2.3.4","4.3.2.1"],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -408,7 +408,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:02.676746Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test-new","tags":["tag0","tag1"],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":["1.2.3.4","4.3.2.1"],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -441,7 +441,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"id":"fb232fee-f545-4640-99c2-c3b436023792","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.918448Z","updated_at":"2022-01-27T14:16:02.676746Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"public-gateway-test-new","tags":["tag0","tag1"],"ip":{"id":"4caaa007-3f8b-4942-8130-01d51abd95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:00.905920Z","updated_at":"2022-01-27T14:16:00.905920Z","tags":[],"address":"163.172.158.223","reverse":"223-158-172-163.instances.scw.cloud","gateway_id":"fb232fee-f545-4640-99c2-c3b436023792","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":["1.2.3.4","4.3.2.1"],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -474,7 +474,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -505,7 +505,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/fb232fee-f545-4640-99c2-c3b436023792
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"gateway","resource_id":"fb232fee-f545-4640-99c2-c3b436023792","type":"not_found"}'

--- a/scaleway/testdata/vpc-public-gateway-dhcp-basic.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-dhcp-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
     body: '{"id":"282a7334-89b0-4148-ba66-5db32dd977f5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:57.103567Z","updated_at":"2022-01-27T14:15:57.103567Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -43,7 +43,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
     method: GET
   response:
     body: '{"id":"282a7334-89b0-4148-ba66-5db32dd977f5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:57.103567Z","updated_at":"2022-01-27T14:15:57.103567Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -76,7 +76,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
     method: GET
   response:
     body: '{"id":"282a7334-89b0-4148-ba66-5db32dd977f5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:57.103567Z","updated_at":"2022-01-27T14:15:57.103567Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -109,7 +109,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
     method: GET
   response:
     body: '{"id":"282a7334-89b0-4148-ba66-5db32dd977f5","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:57.103567Z","updated_at":"2022-01-27T14:15:57.103567Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -142,7 +142,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
     method: DELETE
   response:
     body: ""
@@ -173,7 +173,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/282a7334-89b0-4148-ba66-5db32dd977f5
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"dhcp","resource_id":"282a7334-89b0-4148-ba66-5db32dd977f5","type":"not_found"}'

--- a/scaleway/testdata/vpc-public-gateway-ip-basic.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-ip-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:56.384533Z","tags":[],"address":"163.172.137.156","reverse":"156-137-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -43,7 +43,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:56.384533Z","tags":[],"address":"163.172.137.156","reverse":"156-137-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -76,7 +76,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:56.384533Z","tags":[],"address":"163.172.137.156","reverse":"156-137-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -109,7 +109,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:56.384533Z","tags":[],"address":"163.172.137.156","reverse":"156-137-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -142,7 +142,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:56.384533Z","tags":[],"address":"163.172.137.156","reverse":"156-137-172-163.instances.scw.cloud","gateway_id":null,"zone":"fr-par-1"}'
@@ -177,7 +177,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: PATCH
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:58.041656Z","tags":["tag0","tag1"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -210,7 +210,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:58.041656Z","tags":["tag0","tag1"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -243,7 +243,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:58.041656Z","tags":["tag0","tag1"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -276,7 +276,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:58.041656Z","tags":["tag0","tag1"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -309,7 +309,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:58.041656Z","tags":["tag0","tag1"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -344,7 +344,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: PATCH
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:59.921147Z","tags":["tag2","tag3"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -377,7 +377,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:59.921147Z","tags":["tag2","tag3"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -410,7 +410,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:59.921147Z","tags":["tag2","tag3"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -443,7 +443,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"id":"48e7c588-3632-4904-9a87-003778b168d8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:15:56.384533Z","updated_at":"2022-01-27T14:15:59.921147Z","tags":["tag2","tag3"],"address":"163.172.137.156","reverse":"example.com","gateway_id":null,"zone":"fr-par-1"}'
@@ -476,7 +476,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: DELETE
   response:
     body: ""
@@ -507,7 +507,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/48e7c588-3632-4904-9a87-003778b168d8
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"ip","resource_id":"48e7c588-3632-4904-9a87-003778b168d8","type":"not_found"}'

--- a/scaleway/testdata/vpc-public-gateway-pat-rule-basic.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-pat-rule-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
     body: '{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -78,7 +78,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
     method: GET
   response:
     body: '{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -146,7 +146,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:16:02.616674Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -179,7 +179,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:16:02.616674Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -212,7 +212,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:16:02.656101Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -245,7 +245,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
     method: GET
   response:
     body: '{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -311,7 +311,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:16:02.805583Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -344,7 +344,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:16:03.195145Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -410,7 +410,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
     method: GET
   response:
     body: '{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -443,7 +443,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:16:03.195145Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -476,7 +476,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:16:03.195145Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -511,7 +511,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
     body: '{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:04.099236Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -544,7 +544,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:04.137987Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:04.099236Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -577,7 +577,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -610,7 +610,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
     method: GET
   response:
     body: '{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -643,7 +643,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -676,7 +676,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
     method: GET
   response:
     body: '{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -709,7 +709,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
     method: GET
   response:
     body: '{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -742,7 +742,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/pat-rules
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
     method: POST
   response:
     body: '{"id":"29a9f122-8169-443e-9797-75505ac1db9c","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","created_at":"2022-01-27T14:20:04.809253Z","updated_at":"2022-01-27T14:20:04.809253Z","public_port":42,"private_ip":"192.168.1.1","private_port":42,"protocol":"both","zone":"fr-par-1"}'
@@ -810,7 +810,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -843,7 +843,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
     method: GET
   response:
     body: '{"id":"29a9f122-8169-443e-9797-75505ac1db9c","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","created_at":"2022-01-27T14:20:04.809253Z","updated_at":"2022-01-27T14:20:04.809253Z","public_port":42,"private_ip":"192.168.1.1","private_port":42,"protocol":"both","zone":"fr-par-1"}'
@@ -876,7 +876,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
     method: GET
   response:
     body: '{"id":"29a9f122-8169-443e-9797-75505ac1db9c","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","created_at":"2022-01-27T14:20:04.809253Z","updated_at":"2022-01-27T14:20:04.809253Z","public_port":42,"private_ip":"192.168.1.1","private_port":42,"protocol":"both","zone":"fr-par-1"}'
@@ -909,7 +909,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -942,7 +942,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
     method: GET
   response:
     body: '{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -1008,7 +1008,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1041,7 +1041,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
     method: GET
   response:
     body: '{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -1074,7 +1074,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
     method: GET
   response:
     body: '{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -1107,7 +1107,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
     method: GET
   response:
     body: '{"id":"29a9f122-8169-443e-9797-75505ac1db9c","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","created_at":"2022-01-27T14:20:04.809253Z","updated_at":"2022-01-27T14:20:04.809253Z","public_port":42,"private_ip":"192.168.1.1","private_port":42,"protocol":"both","zone":"fr-par-1"}'
@@ -1140,7 +1140,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
     method: GET
   response:
     body: '{"id":"29a9f122-8169-443e-9797-75505ac1db9c","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","created_at":"2022-01-27T14:20:04.809253Z","updated_at":"2022-01-27T14:20:04.809253Z","public_port":42,"private_ip":"192.168.1.1","private_port":42,"protocol":"both","zone":"fr-par-1"}'
@@ -1173,7 +1173,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1206,7 +1206,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/29a9f122-8169-443e-9797-75505ac1db9c
     method: DELETE
   response:
     body: ""
@@ -1237,7 +1237,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1270,7 +1270,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1303,7 +1303,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce
     method: GET
   response:
     body: '{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:18:10.436336Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"ready","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -1336,7 +1336,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/383e77cc-2702-4575-bfea-5b5cf4b522ce?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -1367,7 +1367,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:20:07.959213Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"detaching","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1400,7 +1400,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/e223a249-f3b8-449b-95c4-4af768f7716f
     method: DELETE
   response:
     body: '{"message":"resource is not found","resource":"dhcp","resource_id":"e223a249-f3b8-449b-95c4-4af768f7716f","type":"not_found"}'
@@ -1433,7 +1433,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1
     method: GET
   response:
     body: '{"id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.616674Z","updated_at":"2022-01-27T14:18:10.486236Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"tf-pn-sweet-beaver","tags":[],"ip":{"id":"a220a9b3-cea2-4990-96af-c8c051a62782","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:02.605812Z","updated_at":"2022-01-27T14:16:02.605812Z","tags":[],"address":"51.15.192.146","reverse":"146-192-15-51.instances.scw.cloud","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","zone":"fr-par-1"},"gateway_networks":[{"id":"383e77cc-2702-4575-bfea-5b5cf4b522ce","created_at":"2022-01-27T14:18:04.099236Z","updated_at":"2022-01-27T14:20:07.959213Z","gateway_id":"07350ba4-a80a-4ce0-9888-366c7925b8c1","private_network_id":"327d0954-0ab4-49ed-986a-37eb82dfb7b4","mac_address":"02:00:00:00:d4:e7","enable_masquerade":true,"status":"detaching","dhcp":{"id":"e223a249-f3b8-449b-95c4-4af768f7716f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-01-27T14:16:01.918905Z","updated_at":"2022-01-27T14:16:01.918905Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.18","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -1466,7 +1466,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.6; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/07350ba4-a80a-4ce0-9888-366c7925b8c1?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""

--- a/scaleway/testdata/vpc-public-network-basic.cassette.yaml
+++ b/scaleway/testdata/vpc-public-network-basic.cassette.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
     body: '{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -78,7 +78,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/d761582e-8376-4147-b274-281af8990658
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/d761582e-8376-4147-b274-281af8990658
     method: GET
   response:
     body: '{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -146,7 +146,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
     body: '{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"}'
@@ -179,7 +179,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/a0b79e0c-95c1-4357-8083-ffa383be2e99
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a0b79e0c-95c1-4357-8083-ffa383be2e99
     method: GET
   response:
     body: '{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"}'
@@ -214,7 +214,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"id":"af89f5fc-255d-4737-8c93-d36549754b62","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.972767Z","updated_at":"2021-10-08T15:04:11.972767Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -247,7 +247,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
     method: GET
   response:
     body: '{"id":"af89f5fc-255d-4737-8c93-d36549754b62","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.972767Z","updated_at":"2021-10-08T15:04:12.141644Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -280,7 +280,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
     method: GET
   response:
     body: '{"id":"af89f5fc-255d-4737-8c93-d36549754b62","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.972767Z","updated_at":"2021-10-08T15:04:12.541750Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -313,7 +313,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
     method: GET
   response:
     body: '{"id":"af89f5fc-255d-4737-8c93-d36549754b62","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.972767Z","updated_at":"2021-10-08T15:04:12.541750Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -346,7 +346,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
     method: GET
   response:
     body: '{"id":"af89f5fc-255d-4737-8c93-d36549754b62","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.972767Z","updated_at":"2021-10-08T15:04:12.541750Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -381,7 +381,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
     body: '{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:42.653810Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":null,"enable_masquerade":false,"status":"created","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -414,7 +414,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
     method: GET
   response:
     body: '{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:42.653810Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":null,"enable_masquerade":false,"status":"created","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -447,7 +447,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
     method: GET
   response:
     body: '{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:42.653810Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":null,"enable_masquerade":false,"status":"created","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -480,7 +480,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
     method: GET
   response:
     body: '{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:42.653810Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":null,"enable_masquerade":false,"status":"created","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -546,7 +546,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/a0b79e0c-95c1-4357-8083-ffa383be2e99
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a0b79e0c-95c1-4357-8083-ffa383be2e99
     method: GET
   response:
     body: '{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"}'
@@ -579,7 +579,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/d761582e-8376-4147-b274-281af8990658
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/d761582e-8376-4147-b274-281af8990658
     method: GET
   response:
     body: '{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"}'
@@ -612,7 +612,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
     method: GET
   response:
     body: '{"id":"af89f5fc-255d-4737-8c93-d36549754b62","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.972767Z","updated_at":"2021-10-08T15:04:42.702784Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:42.653810Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":null,"enable_masquerade":false,"status":"created","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -645,7 +645,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
     method: GET
   response:
     body: '{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:43.739605Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":"02:00:00:00:69:07","enable_masquerade":false,"status":"configuring","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -678,7 +678,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
     method: GET
   response:
     body: '{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:43.739605Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":"02:00:00:00:69:07","enable_masquerade":false,"status":"configuring","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -711,7 +711,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
     method: GET
   response:
     body: '{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:48.957719Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":"02:00:00:00:69:07","enable_masquerade":false,"status":"ready","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}'
@@ -744,7 +744,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
     method: GET
   response:
     body: '{"id":"af89f5fc-255d-4737-8c93-d36549754b62","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.972767Z","updated_at":"2021-10-08T15:04:49.232934Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:04:48.957719Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":"02:00:00:00:69:07","enable_masquerade":false,"status":"ready","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -777,7 +777,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -808,7 +808,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/dhcps/d761582e-8376-4147-b274-281af8990658
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/d761582e-8376-4147-b274-281af8990658
     method: DELETE
   response:
     body: '{"message":"resource is not found","resource":"dhcp","resource_id":"d761582e-8376-4147-b274-281af8990658","type":"not_found"}'
@@ -841,7 +841,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62
     method: GET
   response:
     body: '{"id":"af89f5fc-255d-4737-8c93-d36549754b62","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.972767Z","updated_at":"2021-10-08T15:04:49.232934Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"a0b79e0c-95c1-4357-8083-ffa383be2e99","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:11.388652Z","updated_at":"2021-10-08T15:04:11.388652Z","tags":[],"address":"51.15.235.29","reverse":"29-235-15-51.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[{"id":"542a8437-0e91-41be-8f46-f9d0943e8901","created_at":"2021-10-08T15:04:42.653810Z","updated_at":"2021-10-08T15:05:14.836121Z","gateway_id":"af89f5fc-255d-4737-8c93-d36549754b62","private_network_id":"39d436fa-2180-4c9f-b404-4fe4cc500c10","mac_address":"02:00:00:00:69:07","enable_masquerade":false,"status":"detaching","dhcp":{"id":"d761582e-8376-4147-b274-281af8990658","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T15:04:10.826916Z","updated_at":"2021-10-08T15:04:10.826916Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":false,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":false,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"fr-par-1"},"enable_dhcp":true,"address":null,"zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -874,7 +874,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/af89f5fc-255d-4737-8c93-d36549754b62?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -905,7 +905,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/a0b79e0c-95c1-4357-8083-ffa383be2e99
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/a0b79e0c-95c1-4357-8083-ffa383be2e99
     method: DELETE
   response:
     body: ""
@@ -967,7 +967,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/542a8437-0e91-41be-8f46-f9d0943e8901
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"542a8437-0e91-41be-8f46-f9d0943e8901","type":"not_found"}'

--- a/scaleway/testdata/vpc-public-network-without-dhcp.cassette.yaml
+++ b/scaleway/testdata/vpc-public-network-without-dhcp.cassette.yaml
@@ -78,7 +78,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
     body: '{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"}'
@@ -111,7 +111,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/959a2cc3-1403-40be-a4fb-714a381cbbc4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/959a2cc3-1403-40be-a4fb-714a381cbbc4
     method: GET
   response:
     body: '{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"}'
@@ -146,7 +146,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
     body: '{"id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.934550Z","updated_at":"2021-10-08T14:56:26.934550Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -179,7 +179,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
     method: GET
   response:
     body: '{"id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.934550Z","updated_at":"2021-10-08T14:56:26.972360Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -212,7 +212,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
     method: GET
   response:
     body: '{"id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.934550Z","updated_at":"2021-10-08T14:56:26.972360Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -245,7 +245,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
     method: GET
   response:
     body: '{"id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.934550Z","updated_at":"2021-10-08T14:56:27.121001Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -278,7 +278,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
     method: GET
   response:
     body: '{"id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.934550Z","updated_at":"2021-10-08T14:56:27.524396Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -313,7 +313,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
     body: '{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:56:57.384221Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -346,7 +346,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
     method: GET
   response:
     body: '{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:56:57.384221Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -379,7 +379,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
     method: GET
   response:
     body: '{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:56:57.384221Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -412,7 +412,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
     method: GET
   response:
     body: '{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:56:57.384221Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -478,7 +478,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/959a2cc3-1403-40be-a4fb-714a381cbbc4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/959a2cc3-1403-40be-a4fb-714a381cbbc4
     method: GET
   response:
     body: '{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"}'
@@ -511,7 +511,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
     method: GET
   response:
     body: '{"id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.934550Z","updated_at":"2021-10-08T14:56:57.432726Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:56:58.185798Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":"02:00:00:00:69:03","enable_masquerade":true,"status":"configuring","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -544,7 +544,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
     method: GET
   response:
     body: '{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:56:58.185798Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":"02:00:00:00:69:03","enable_masquerade":true,"status":"configuring","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -577,7 +577,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
     method: GET
   response:
     body: '{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:56:58.185798Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":"02:00:00:00:69:03","enable_masquerade":true,"status":"configuring","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -610,7 +610,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
     method: GET
   response:
     body: '{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:57:02.579634Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":"02:00:00:00:69:03","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}'
@@ -643,7 +643,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
     method: GET
   response:
     body: '{"id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.934550Z","updated_at":"2021-10-08T14:57:02.765044Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:57:02.579634Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":"02:00:00:00:69:03","enable_masquerade":true,"status":"ready","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -676,7 +676,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -707,7 +707,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001
     method: GET
   response:
     body: '{"id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.934550Z","updated_at":"2021-10-08T14:57:02.765044Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"fr-par-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"959a2cc3-1403-40be-a4fb-714a381cbbc4","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","created_at":"2021-10-08T14:56:26.676441Z","updated_at":"2021-10-08T14:56:26.676441Z","tags":[],"address":"212.47.229.167","reverse":"167-229-47-212.instances.scw.cloud","zone":"fr-par-1"},"gateway_networks":[{"id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","created_at":"2021-10-08T14:56:57.384221Z","updated_at":"2021-10-08T14:57:29.924563Z","gateway_id":"226c5a20-ba24-4568-a2fc-b8d0b2046001","private_network_id":"ab68b593-3add-4762-b045-f70d14c63922","mac_address":"02:00:00:00:69:03","enable_masquerade":true,"status":"detaching","dhcp":null,"enable_dhcp":false,"address":"192.168.1.42/24","zone":"fr-par-1"}],"upstream_dns_servers":[],"version":"0.2.13","can_upgrade_to":null,"zone":"fr-par-1"}'
@@ -740,7 +740,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/226c5a20-ba24-4568-a2fc-b8d0b2046001?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -802,7 +802,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/ips/959a2cc3-1403-40be-a4fb-714a381cbbc4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/959a2cc3-1403-40be-a4fb-714a381cbbc4
     method: DELETE
   response:
     body: ""
@@ -833,7 +833,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.17.1; darwin; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1beta1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/0de5ffd0-53a3-4b8d-a472-24fef26c3d9a
     method: GET
   response:
     body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"0de5ffd0-53a3-4b8d-a472-24fef26c3d9a","type":"not_found"}'


### PR DESCRIPTION
The v1 API is a drop-in replacement for v1beta1.