### PR TITLE
fix: replace DHCP reservation on mac_address update

### DIFF
--- a/scaleway/resource_vpc_public_gateway_dhcp_reservation.go
+++ b/scaleway/resource_vpc_public_gateway_dhcp_reservation.go
@@ -41,6 +41,7 @@ func resourceScalewayVPCPublicGatewayDHCPReservation() *schema.Resource {
 			"mac_address": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				Description:  "The MAC address to give a static entry to.",
 				ValidateFunc: validation.IsMACAddress,
 			},


### PR DESCRIPTION
The update method for DHCP reservation doesn't update the mac address
(same as the api behind). Any change on this field must trigger a
replacement, not an in-place update (which won't do anything).