### PR TITLE
fix: PN delete operation and wait before consider a nic deleted

### DIFF
--- a/scaleway/resource_instance_private_nic.go
+++ b/scaleway/resource_instance_private_nic.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -190,6 +191,10 @@ func resourceScalewayInstancePrivateNICDelete(ctx context.Context, d *schema.Res
 		PrivateNicID: privateNICID,
 		Zone:         zone,
 	}, scw.WithContext(ctx))
+
+	// Wait for the NIC to be deleted from virtual machine
+	// Checkout CP-6367
+	time.Sleep(10 * time.Second)
 
 	if err != nil && !is404Error(err) {
 		return diag.FromErr(err)


### PR DESCRIPTION
It seems, we could have a private network nic flaged as deleted but still present on VM. 
It's a problem in case of unplug/plug of private NIC with the same private network id as private nic is not correctly replaced in the VM