### PR TITLE
Change the computed volume size of an instance

### DIFF
--- a/scaleway/resource_instance_server.go
+++ b/scaleway/resource_instance_server.go
@@ -332,7 +332,7 @@ func resourceScalewayInstanceServerCreate(ctx context.Context, d *schema.Resourc
 			req.Volumes["0"] = &instance.VolumeServerTemplate{
 				Name:       newRandomName("vol"),
 				VolumeType: instance.VolumeVolumeTypeLSSD,
-				Size:       serverType.VolumesConstraint.MinSize,
+				Size:       serverType.VolumesConstraint.MaxSize,
 			}
 		}
 	}


### PR DESCRIPTION
Change the computed volume size from serverType.VolumesConstraint.MinSize to serverType.VolumesConstraint.MaxSize. It's an adaptation to the loose constraints where serverType.VolumesConstraint.MinSize is 0.