### PR TITLE
feat(container): add destroy_registry field to container namespace

### DIFF
--- a/scaleway/testdata/container-namespace-destroy-registry.cassette.yaml
+++ b/scaleway/testdata/container-namespace-destroy-registry.cassette.yaml
@@ -1,0 +1,434 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+    method: POST
+  response:
+    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "363"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3918770b-2ef6-4646-acdf-311c7ddb54cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: GET
+  response:
+    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "363"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f01b1c14-a077-4ed1-a793-064152f7a879
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: GET
+  response:
+    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "442"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b56b750-2e37-40e4-9125-8a3d9a07c1e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: GET
+  response:
+    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "442"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dda9cde2-2106-4af5-918b-cb054c17beb8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: GET
+  response:
+    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "442"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7de0eee6-a39f-47d0-aa97-bf811a459258
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: GET
+  response:
+    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "442"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a0ec1dd6-d17b-4b8a-9e25-5ab8c134ebb2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: GET
+  response:
+    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "442"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83bd04c4-b0a6-49ce-bace-868a3785ccad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: DELETE
+  response:
+    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "445"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0895b36-cca2-4719-a18e-fe5222bc3561
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: GET
+  response:
+    body: '{"message":"Namespace was not found"}'
+    headers:
+      Content-Length:
+      - "37"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f4bf057-ea7e-4731-b7a1-5c598a545f9e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/242f44d4-1c0f-40dd-904c-85ab829f502c
+    method: DELETE
+  response:
+    body: '{"id":"242f44d4-1c0f-40dd-904c-85ab829f502c","name":"funcscwtestcrns01sgxelf14","description":"","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","status_message":"","endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","is_public":false,"size":0,"created_at":"2022-06-06T13:59:55.618276Z","updated_at":"2022-06-06T13:59:58.693160161Z","image_count":0,"region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "455"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7295833-82a6-4922-a5c9-625f3f820558
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/242f44d4-1c0f-40dd-904c-85ab829f502c
+    method: GET
+  response:
+    body: '{"message":"Namespace was not found"}'
+    headers:
+      Content-Length:
+      - "37"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a405ac2-1fd7-46bf-b671-56a3ee48ab94
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    method: DELETE
+  response:
+    body: '{"message":"Namespace was not found"}'
+    headers:
+      Content-Length:
+      - "37"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 19725d8f-ef4d-4cd1-9e0f-5d1450399d9e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/242f44d4-1c0f-40dd-904c-85ab829f502c
+    method: DELETE
+  response:
+    body: '{"message":"Namespace was not found"}'
+    headers:
+      Content-Length:
+      - "37"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jun 2022 13:59:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f24ec8be-441f-418f-b8f4-cbfcda129235
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
Fix #1215
Add a new field to `scaleway_container_namespace`
```hcl
resource scaleway_container_namespace main {
    name = "test-cr-ns-01"
    destroy_registry = true
}
```

It defaults to `false` and can be set to true to delete registry namespace after container namespace