### PR TITLE
fix: remove GetOk usage with optional boolean

### DIFF
--- a/scaleway/resource_rdb_instance.go
+++ b/scaleway/resource_rdb_instance.go
@@ -327,10 +327,7 @@ func resourceScalewayRdbInstanceCreate(ctx context.Context, d *schema.ResourceDa
 			InstanceID: res.ID,
 		}
 
-		backupSameRegion, backupSameRegionExist := d.GetOk("backup_same_region")
-		if backupSameRegionExist {
-			updateReq.BackupSameRegion = expandBoolPtr(backupSameRegion)
-		}
+		updateReq.BackupSameRegion = expandBoolPtr(d.Get("backup_same_region"))
 
 		updateReq.IsBackupScheduleDisabled = scw.BoolPtr(d.Get("disable_backup").(bool))
 		if backupScheduleFrequency, okFrequency := d.GetOk("backup_schedule_frequency"); okFrequency {

--- a/scaleway/resource_vpc_public_gateway_dhcp.go
+++ b/scaleway/resource_vpc_public_gateway_dhcp.go
@@ -140,17 +140,9 @@ func resourceScalewayVPCPublicGatewayDHCPCreate(ctx context.Context, d *schema.R
 		Subnet:    subnet,
 	}
 
-	if pushDefaultRoute, ok := d.GetOk("push_default_route"); ok {
-		req.PushDefaultRoute = expandBoolPtr(pushDefaultRoute)
-	}
-
-	if pushDNServer, ok := d.GetOk("push_dns_server"); ok {
-		req.PushDNSServer = expandBoolPtr(pushDNServer)
-	}
-
-	if enableDynamic, ok := d.GetOk("enable_dynamic"); ok {
-		req.EnableDynamic = expandBoolPtr(enableDynamic)
-	}
+	req.PushDefaultRoute = expandBoolPtr(d.Get("push_default_route"))
+	req.PushDNSServer = expandBoolPtr(d.Get("push_dns_server"))
+	req.EnableDynamic = expandBoolPtr(d.Get("enable_dynamic"))
 
 	if dnsServerOverride, ok := d.GetOk("dns_servers_override"); ok {
 		req.DNSServersOverride = expandStringsPtr(dnsServerOverride)


### PR DESCRIPTION
GetOk returned false for the ok value when the boolean was false, making the schema value not passed to the api