### PR TITLE
test(rdb_instance): detach private network in final steps

### DIFF
--- a/scaleway/resource_rdb_instance_test.go
+++ b/scaleway/resource_rdb_instance_test.go
@@ -389,6 +389,20 @@ func TestAccScalewayRdbInstance_PrivateNetwork(t *testing.T) {
 						name = "my_private_network"
 						zone = "nl-ams-1"
 					}
+
+					resource scaleway_rdb_instance main {
+						name = "test-rdb"
+						node_type = "db-dev-s"
+						engine = "PostgreSQL-11"
+						is_ha_cluster = false
+						disable_backup = true
+						user_name = "my_initial_user"
+						password = "thiZ_is_v&ry_s3cret"
+						region= "nl-ams"
+						tags = [ "terraform-test", "scaleway_rdb_instance", "volume", "rdb_pn" ]
+						volume_type = "bssd"
+						volume_size_in_gb = 10
+					}
 				`,
 			},
 		},
@@ -474,6 +488,20 @@ func TestAccScalewayRdbInstance_PrivateNetwork_DHCP(t *testing.T) {
 					resource scaleway_vpc_private_network pn02 {
 						name = "my_private_network"
 						zone = "nl-ams-1"
+					}
+
+					resource scaleway_rdb_instance main {
+						name = "test-rdb"
+						node_type = "db-dev-s"
+						engine = "PostgreSQL-11"
+						is_ha_cluster = false
+						disable_backup = true
+						user_name = "my_initial_user"
+						password = "thiZ_is_v&ry_s3cret"
+						region= "nl-ams"
+						tags = [ "terraform-test", "scaleway_rdb_instance", "volume", "rdb_pn" ]
+						volume_type = "bssd"
+						volume_size_in_gb = 10
 					}
 				`,
 			},

--- a/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
+    body: '{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:18 GMT
+      - Thu, 16 Jun 2022 14:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,23 +32,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60fb92c1-9fa2-4c31-82e6-db989437b67f
+      - 9f34852a-b58f-4d92-8ee6-3570a31e0c94
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my_private_network","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","tags":null,"subnets":null}'
+    body: '{"name":"my_private_network","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks
     method: POST
   response:
-    body: '{"id":"327ccf42-2783-46f7-a05f-f5f37f020550","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.554410Z","updated_at":"2022-05-20T13:08:18.554410Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.626003Z","updated_at":"2022-06-16T14:56:45.626003Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -57,7 +57,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:18 GMT
+      - Thu, 16 Jun 2022 14:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -67,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05dd0538-e7a4-44d3-ab9e-c3335a5f7097
+      - 48310346-5d02-4044-b399-a929c8dea05b
     status: 200 OK
     code: 200
     duration: ""
@@ -76,12 +76,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/44023d01-0489-45be-95c6-5438997d782d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/c8e6c9d4-48a7-4c90-840d-138aa251fb1f
     method: GET
   response:
-    body: '{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
+    body: '{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:18 GMT
+      - Thu, 16 Jun 2022 14:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cff0b8b-0c18-4ac7-ad88-66afdc3b25b7
+      - 4156facd-e923-465b-9840-649f40a2c32f
     status: 200 OK
     code: 200
     duration: ""
@@ -109,12 +109,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/327ccf42-2783-46f7-a05f-f5f37f020550
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/6d5fcd42-4fd6-466c-abb6-b22b300b4aae
     method: GET
   response:
-    body: '{"id":"327ccf42-2783-46f7-a05f-f5f37f020550","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.554410Z","updated_at":"2022-05-20T13:08:18.554410Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.626003Z","updated_at":"2022-06-16T14:56:45.626003Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -123,7 +123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:18 GMT
+      - Thu, 16 Jun 2022 14:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,23 +133,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff907401-f4ac-4927-b113-4882e00efd58
+      - 8e8f7df6-9fb4-4969-a3ba-0b690fa160b2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","tags":null}'
+    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","tags":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
-    body: '{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
+    body: '{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "356"
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:19 GMT
+      - Thu, 16 Jun 2022 14:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 269df8f9-12ee-46d7-b1dc-db9c302624d7
+      - 914bb246-cda1-47a1-adc8-f7bb01743044
     status: 200 OK
     code: 200
     duration: ""
@@ -177,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/4573b90f-59dc-4c6f-b82f-9dc886f7ed83
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6
     method: GET
   response:
-    body: '{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
+    body: '{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "356"
@@ -191,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:19 GMT
+      - Thu, 16 Jun 2022 14:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,56 +201,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63eeab11-d9f5-4fcf-b384-a782cc0e78bb
+      - fe376a1d-be9c-4e2e-812d-7ee07c457881
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","enable_smtp":false,"enable_bastion":false,"bastion_port":0}'
+    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:19.404235Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "913"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:08:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a9e91de-427a-4e59-b630-b85730ab3b51
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
-    method: GET
-  response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:19.467655Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:46.463141Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "917"
@@ -259,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:19 GMT
+      - Thu, 16 Jun 2022 14:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,23 +236,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fade01aa-d085-4fdf-aa23-b61b72fb8093
+      - d7b7e6bc-2fda-4da5-b6ee-a9e15a52d152
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","name":"test-rdb","engine":"PostgreSQL-11","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","name":"test-rdb","engine":"PostgreSQL-11","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "919"
@@ -294,7 +261,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:19 GMT
+      - Thu, 16 Jun 2022 14:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -304,7 +271,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa0b6de5-2623-4356-81a3-d10a673fb89a
+      - 3cb7d146-037f-4509-929e-03bfc5075f1f
     status: 200 OK
     code: 200
     duration: ""
@@ -313,12 +280,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:46.518516Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "921"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 14:56:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b47e2f92-b52f-4518-b953-78ef1b2f0bec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "919"
@@ -327,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:19 GMT
+      - Thu, 16 Jun 2022 14:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c4b6251-1d3d-48e6-b324-b519a1236c1c
+      - db5912f3-b183-4a72-8812-478879d6294a
     status: 200 OK
     code: 200
     duration: ""
@@ -346,21 +346,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:20.257654Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:47.190939Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:24 GMT
+      - Thu, 16 Jun 2022 14:56:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f847f863-cdba-42d2-9af1-e2d93e1f5ffd
+      - d9c567dc-dac2-49d8-b75c-df97921d8d8f
     status: 200 OK
     code: 200
     duration: ""
@@ -379,21 +379,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:20.257654Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:47.190939Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:24 GMT
+      - Thu, 16 Jun 2022 14:56:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9927f626-775e-4047-830b-ebc894a2b060
+      - 850c5f30-0ff5-45c3-bfa2-816f59229727
     status: 200 OK
     code: 200
     duration: ""
@@ -412,21 +412,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:20.257654Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:47.190939Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:24 GMT
+      - Thu, 16 Jun 2022 14:56:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,23 +436,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae646b8d-e6da-4bd3-afa8-2b0030a30123
+      - 2a13207f-c61c-4f8e-87be-28fba729e0c0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","enable_masquerade":true,"dhcp_id":"44023d01-0489-45be-95c6-5438997d782d","enable_dhcp":true}'
+    body: '{"gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","enable_masquerade":true,"dhcp_id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","enable_dhcp":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:24.929860Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:51.992997Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "934"
@@ -461,7 +461,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:24 GMT
+      - Thu, 16 Jun 2022 14:56:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -471,7 +471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 132cdbdd-393f-4a89-b9db-07c94f40ebd3
+      - 6b6aacd5-d507-4349-8844-4a0f50f794ae
     status: 200 OK
     code: 200
     duration: ""
@@ -480,21 +480,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:24.997868Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:24.929860Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:52.048097Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:51.992997Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1855"
+      - "1859"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:25 GMT
+      - Thu, 16 Jun 2022 14:56:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -504,7 +504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e5465e6-d959-4579-906d-6368211e4378
+      - 756aa1f1-653c-4d16-99a0-a180283b849e
     status: 200 OK
     code: 200
     duration: ""
@@ -513,21 +513,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:24.997868Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:24.929860Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:52.048097Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:51.992997Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1855"
+      - "1859"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:30 GMT
+      - Thu, 16 Jun 2022 14:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfe7296f-8373-4134-8a1a-963409c7948d
+      - a6cb1700-1116-4cc2-96d9-efd736ed56bf
     status: 200 OK
     code: 200
     duration: ""
@@ -546,21 +546,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:35 GMT
+      - Thu, 16 Jun 2022 14:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1438181a-1719-41bd-aaf3-1b3beef400c6
+      - 296ba477-25b1-4b35-808c-af3b6514c5e5
     status: 200 OK
     code: 200
     duration: ""
@@ -579,45 +579,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
     method: GET
   response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:08:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 586a8ea6-107a-4681-8012-87240db976bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
-    method: GET
-  response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -626,7 +593,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:35 GMT
+      - Thu, 16 Jun 2022 14:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -636,7 +603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a0f884d-10c2-43fb-add5-025c18b13a06
+      - bd1217cf-c806-40b2-9d25-827ff232f8af
     status: 200 OK
     code: 200
     duration: ""
@@ -645,45 +612,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1864"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:08:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c1849d98-53df-41d2-b9ad-ebe74180c5f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
-    method: GET
-  response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -692,7 +626,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:35 GMT
+      - Thu, 16 Jun 2022 14:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -702,7 +636,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e97261b-0553-45d6-9f3a-9cb3a65d8762
+      - d524a0b0-dd09-4f4c-b3aa-a1b895cfd2f2
     status: 200 OK
     code: 200
     duration: ""
@@ -711,12 +645,78 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 14:57:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 55e9352e-a6c2-4a3e-81f9-eec37893c8a6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
+    method: GET
+  response:
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 14:57:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ac4ffb83-ec5b-4e44-9587-369a851764b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "919"
@@ -725,7 +725,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:08:49 GMT
+      - Thu, 16 Jun 2022 14:57:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -735,7 +735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 565af388-6a26-460b-9fb5-3fef1dce50a4
+      - 583e195c-e6a5-43b5-b652-a552b96fc526
     status: 200 OK
     code: 200
     duration: ""
@@ -744,12 +744,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "919"
@@ -758,7 +758,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:09:20 GMT
+      - Thu, 16 Jun 2022 14:57:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70577261-983c-42d2-a057-95f1b4873ba7
+      - 3c33436b-f025-47a5-b48c-3e0ea6afed8a
     status: 200 OK
     code: 200
     duration: ""
@@ -777,12 +777,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "919"
@@ -791,7 +791,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:09:50 GMT
+      - Thu, 16 Jun 2022 14:58:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,7 +801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce889540-f827-4d7d-9b76-6236c69eb423
+      - df1b544a-df1b-4a76-8913-c2c6bc5be5e6
     status: 200 OK
     code: 200
     duration: ""
@@ -810,12 +810,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "919"
@@ -824,7 +824,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:20 GMT
+      - Thu, 16 Jun 2022 14:58:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -834,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45ebe6db-04f1-40dc-8ed4-c19518f467d3
+      - 84ec8963-0462-47c2-af4f-eece4547d30f
     status: 200 OK
     code: 200
     duration: ""
@@ -843,12 +843,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "919"
@@ -857,7 +857,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:50 GMT
+      - Thu, 16 Jun 2022 14:59:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45279757-6042-436b-8fc8-02f735b42035
+      - ed9d112c-e1d4-4843-90b8-2a291261aa59
     status: 200 OK
     code: 200
     duration: ""
@@ -876,12 +876,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "919"
@@ -890,7 +890,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:20 GMT
+      - Thu, 16 Jun 2022 14:59:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -900,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19faa70c-cf40-49e4-b06f-dfdcd2d0aa74
+      - f7e5aba3-cb58-4d87-aaa8-fc3d28d787b5
     status: 200 OK
     code: 200
     duration: ""
@@ -909,12 +909,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "919"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd227c68-c2b0-46ee-abb1-60754ff8ae91
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -923,7 +956,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:50 GMT
+      - Thu, 16 Jun 2022 15:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3708bad-b7d1-4053-b8b8-d2ea491058e6
+      - b1ed06b6-dac3-4be7-9a1e-e488c312c0e7
     status: 200 OK
     code: 200
     duration: ""
@@ -942,12 +975,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68/certificate
     method: GET
   response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVTjh1aXBXU3gzRml0WGlpLys3UnhZZnNDN3BVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFOalEzWWpJeE9DMWhZV00xCkxUUXdZMll0T1dNNFppMHlPVGRsTW1WbVpXUXpZVFV1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE13T1RRNVdoY05Nekl3TlRFM01UTXdPVFE1V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFUyTkRkaU1qRTRMV0ZoWXpVdE5EQmpaaTA1WXpobUxUSTVOMlV5WldabFpETmgKTlM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMR3ZPZ1lVemVWN3lIcDJzN1hrNmZRZHhheEJuZnVBNk8vRnhCVzZ2T05oMTNCTFJZQ1FmODIwCmJxV2hueVZwdEVFSHd3V1BnZlo0dkxaMWdqWTdLZUcrbk9XRkxNbms3dHh5dlZ6Qzlibnc2V0pKbS9QVGRnQjMKYmdrRHBlMFRTbTdhMk9qUEJFTFpJZmFHaTFDSGE2eVd4S0QveVRVTldPb1c2MjRQUjZRaVVrYjNaMU5JZ2tiYQpBV2dzZUVXYi9ySzR1SHVLSzR1T1pVMG1LR2lJdmVaeWdEWURzWndEL3B5bjYrNE1uK1k5ZWptOTFIaUpuN1hOCnpIdVp5b3BMS3F1TytucDZKWmFxcGxBblhvSnBxTjRKSWRZYWo3Y2w4dUM0eXZ4WVZKbjI1eGtZdkVxdDhPN0MKOFRGck9adDFsSVAyWWcvWXRDeUUxTmQ3KytsZ0kvMENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOVFkwTjJJeU1UZ3RZV0ZqTlMwME1HTm1MVGxqT0dZdE1qazNaVEpsWm1Wa00yRTFMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMEUraHdUQXFBSCtod1F6bm9OT01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ2sKMXpMOVFDWHc4L29vUjdUUjZjZFE2MmUzN3hDOWdwbDhGSnR4K25xcnIwQ2pwSW9YZ0VtSWNQUHU3Q29xV0tCbQpYbkdqd2craURzakZBU1haMDRCb0tyTWIzeVVDVWZPU245b2E4eGhFbDJzRzVPS08vcmE2RDUweXlqS3lRdzdKCllGMTlaclpGZ0s2ZVRxWkY5Q1F3blJ0bWdxcDZKQXFxL1h4QjV0Sy81bFIyd3FKNlV3RWJwUkxuVTdyWmE2WmsKV28zY0p2WmJLWjNXc01rdlM0dENtakdwajlkcTZPSW9ET0s1OHVQQzk5d3g0bExFMXJ2TEtNZ05kVmJJZVBsKwpSMnNtM1diNUMrNXhVTUt4cVZJVGUrTng3Qk54dlQrM081NkRzYnM3SlJkeGZXN2hQSldKb3hDUElkd0FrOExqCjBTakk1RFZKWE5DU3N4VlBIWGI4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVYTNUSjFvbS9VYTYrZG9GMlJmVjFqcUJWQkJFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MWtNak00TmpBM05pMWpNelUyCkxUUmtNMkl0WWpnNE5DMDFNalE1TmpObU0yRmtOamd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVFExT0RNM1doY05Nekl3TmpFek1UUTFPRE0zV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMV1F5TXpnMk1EYzJMV016TlRZdE5HUXpZaTFpT0RnMExUVXlORGsyTTJZellXUTIKT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMSjRMMzdTcjZ3R2xJNkFLZGZQeC9QaGJQeGJrZUc0UHVCangwNjl1U2FrTFdGOVAybDNkMUEzCnVZRFVmaDBUL3B1QTZzVW9yaGxqcTFWaHZjOFc1YW9VTW9NNG0rdzAvN0VKUGpER29WWERzTElVWkYyak9yYjEKVlNETmhxVEwwS3YyKzVYRVBaV203VUMzMTgwNU9nT2xQQkM2N2hRNGgvTi9BSXlreERORks3bmVxL3lWekFreQovWmxCZFJySENCS1luVWt2Sjl4WE5YMUZ5ZlBsM3R1MlNLTmRzYmJRU0NYUEJ2MUEvTWh3K1Rld0JoT2IwSU5qCllJdE5hU0NwcGZJSnRFQWtuNDBObXVIUVg0ZEZIK2ZVMEtaT1c5YkhLWnpZNmJuUGlMNkZpMDV6NnNMRmFRWEYKc2hNNU9KUVNaWTVQejZXWXZFbktTUjcwbDZ2dmVOVUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApaREl6T0RZd056WXRZek0xTmkwMFpETmlMV0k0T0RRdE5USTBPVFl6WmpOaFpEWTRMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucWdoaHdUQXFBSCtod1F6bm9Jd01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQjkKWkZTdUxOK2JDQjA0Z3JwYWxqUjFONFVZeVU2WlJIaHNSTDlOa3hUTTJmcU1LRlVSRU5EUkNHNEJPUkNmc1I1SQpVUkFaQ2cxWjJHcTcrU2xId3RGcEEvSWdNNGpReHVydFRNR3FZenRQenNHczlWdEthcTY3c3JUM2xtcno0by95CnFZUjg1ek1EcThpSUtSWDQ5RXlFaVhpZHlnMm5kQTNSSXZIUzQ4QW04SjhSTDYzWkw4TlJwUWpwZ0h6WEsvZlcKWk1URVFPM2tnSnpqelR6UWJaanU1ODgwUGdwUEFobHJKa2pGNFRTWmlPdkJkdTR2bVR0ZHVaK2tBTE1FRUJGTgo0cnUwZVVnTHhFVHJiRG9KcGpTaFZ6YXd0VXNoL25MUk0yUEVQdXJwOFN1dUJESnhwVnJUVEgzbE15c0M0OTd6Cis1bXZONHNWdDZRVW1iT0dmMHN2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
     headers:
       Content-Length:
       - "1999"
@@ -956,7 +989,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:50 GMT
+      - Thu, 16 Jun 2022 15:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -966,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b73bcc57-5a38-438d-9e1d-24fa1d95c957
+      - e92d314a-347c-4266-9a38-c629e08e7f61
     status: 200 OK
     code: 200
     duration: ""
@@ -975,21 +1008,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:51 GMT
+      - Thu, 16 Jun 2022 15:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -999,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28b3d5ca-705e-4363-aadf-a0571e4d3793
+      - 2b8118f5-823b-4f77-a7dc-31d474ca4713
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,21 +1041,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:51 GMT
+      - Thu, 16 Jun 2022 15:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1032,23 +1065,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97b06695-21bd-4948-866e-151075e9a2e3
+      - 0893ee72-29b1-4554-8a66-6984537d1ebd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: '{"gateway_id":"d259a183-debe-406e-9bea-a64141681993","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"id":"f70e74a5-0c71-4164-b875-a6cedc573413","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","created_at":"2022-05-20T13:11:51.212871Z","updated_at":"2022-05-20T13:11:51.212871Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    body: '{"id":"dee5b326-b9f6-4d15-9bd1-a8cb790a74ea","gateway_id":"d259a183-debe-406e-9bea-a64141681993","created_at":"2022-06-16T15:00:49.141299Z","updated_at":"2022-06-16T15:00:49.141299Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -1057,7 +1090,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:51 GMT
+      - Thu, 16 Jun 2022 15:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1067,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 734feaea-7dea-4d79-ac1d-33aa6e3140d5
+      - 727dddd4-12c6-4534-a777-cfb6c0d39645
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,21 +1109,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:51 GMT
+      - Thu, 16 Jun 2022 15:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1100,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3ebdb03-8d0e-4611-be88-8e89fd019026
+      - 0f38ef0a-16b7-4d73-8975-f1ae95fd285a
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,12 +1142,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/f70e74a5-0c71-4164-b875-a6cedc573413
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dee5b326-b9f6-4d15-9bd1-a8cb790a74ea
     method: GET
   response:
-    body: '{"id":"f70e74a5-0c71-4164-b875-a6cedc573413","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","created_at":"2022-05-20T13:11:51.212871Z","updated_at":"2022-05-20T13:11:51.212871Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    body: '{"id":"dee5b326-b9f6-4d15-9bd1-a8cb790a74ea","gateway_id":"d259a183-debe-406e-9bea-a64141681993","created_at":"2022-06-16T15:00:49.141299Z","updated_at":"2022-06-16T15:00:49.141299Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -1123,7 +1156,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:51 GMT
+      - Thu, 16 Jun 2022 15:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1133,7 +1166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4096679c-6655-4455-b5fa-e85582564c0f
+      - 9fc8e327-2ba4-41d2-b49d-64ac2ae94cfb
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,12 +1175,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -1156,7 +1189,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:51 GMT
+      - Thu, 16 Jun 2022 15:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cfa46b1-dbbb-40bf-8db7-9ca480e20431
+      - 2e847a5a-3907-4f61-9c04-e2287c49e2f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,12 +1208,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/4573b90f-59dc-4c6f-b82f-9dc886f7ed83
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6
     method: GET
   response:
-    body: '{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"}'
+    body: '{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "390"
@@ -1189,7 +1222,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3778916f-1e6f-4f3c-bf26-006d1a222a28
+      - d0bc9d1b-00a3-437b-8538-75b4e6c0ef23
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,12 +1241,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/44023d01-0489-45be-95c6-5438997d782d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/c8e6c9d4-48a7-4c90-840d-138aa251fb1f
     method: GET
   response:
-    body: '{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
+    body: '{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -1222,7 +1255,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffbd510f-0916-41f8-8f56-e23314dd0771
+      - 5d350e4c-07f0-4fcc-b39f-4c6b442d103b
     status: 200 OK
     code: 200
     duration: ""
@@ -1241,12 +1274,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/327ccf42-2783-46f7-a05f-f5f37f020550
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/6d5fcd42-4fd6-466c-abb6-b22b300b4aae
     method: GET
   response:
-    body: '{"id":"327ccf42-2783-46f7-a05f-f5f37f020550","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.554410Z","updated_at":"2022-05-20T13:08:18.554410Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.626003Z","updated_at":"2022-06-16T14:56:45.626003Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -1255,7 +1288,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1265,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b9504e2-d06a-4733-aaf2-2a3f0a57c243
+      - 84970309-ba88-471a-91f0-ead97d6bb543
     status: 200 OK
     code: 200
     duration: ""
@@ -1274,21 +1307,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1298,7 +1331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6531773-a8cf-4423-9387-508b8c3e3eba
+      - 30d05eac-824c-4a04-9005-7417114dc12e
     status: 200 OK
     code: 200
     duration: ""
@@ -1307,12 +1340,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -1321,7 +1354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1331,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f695a0c8-a7fd-42e9-bac9-8d46d933b856
+      - 4817025a-e527-40c4-a405-14a04db0bc52
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,12 +1373,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
     method: GET
   response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -1354,7 +1387,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1364,7 +1397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e3ba3d6-bf7c-4e49-a275-0a7c38843f14
+      - 923349f9-320c-4616-b4af-8f194f1b0e0e
     status: 200 OK
     code: 200
     duration: ""
@@ -1373,12 +1406,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68/certificate
     method: GET
   response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVTjh1aXBXU3gzRml0WGlpLys3UnhZZnNDN3BVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFOalEzWWpJeE9DMWhZV00xCkxUUXdZMll0T1dNNFppMHlPVGRsTW1WbVpXUXpZVFV1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE13T1RRNVdoY05Nekl3TlRFM01UTXdPVFE1V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFUyTkRkaU1qRTRMV0ZoWXpVdE5EQmpaaTA1WXpobUxUSTVOMlV5WldabFpETmgKTlM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMR3ZPZ1lVemVWN3lIcDJzN1hrNmZRZHhheEJuZnVBNk8vRnhCVzZ2T05oMTNCTFJZQ1FmODIwCmJxV2hueVZwdEVFSHd3V1BnZlo0dkxaMWdqWTdLZUcrbk9XRkxNbms3dHh5dlZ6Qzlibnc2V0pKbS9QVGRnQjMKYmdrRHBlMFRTbTdhMk9qUEJFTFpJZmFHaTFDSGE2eVd4S0QveVRVTldPb1c2MjRQUjZRaVVrYjNaMU5JZ2tiYQpBV2dzZUVXYi9ySzR1SHVLSzR1T1pVMG1LR2lJdmVaeWdEWURzWndEL3B5bjYrNE1uK1k5ZWptOTFIaUpuN1hOCnpIdVp5b3BMS3F1TytucDZKWmFxcGxBblhvSnBxTjRKSWRZYWo3Y2w4dUM0eXZ4WVZKbjI1eGtZdkVxdDhPN0MKOFRGck9adDFsSVAyWWcvWXRDeUUxTmQ3KytsZ0kvMENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOVFkwTjJJeU1UZ3RZV0ZqTlMwME1HTm1MVGxqT0dZdE1qazNaVEpsWm1Wa00yRTFMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMEUraHdUQXFBSCtod1F6bm9OT01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ2sKMXpMOVFDWHc4L29vUjdUUjZjZFE2MmUzN3hDOWdwbDhGSnR4K25xcnIwQ2pwSW9YZ0VtSWNQUHU3Q29xV0tCbQpYbkdqd2craURzakZBU1haMDRCb0tyTWIzeVVDVWZPU245b2E4eGhFbDJzRzVPS08vcmE2RDUweXlqS3lRdzdKCllGMTlaclpGZ0s2ZVRxWkY5Q1F3blJ0bWdxcDZKQXFxL1h4QjV0Sy81bFIyd3FKNlV3RWJwUkxuVTdyWmE2WmsKV28zY0p2WmJLWjNXc01rdlM0dENtakdwajlkcTZPSW9ET0s1OHVQQzk5d3g0bExFMXJ2TEtNZ05kVmJJZVBsKwpSMnNtM1diNUMrNXhVTUt4cVZJVGUrTng3Qk54dlQrM081NkRzYnM3SlJkeGZXN2hQSldKb3hDUElkd0FrOExqCjBTakk1RFZKWE5DU3N4VlBIWGI4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVYTNUSjFvbS9VYTYrZG9GMlJmVjFqcUJWQkJFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MWtNak00TmpBM05pMWpNelUyCkxUUmtNMkl0WWpnNE5DMDFNalE1TmpObU0yRmtOamd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVFExT0RNM1doY05Nekl3TmpFek1UUTFPRE0zV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMV1F5TXpnMk1EYzJMV016TlRZdE5HUXpZaTFpT0RnMExUVXlORGsyTTJZellXUTIKT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMSjRMMzdTcjZ3R2xJNkFLZGZQeC9QaGJQeGJrZUc0UHVCangwNjl1U2FrTFdGOVAybDNkMUEzCnVZRFVmaDBUL3B1QTZzVW9yaGxqcTFWaHZjOFc1YW9VTW9NNG0rdzAvN0VKUGpER29WWERzTElVWkYyak9yYjEKVlNETmhxVEwwS3YyKzVYRVBaV203VUMzMTgwNU9nT2xQQkM2N2hRNGgvTi9BSXlreERORks3bmVxL3lWekFreQovWmxCZFJySENCS1luVWt2Sjl4WE5YMUZ5ZlBsM3R1MlNLTmRzYmJRU0NYUEJ2MUEvTWh3K1Rld0JoT2IwSU5qCllJdE5hU0NwcGZJSnRFQWtuNDBObXVIUVg0ZEZIK2ZVMEtaT1c5YkhLWnpZNmJuUGlMNkZpMDV6NnNMRmFRWEYKc2hNNU9KUVNaWTVQejZXWXZFbktTUjcwbDZ2dmVOVUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApaREl6T0RZd056WXRZek0xTmkwMFpETmlMV0k0T0RRdE5USTBPVFl6WmpOaFpEWTRMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucWdoaHdUQXFBSCtod1F6bm9Jd01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQjkKWkZTdUxOK2JDQjA0Z3JwYWxqUjFONFVZeVU2WlJIaHNSTDlOa3hUTTJmcU1LRlVSRU5EUkNHNEJPUkNmc1I1SQpVUkFaQ2cxWjJHcTcrU2xId3RGcEEvSWdNNGpReHVydFRNR3FZenRQenNHczlWdEthcTY3c3JUM2xtcno0by95CnFZUjg1ek1EcThpSUtSWDQ5RXlFaVhpZHlnMm5kQTNSSXZIUzQ4QW04SjhSTDYzWkw4TlJwUWpwZ0h6WEsvZlcKWk1URVFPM2tnSnpqelR6UWJaanU1ODgwUGdwUEFobHJKa2pGNFRTWmlPdkJkdTR2bVR0ZHVaK2tBTE1FRUJGTgo0cnUwZVVnTHhFVHJiRG9KcGpTaFZ6YXd0VXNoL25MUk0yUEVQdXJwOFN1dUJESnhwVnJUVEgzbE15c0M0OTd6Cis1bXZONHNWdDZRVW1iT0dmMHN2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
     headers:
       Content-Length:
       - "1999"
@@ -1387,7 +1420,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1397,7 +1430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e39255b7-07a3-4fe6-b4c6-f4685907391b
+      - ddf90a95-18d6-47bc-8cc7-1c5c0e430bc2
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,21 +1439,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1430,7 +1463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fb89577-c860-4e0d-ac20-247a1629dcb0
+      - e1b0d498-da9d-4cd8-b9a5-f1083a8d33ff
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,12 +1472,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
     method: GET
   response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -1453,7 +1486,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1463,7 +1496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b1eb548-d971-4660-97a0-d0e379e42c10
+      - 0beb12e4-457e-4d3a-8ca2-742da3fcf8ad
     status: 200 OK
     code: 200
     duration: ""
@@ -1472,12 +1505,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/f70e74a5-0c71-4164-b875-a6cedc573413
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dee5b326-b9f6-4d15-9bd1-a8cb790a74ea
     method: GET
   response:
-    body: '{"id":"f70e74a5-0c71-4164-b875-a6cedc573413","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","created_at":"2022-05-20T13:11:51.212871Z","updated_at":"2022-05-20T13:11:51.212871Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    body: '{"id":"dee5b326-b9f6-4d15-9bd1-a8cb790a74ea","gateway_id":"d259a183-debe-406e-9bea-a64141681993","created_at":"2022-06-16T15:00:49.141299Z","updated_at":"2022-06-16T15:00:49.141299Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -1486,7 +1519,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:52 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1496,7 +1529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bf3fd03-824d-4fce-8ad4-06d5ac84285b
+      - 157880c9-8646-483d-8f03-ba3133aa0979
     status: 200 OK
     code: 200
     duration: ""
@@ -1505,12 +1538,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/4573b90f-59dc-4c6f-b82f-9dc886f7ed83
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6
     method: GET
   response:
-    body: '{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"}'
+    body: '{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "390"
@@ -1519,7 +1552,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:53 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1529,7 +1562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c29396b-8d82-4341-adae-253aff65fa0e
+      - b0d90b6d-9a27-4217-a1dc-d4c6424fe69d
     status: 200 OK
     code: 200
     duration: ""
@@ -1538,12 +1571,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/327ccf42-2783-46f7-a05f-f5f37f020550
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/6d5fcd42-4fd6-466c-abb6-b22b300b4aae
     method: GET
   response:
-    body: '{"id":"327ccf42-2783-46f7-a05f-f5f37f020550","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.554410Z","updated_at":"2022-05-20T13:08:18.554410Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.626003Z","updated_at":"2022-06-16T14:56:45.626003Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -1552,7 +1585,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:53 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,7 +1595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf74b160-0827-4a16-a344-45e53b41b29d
+      - 00a7e682-3c70-4334-ad0c-24d229db484a
     status: 200 OK
     code: 200
     duration: ""
@@ -1571,78 +1604,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/c8e6c9d4-48a7-4c90-840d-138aa251fb1f
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1864"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:11:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e0c78ad-a9c2-4d75-a4bb-b6fa59982e4d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/f70e74a5-0c71-4164-b875-a6cedc573413
-    method: GET
-  response:
-    body: '{"id":"f70e74a5-0c71-4164-b875-a6cedc573413","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","created_at":"2022-05-20T13:11:51.212871Z","updated_at":"2022-05-20T13:11:51.212871Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:11:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bb9a62c2-9527-4c80-83a4-659752f4388f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/44023d01-0489-45be-95c6-5438997d782d
-    method: GET
-  response:
-    body: '{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
+    body: '{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -1651,7 +1618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:53 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1661,7 +1628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb24db29-5733-4203-8699-f9cb1e2a2587
+      - e3122a4b-716d-4e35-97d4-5a6f7c073497
     status: 200 OK
     code: 200
     duration: ""
@@ -1670,21 +1637,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:53 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1694,7 +1661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab1ad394-fc52-4544-9f5c-4dc3ec4aad20
+      - f69b1a6a-9591-44e7-ac53-3af4c1994690
     status: 200 OK
     code: 200
     duration: ""
@@ -1703,144 +1670,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dee5b326-b9f6-4d15-9bd1-a8cb790a74ea
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
-    headers:
-      Content-Length:
-      - "1393"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:11:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 408c00da-47a8-466f-87e0-4fc0a348293f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
-    method: GET
-  response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1864"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:11:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ddf73098-b36d-4098-adf8-1751ad72d021
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5/certificate
-    method: GET
-  response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVTjh1aXBXU3gzRml0WGlpLys3UnhZZnNDN3BVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFOalEzWWpJeE9DMWhZV00xCkxUUXdZMll0T1dNNFppMHlPVGRsTW1WbVpXUXpZVFV1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE13T1RRNVdoY05Nekl3TlRFM01UTXdPVFE1V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFUyTkRkaU1qRTRMV0ZoWXpVdE5EQmpaaTA1WXpobUxUSTVOMlV5WldabFpETmgKTlM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMR3ZPZ1lVemVWN3lIcDJzN1hrNmZRZHhheEJuZnVBNk8vRnhCVzZ2T05oMTNCTFJZQ1FmODIwCmJxV2hueVZwdEVFSHd3V1BnZlo0dkxaMWdqWTdLZUcrbk9XRkxNbms3dHh5dlZ6Qzlibnc2V0pKbS9QVGRnQjMKYmdrRHBlMFRTbTdhMk9qUEJFTFpJZmFHaTFDSGE2eVd4S0QveVRVTldPb1c2MjRQUjZRaVVrYjNaMU5JZ2tiYQpBV2dzZUVXYi9ySzR1SHVLSzR1T1pVMG1LR2lJdmVaeWdEWURzWndEL3B5bjYrNE1uK1k5ZWptOTFIaUpuN1hOCnpIdVp5b3BMS3F1TytucDZKWmFxcGxBblhvSnBxTjRKSWRZYWo3Y2w4dUM0eXZ4WVZKbjI1eGtZdkVxdDhPN0MKOFRGck9adDFsSVAyWWcvWXRDeUUxTmQ3KytsZ0kvMENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOVFkwTjJJeU1UZ3RZV0ZqTlMwME1HTm1MVGxqT0dZdE1qazNaVEpsWm1Wa00yRTFMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMEUraHdUQXFBSCtod1F6bm9OT01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ2sKMXpMOVFDWHc4L29vUjdUUjZjZFE2MmUzN3hDOWdwbDhGSnR4K25xcnIwQ2pwSW9YZ0VtSWNQUHU3Q29xV0tCbQpYbkdqd2craURzakZBU1haMDRCb0tyTWIzeVVDVWZPU245b2E4eGhFbDJzRzVPS08vcmE2RDUweXlqS3lRdzdKCllGMTlaclpGZ0s2ZVRxWkY5Q1F3blJ0bWdxcDZKQXFxL1h4QjV0Sy81bFIyd3FKNlV3RWJwUkxuVTdyWmE2WmsKV28zY0p2WmJLWjNXc01rdlM0dENtakdwajlkcTZPSW9ET0s1OHVQQzk5d3g0bExFMXJ2TEtNZ05kVmJJZVBsKwpSMnNtM1diNUMrNXhVTUt4cVZJVGUrTng3Qk54dlQrM081NkRzYnM3SlJkeGZXN2hQSldKb3hDUElkd0FrOExqCjBTakk1RFZKWE5DU3N4VlBIWGI4Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
-    headers:
-      Content-Length:
-      - "1999"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:11:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1cba1ab-1779-4aee-873f-8436320caf53
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
-    method: GET
-  response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:11:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d909c2cd-9be0-4fac-833c-2596e95e7415
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/f70e74a5-0c71-4164-b875-a6cedc573413
-    method: GET
-  response:
-    body: '{"id":"f70e74a5-0c71-4164-b875-a6cedc573413","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","created_at":"2022-05-20T13:11:51.212871Z","updated_at":"2022-05-20T13:11:51.212871Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    body: '{"id":"dee5b326-b9f6-4d15-9bd1-a8cb790a74ea","gateway_id":"d259a183-debe-406e-9bea-a64141681993","created_at":"2022-06-16T15:00:49.141299Z","updated_at":"2022-06-16T15:00:49.141299Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -1849,7 +1684,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:53 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1859,7 +1694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 241faa7c-dfa0-4726-aff5-ee61ecd2cc2c
+      - 12e4e14a-ae68-431e-acb6-f254d716e729
     status: 200 OK
     code: 200
     duration: ""
@@ -1868,21 +1703,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "947"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:53 GMT
+      - Thu, 16 Jun 2022 15:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1892,7 +1727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 707ac928-51ca-407d-9dc3-06dbf0f4dd66
+      - 24e3d2f5-d8ae-4829-8328-196b420f6d1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1901,9 +1736,207 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/f70e74a5-0c71-4164-b875-a6cedc573413
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1393"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b990011-e374-4c20-9ee3-3354aa31beb9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
+    method: GET
+  response:
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8c2a272-c874-485d-a24a-10edb1586a01
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68/certificate
+    method: GET
+  response:
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVYTNUSjFvbS9VYTYrZG9GMlJmVjFqcUJWQkJFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MWtNak00TmpBM05pMWpNelUyCkxUUmtNMkl0WWpnNE5DMDFNalE1TmpObU0yRmtOamd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVFExT0RNM1doY05Nekl3TmpFek1UUTFPRE0zV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMV1F5TXpnMk1EYzJMV016TlRZdE5HUXpZaTFpT0RnMExUVXlORGsyTTJZellXUTIKT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMSjRMMzdTcjZ3R2xJNkFLZGZQeC9QaGJQeGJrZUc0UHVCangwNjl1U2FrTFdGOVAybDNkMUEzCnVZRFVmaDBUL3B1QTZzVW9yaGxqcTFWaHZjOFc1YW9VTW9NNG0rdzAvN0VKUGpER29WWERzTElVWkYyak9yYjEKVlNETmhxVEwwS3YyKzVYRVBaV203VUMzMTgwNU9nT2xQQkM2N2hRNGgvTi9BSXlreERORks3bmVxL3lWekFreQovWmxCZFJySENCS1luVWt2Sjl4WE5YMUZ5ZlBsM3R1MlNLTmRzYmJRU0NYUEJ2MUEvTWh3K1Rld0JoT2IwSU5qCllJdE5hU0NwcGZJSnRFQWtuNDBObXVIUVg0ZEZIK2ZVMEtaT1c5YkhLWnpZNmJuUGlMNkZpMDV6NnNMRmFRWEYKc2hNNU9KUVNaWTVQejZXWXZFbktTUjcwbDZ2dmVOVUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApaREl6T0RZd056WXRZek0xTmkwMFpETmlMV0k0T0RRdE5USTBPVFl6WmpOaFpEWTRMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucWdoaHdUQXFBSCtod1F6bm9Jd01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQjkKWkZTdUxOK2JDQjA0Z3JwYWxqUjFONFVZeVU2WlJIaHNSTDlOa3hUTTJmcU1LRlVSRU5EUkNHNEJPUkNmc1I1SQpVUkFaQ2cxWjJHcTcrU2xId3RGcEEvSWdNNGpReHVydFRNR3FZenRQenNHczlWdEthcTY3c3JUM2xtcno0by95CnFZUjg1ek1EcThpSUtSWDQ5RXlFaVhpZHlnMm5kQTNSSXZIUzQ4QW04SjhSTDYzWkw4TlJwUWpwZ0h6WEsvZlcKWk1URVFPM2tnSnpqelR6UWJaanU1ODgwUGdwUEFobHJKa2pGNFRTWmlPdkJkdTR2bVR0ZHVaK2tBTE1FRUJGTgo0cnUwZVVnTHhFVHJiRG9KcGpTaFZ6YXd0VXNoL25MUk0yUEVQdXJwOFN1dUJESnhwVnJUVEgzbE15c0M0OTd6Cis1bXZONHNWdDZRVW1iT0dmMHN2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    headers:
+      Content-Length:
+      - "1999"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 78a52088-4e83-44a6-8521-f6ce44ee006d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
+    method: GET
+  response:
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e2f3e9d7-d8f9-4cce-991f-d5d990d93a14
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dee5b326-b9f6-4d15-9bd1-a8cb790a74ea
+    method: GET
+  response:
+    body: '{"id":"dee5b326-b9f6-4d15-9bd1-a8cb790a74ea","gateway_id":"d259a183-debe-406e-9bea-a64141681993","created_at":"2022-06-16T15:00:49.141299Z","updated_at":"2022-06-16T15:00:49.141299Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "283"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6bfa863f-1c2a-4679-a85c-293c2b1da1f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
+    method: GET
+  response:
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fa653f1-0a06-4b9e-8cbd-d79cc5b5c335
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/dee5b326-b9f6-4d15-9bd1-a8cb790a74ea
     method: DELETE
   response:
     body: ""
@@ -1913,7 +1946,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:53 GMT
+      - Thu, 16 Jun 2022 15:00:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1923,7 +1956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 809fd476-8f3c-4ada-9a4d-7231d9058a71
+      - 9a10e0a6-1473-4c39-9f15-a39aac815119
     status: 204 No Content
     code: 204
     duration: ""
@@ -1932,21 +1965,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:54 GMT
+      - Thu, 16 Jun 2022 15:00:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1956,7 +1989,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2750958-cf73-4819-96c8-f93ffcfc4bce
+      - b0daaaa6-d83a-402d-a09e-b2e14e8e9b88
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,12 +1998,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
     method: GET
   response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:08:31.243178Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"ready","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T14:56:58.297255Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"ready","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -1979,7 +2012,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:54 GMT
+      - Thu, 16 Jun 2022 15:00:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1989,7 +2022,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26ba6e3e-ea18-4d70-baf0-65a91278e47b
+      - 1c2e7743-25a9-4dc9-978f-70cf7e0e6add
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,12 +2031,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -2012,7 +2045,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:54 GMT
+      - Thu, 16 Jun 2022 15:00:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2022,7 +2055,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cadfc55-a6d6-48ad-a7e0-cd06be94796b
+      - 8350a7fd-5d25-42fb-886c-b5c874586fbd
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,9 +2064,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2043,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:54 GMT
+      - Thu, 16 Jun 2022 15:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,21 +2086,56 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ccf032c-97eb-4977-b723-f895e99e45d6
+      - 7a256f98-35bf-4c87-9822-6c9c6bde2dc7
     status: 204 No Content
     code: 204
+    duration: ""
+- request:
+    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":null,"name":null,"tags":null,"logs_policy":null,"backup_same_region":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: PATCH
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1393"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 694a9293-e2b9-4cb3-8c05-2cbfc7dee42a
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
     method: GET
   response:
-    body: '{"id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","created_at":"2022-05-20T13:08:24.929860Z","updated_at":"2022-05-20T13:11:54.306388Z","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","mac_address":"02:00:00:00:a4:09","enable_masquerade":true,"status":"detaching","dhcp":{"id":"44023d01-0489-45be-95c6-5438997d782d","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.575681Z","updated_at":"2022-05-20T13:08:18.575681Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","created_at":"2022-06-16T14:56:51.992997Z","updated_at":"2022-06-16T15:00:52.093476Z","gateway_id":"d259a183-debe-406e-9bea-a64141681993","private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","mac_address":"02:00:00:00:af:0c","enable_masquerade":true,"status":"detaching","dhcp":{"id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.659077Z","updated_at":"2022-06-16T14:56:45.659077Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "951"
@@ -2076,7 +2144,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:54 GMT
+      - Thu, 16 Jun 2022 15:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2154,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be20ddcc-f696-41fb-8591-e65e87e148ab
+      - 8a4b487a-3057-40bc-9285-139b9a6d3aa1
     status: 200 OK
     code: 200
     duration: ""
@@ -2095,21 +2163,52 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1393"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:00:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f4acd54e-849d-4839-a530-b8a9c9b6efdb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/608dc143-6be2-43cf-8cf6-d79a159df0e8
     method: DELETE
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"deleting","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: ""
     headers:
-      Content-Length:
-      - "1396"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:54 GMT
+      - Thu, 16 Jun 2022 15:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,30 +2218,30 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a49b10f1-85f5-4478-8b22-0f657a230f54
-    status: 200 OK
-    code: 200
+      - d7c1dff3-70ab-4fd7-8298-fde900b7ca67
+    status: 204 No Content
+    code: 204
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"deleting","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.131.78","port":65511,"name":null,"id":"f7befe82-c1c1-4fa9-b6a2-2ca270df4e60","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"add22d43-da51-43c0-abd5-3b51751c0a41","private_network":{"private_network_id":"327ccf42-2783-46f7-a05f-f5f37f020550","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:08:19.223819Z","region":"nl-ams"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"configuring","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},{"ip":"192.168.1.254","port":5432,"name":null,"id":"608dc143-6be2-43cf-8cf6-d79a159df0e8","private_network":{"private_network_id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
-      - "1396"
+      - "1399"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:54 GMT
+      - Thu, 16 Jun 2022 15:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d60a939f-bffa-472e-8478-893951acb72a
+      - 67bc19f6-b025-4afd-ae74-76dfc55d20e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2161,12 +2260,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/d64d9b02-dddf-496b-9e62-4160cc7d94fa
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/ec17c586-8bc6-4e56-a6ec-d7ed1eff057e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"d64d9b02-dddf-496b-9e62-4160cc7d94fa","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"ec17c586-8bc6-4e56-a6ec-d7ed1eff057e","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2175,7 +2274,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:59 GMT
+      - Thu, 16 Jun 2022 15:00:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdbd995a-8873-457a-917d-733c65855c7b
+      - 5829c8c3-6b5a-4957-9dba-de5be57a4ac1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2194,21 +2293,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:59 GMT
+      - Thu, 16 Jun 2022 15:00:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79cb1c22-fc59-427e-bc75-7c5269ef3134
+      - 0d287875-a993-40e5-b9cc-38264f02d9ac
     status: 200 OK
     code: 200
     duration: ""
@@ -2227,12 +2326,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/44023d01-0489-45be-95c6-5438997d782d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/c8e6c9d4-48a7-4c90-840d-138aa251fb1f
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"44023d01-0489-45be-95c6-5438997d782d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"c8e6c9d4-48a7-4c90-840d-138aa251fb1f","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2241,7 +2340,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:59 GMT
+      - Thu, 16 Jun 2022 15:00:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ce94b18-71db-4c9d-ae67-62996adac9bf
+      - f359734d-d8ab-4bfb-b72f-f66573ad2751
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2260,21 +2359,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.404235Z","updated_at":"2022-05-20T13:08:31.382107Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"4573b90f-59dc-4c6f-b82f-9dc886f7ed83","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:19.140914Z","updated_at":"2022-05-20T13:08:19.140914Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"d259a183-debe-406e-9bea-a64141681993","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.463141Z","updated_at":"2022-06-16T14:56:58.409948Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:46.211713Z","updated_at":"2022-06-16T14:56:46.211713Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"d259a183-debe-406e-9bea-a64141681993","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:59 GMT
+      - Thu, 16 Jun 2022 15:00:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ae9f421-8879-4bc4-bbd4-0cb984db6ab6
+      - 30929356-ac85-44b8-b6b4-922a55e18b43
     status: 200 OK
     code: 200
     duration: ""
@@ -2293,9 +2392,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -2305,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:59 GMT
+      - Thu, 16 Jun 2022 15:00:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2315,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a7b8481-3163-45bd-98d7-2a9748f8091b
+      - a8fc36e1-9131-4a7c-ad9f-6221298633a8
     status: 204 No Content
     code: 204
     duration: ""
@@ -2324,12 +2423,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/21504efb-0e84-4c52-8384-2a2d1fee9e09
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d259a183-debe-406e-9bea-a64141681993
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"21504efb-0e84-4c52-8384-2a2d1fee9e09","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"d259a183-debe-406e-9bea-a64141681993","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2338,7 +2437,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:59 GMT
+      - Thu, 16 Jun 2022 15:00:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2348,7 +2447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6bf75f7-4b9f-45e0-9f92-e991c8c9daeb
+      - f8fbf7da-a639-4660-8cee-a14fcda3189a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2357,9 +2456,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/4573b90f-59dc-4c6f-b82f-9dc886f7ed83
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/1f68f92d-1f23-4c7f-8e9e-f81f8d5c72e6
     method: DELETE
   response:
     body: ""
@@ -2369,7 +2468,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:12:00 GMT
+      - Thu, 16 Jun 2022 15:00:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2379,7 +2478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0c28be0-4e80-486b-9a0d-9d236b3741ed
+      - a1208445-93ea-4881-9c73-9aff048e2fee
     status: 204 No Content
     code: 204
     duration: ""
@@ -2388,21 +2487,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5647b218-aac5-40cf-9c8f-297e2efed3a5
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5647b218-aac5-40cf-9c8f-297e2efed3a5","type":"not_found"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
-      - "129"
+      - "1172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:12:24 GMT
+      - Thu, 16 Jun 2022 15:01:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2412,40 +2511,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58d5e81d-3487-4cee-89ed-d4a734ec5ca8
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/327ccf42-2783-46f7-a05f-f5f37f020550
-    method: GET
-  response:
-    body: '{"id":"327ccf42-2783-46f7-a05f-f5f37f020550","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:08:18.554410Z","updated_at":"2022-05-20T13:08:18.554410Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "309"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:12:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8418b8ed-c7fc-4cbf-b938-b3fc1461559f
+      - b44a03c4-ce4c-4fae-b4af-e809e02b277c
     status: 200 OK
     code: 200
     duration: ""
@@ -2454,22 +2520,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/327ccf42-2783-46f7-a05f-f5f37f020550
-    method: DELETE
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
   response:
-    body: '{"help_message":"Private Network must be empty to be deleted","message":"precondition
-      is not respected","precondition":"resource_still_in_use","type":"precondition_failed"}'
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
     headers:
       Content-Length:
-      - "172"
+      - "1172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:12:25 GMT
+      - Thu, 16 Jun 2022 15:01:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2479,7 +2544,335 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f262812c-7933-48d9-8da0-4a706c4ed027
-    status: 412 Precondition Failed
-    code: 412
+      - 76806fc4-6eee-45b7-b91d-0ee9c237852f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68/certificate
+    method: GET
+  response:
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVYTNUSjFvbS9VYTYrZG9GMlJmVjFqcUJWQkJFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MWtNak00TmpBM05pMWpNelUyCkxUUmtNMkl0WWpnNE5DMDFNalE1TmpObU0yRmtOamd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVFExT0RNM1doY05Nekl3TmpFek1UUTFPRE0zV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMV1F5TXpnMk1EYzJMV016TlRZdE5HUXpZaTFpT0RnMExUVXlORGsyTTJZellXUTIKT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMSjRMMzdTcjZ3R2xJNkFLZGZQeC9QaGJQeGJrZUc0UHVCangwNjl1U2FrTFdGOVAybDNkMUEzCnVZRFVmaDBUL3B1QTZzVW9yaGxqcTFWaHZjOFc1YW9VTW9NNG0rdzAvN0VKUGpER29WWERzTElVWkYyak9yYjEKVlNETmhxVEwwS3YyKzVYRVBaV203VUMzMTgwNU9nT2xQQkM2N2hRNGgvTi9BSXlreERORks3bmVxL3lWekFreQovWmxCZFJySENCS1luVWt2Sjl4WE5YMUZ5ZlBsM3R1MlNLTmRzYmJRU0NYUEJ2MUEvTWh3K1Rld0JoT2IwSU5qCllJdE5hU0NwcGZJSnRFQWtuNDBObXVIUVg0ZEZIK2ZVMEtaT1c5YkhLWnpZNmJuUGlMNkZpMDV6NnNMRmFRWEYKc2hNNU9KUVNaWTVQejZXWXZFbktTUjcwbDZ2dmVOVUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApaREl6T0RZd056WXRZek0xTmkwMFpETmlMV0k0T0RRdE5USTBPVFl6WmpOaFpEWTRMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucWdoaHdUQXFBSCtod1F6bm9Jd01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQjkKWkZTdUxOK2JDQjA0Z3JwYWxqUjFONFVZeVU2WlJIaHNSTDlOa3hUTTJmcU1LRlVSRU5EUkNHNEJPUkNmc1I1SQpVUkFaQ2cxWjJHcTcrU2xId3RGcEEvSWdNNGpReHVydFRNR3FZenRQenNHczlWdEthcTY3c3JUM2xtcno0by95CnFZUjg1ek1EcThpSUtSWDQ5RXlFaVhpZHlnMm5kQTNSSXZIUzQ4QW04SjhSTDYzWkw4TlJwUWpwZ0h6WEsvZlcKWk1URVFPM2tnSnpqelR6UWJaanU1ODgwUGdwUEFobHJKa2pGNFRTWmlPdkJkdTR2bVR0ZHVaK2tBTE1FRUJGTgo0cnUwZVVnTHhFVHJiRG9KcGpTaFZ6YXd0VXNoL25MUk0yUEVQdXJwOFN1dUJESnhwVnJUVEgzbE15c0M0OTd6Cis1bXZONHNWdDZRVW1iT0dmMHN2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    headers:
+      Content-Length:
+      - "1999"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a54f214-8669-4683-aadb-3c2fb54ef07e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/6d5fcd42-4fd6-466c-abb6-b22b300b4aae
+    method: GET
+  response:
+    body: '{"id":"6d5fcd42-4fd6-466c-abb6-b22b300b4aae","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T14:56:45.626003Z","updated_at":"2022-06-16T14:56:45.626003Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "309"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08ebe593-46cf-4cc7-8590-b762d194822d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1172"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fdcd883f-8ce7-4116-ac45-5dc6be518061
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68/certificate
+    method: GET
+  response:
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVYTNUSjFvbS9VYTYrZG9GMlJmVjFqcUJWQkJFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MWtNak00TmpBM05pMWpNelUyCkxUUmtNMkl0WWpnNE5DMDFNalE1TmpObU0yRmtOamd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVFExT0RNM1doY05Nekl3TmpFek1UUTFPRE0zV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMV1F5TXpnMk1EYzJMV016TlRZdE5HUXpZaTFpT0RnMExUVXlORGsyTTJZellXUTIKT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMSjRMMzdTcjZ3R2xJNkFLZGZQeC9QaGJQeGJrZUc0UHVCangwNjl1U2FrTFdGOVAybDNkMUEzCnVZRFVmaDBUL3B1QTZzVW9yaGxqcTFWaHZjOFc1YW9VTW9NNG0rdzAvN0VKUGpER29WWERzTElVWkYyak9yYjEKVlNETmhxVEwwS3YyKzVYRVBaV203VUMzMTgwNU9nT2xQQkM2N2hRNGgvTi9BSXlreERORks3bmVxL3lWekFreQovWmxCZFJySENCS1luVWt2Sjl4WE5YMUZ5ZlBsM3R1MlNLTmRzYmJRU0NYUEJ2MUEvTWh3K1Rld0JoT2IwSU5qCllJdE5hU0NwcGZJSnRFQWtuNDBObXVIUVg0ZEZIK2ZVMEtaT1c5YkhLWnpZNmJuUGlMNkZpMDV6NnNMRmFRWEYKc2hNNU9KUVNaWTVQejZXWXZFbktTUjcwbDZ2dmVOVUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApaREl6T0RZd056WXRZek0xTmkwMFpETmlMV0k0T0RRdE5USTBPVFl6WmpOaFpEWTRMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucWdoaHdUQXFBSCtod1F6bm9Jd01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQjkKWkZTdUxOK2JDQjA0Z3JwYWxqUjFONFVZeVU2WlJIaHNSTDlOa3hUTTJmcU1LRlVSRU5EUkNHNEJPUkNmc1I1SQpVUkFaQ2cxWjJHcTcrU2xId3RGcEEvSWdNNGpReHVydFRNR3FZenRQenNHczlWdEthcTY3c3JUM2xtcno0by95CnFZUjg1ek1EcThpSUtSWDQ5RXlFaVhpZHlnMm5kQTNSSXZIUzQ4QW04SjhSTDYzWkw4TlJwUWpwZ0h6WEsvZlcKWk1URVFPM2tnSnpqelR6UWJaanU1ODgwUGdwUEFobHJKa2pGNFRTWmlPdkJkdTR2bVR0ZHVaK2tBTE1FRUJGTgo0cnUwZVVnTHhFVHJiRG9KcGpTaFZ6YXd0VXNoL25MUk0yUEVQdXJwOFN1dUJESnhwVnJUVEgzbE15c0M0OTd6Cis1bXZONHNWdDZRVW1iT0dmMHN2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    headers:
+      Content-Length:
+      - "1999"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cf8ebb90-a297-4c93-b288-6254d2349ea6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1172"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e86b9b38-bf6c-47bc-8bb2-65e5a80ec175
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: DELETE
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1175"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a904ed2-42f9-4d24-87da-b2d9c11abd7f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/6d5fcd42-4fd6-466c-abb6-b22b300b4aae
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1aefa524-ee86-4fde-aba9-a2488c4b4f6c
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"id":"d2386076-c356-4d3b-b884-524963f3ad68","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.130.48","port":14284,"name":null,"id":"822e19a5-637f-4bc1-ba4e-fa9844f810a0","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T14:56:46.049167Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1175"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df98d61c-fcee-4bfc-b709-ef55640444f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"d2386076-c356-4d3b-b884-524963f3ad68","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9380856d-c3ac-48f0-a734-5308b6b93628
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/d2386076-c356-4d3b-b884-524963f3ad68
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"d2386076-c356-4d3b-b884-524963f3ad68","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 15:01:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f186cf00-25e5-4bc6-bbdd-42524f16bf19
+    status: 404 Not Found
+    code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"my_private_network","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","tags":null,"subnets":null}'
+    body: '{"name":"my_private_network","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks
     method: POST
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:10:03.701090Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:36:22.435434Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:03 GMT
+      - Thu, 16 Jun 2022 13:36:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4e1d4d3-f985-417d-bdcd-de1af7acdbff
+      - 752c44ac-015d-4cdf-9ea9-fbff5379eaee
     status: 200 OK
     code: 200
     duration: ""
@@ -41,12 +41,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:10:03.701090Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:36:22.435434Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:03 GMT
+      - Thu, 16 Jun 2022 13:36:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c64df09-a277-48bb-9bd2-269b940b0209
+      - ac64e63c-6e91-407f-853e-26a2726c1597
     status: 200 OK
     code: 200
     duration: ""
@@ -74,12 +74,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:10:03.701090Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:36:22.435434Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -88,7 +88,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:04 GMT
+      - Thu, 16 Jun 2022 13:36:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91b91b67-ca91-418e-b381-bd7a44f77c3e
+      - db4fd657-e5e9-4dfa-9965-6082c0860a80
     status: 200 OK
     code: 200
     duration: ""
@@ -107,12 +107,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:10:03.701090Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:36:22.435434Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:04 GMT
+      - Thu, 16 Jun 2022 13:36:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,23 +131,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9f3c9e3-2098-4b22-9328-cb443382dcb4
+      - 8128796a-8dcd-417b-b7e9-4ac7decf68f3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","name":"test-rdb","engine":"PostgreSQL-11","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","name":"test-rdb","engine":"PostgreSQL-11","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "917"
@@ -156,7 +156,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:05 GMT
+      - Thu, 16 Jun 2022 13:36:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37a7f5da-2a13-4fea-98fe-eb1e7885a0e7
+      - d0fbd60d-9831-4e14-b9cb-c704010161d7
     status: 200 OK
     code: 200
     duration: ""
@@ -175,12 +175,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "917"
@@ -189,7 +189,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:05 GMT
+      - Thu, 16 Jun 2022 13:36:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -199,7 +199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f81d81c-1151-4e7d-b650-9eedb7de3020
+      - 8a85c04e-50ab-47ad-9a0b-0fb04b32b361
     status: 200 OK
     code: 200
     duration: ""
@@ -208,12 +208,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "917"
@@ -222,7 +222,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:10:36 GMT
+      - Thu, 16 Jun 2022 13:36:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -232,7 +232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b681a13-e76d-4e08-be4a-c4b2d7be3ab1
+      - b332d640-9f96-4cf3-9b15-6e75e4230220
     status: 200 OK
     code: 200
     duration: ""
@@ -241,12 +241,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"provisioning","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "917"
@@ -255,7 +255,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:06 GMT
+      - Thu, 16 Jun 2022 13:37:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -265,7 +265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a96ce84-63ce-47e4-bca7-4cc388f856ee
+      - 2b467cda-7e73-4a29-be26-3b331d285b3d
     status: 200 OK
     code: 200
     duration: ""
@@ -274,12 +274,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "917"
@@ -288,7 +288,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:11:36 GMT
+      - Thu, 16 Jun 2022 13:37:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 862ab7c4-9b85-4d45-90de-b31cc791da3e
+      - 0f24b58c-bff9-4d34-b6be-35132ae1bb85
     status: 200 OK
     code: 200
     duration: ""
@@ -307,12 +307,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "917"
@@ -321,7 +321,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:12:06 GMT
+      - Thu, 16 Jun 2022 13:38:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -331,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf553842-4cee-4dd6-984d-c416b7057c3f
+      - 4993c9b6-5404-49f8-acb7-5254780f8298
     status: 200 OK
     code: 200
     duration: ""
@@ -340,12 +340,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "917"
@@ -354,7 +354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:12:36 GMT
+      - Thu, 16 Jun 2022 13:38:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04d96b69-6086-4898-924d-19d26138530b
+      - 22a85587-17e9-4e66-a87f-c90d2d30e56d
     status: 200 OK
     code: 200
     duration: ""
@@ -373,12 +373,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "917"
@@ -387,7 +387,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:06 GMT
+      - Thu, 16 Jun 2022 13:39:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,7 +397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2b93396-f312-439a-a4cd-c8ec8f9a73a7
+      - f0b657f3-8364-421a-8846-c57f46123e73
     status: 200 OK
     code: 200
     duration: ""
@@ -406,12 +406,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":null,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "917"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:40:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3b97e3df-3d55-418d-abff-9886b18ced55
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
+  response:
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1391"
@@ -420,7 +453,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:36 GMT
+      - Thu, 16 Jun 2022 13:40:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80285585-6e27-4534-9044-e1181f40b128
+      - 793194c8-5430-4f07-aa13-ad47cd8eb415
     status: 200 OK
     code: 200
     duration: ""
@@ -439,12 +472,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
     method: GET
   response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVVDQwclhFdW0rSlN6NkNwSWdnbXlCQlpWOWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDROelpoWW1abE15MHpNekkwCkxUUTVOMll0T1dRMk5pMDBObVkzTm1WbVpqQmxPVGN1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE14TVRNeldoY05Nekl3TlRFM01UTXhNVE16V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVGczTm1GaVptVXpMVE16TWpRdE5EazNaaTA1WkRZMkxUUTJaamMyWldabU1HVTUKTnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMUXJwS2FEQ2ZJOVNXOExCR1VNT2FKQitwb1Irck1uQ1hRWmJWcDBlWHQ5NUpKMzdsY0g3cWJHCk9ncUFCd3FIdTEvZnNiWHc1SWVMZ0VtY0Fid3dGVkU0OUZXSk9JVkcrRU9YUmRoK2NsTmtoTitCU1I1L0NBRFUKQ2JrNnZvN0ZqL3ZuclFrZjg5bVdxZDBrN0xhUTBadzExYjRzVEwwcWE5SFhtQUpsczYyMzlEYXhybzJsc2s0WQpxSHprbDNZZXJiVmFnWjZCT3psUkI0R2lnaEd1SUxjajRIc1pxNlp4SUh3YWFpYmQwWThaOFJhYVZWU0ZLNytFCkhZNXY3V04vZHhqVXArOFF2MUo2YzRRRXRFSlU5bmN1czEydmRUeG5NNG8vVU14K2xqUUtuaVA5bzhuYXVwVkoKNlAwQmdXaEVyc0hKVUNLUnQ3bWZTMzJwNWFlMmR1VUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApPRGMyWVdKbVpUTXRNek15TkMwME9UZG1MVGxrTmpZdE5EWm1OelpsWm1Zd1pUazNMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucm5raHdUQXFBRXFod1F6bm9FeE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0EKNzNzM1F0YmpMczZOaktON2JBMVpZMUpNWjJ6TkN0WlRlUnBEUnVQQ2JBYlE0NGpGVnp3dENTd3VTWmFUcGxmaQpCQzNMeTVneTZGVHFKMXF1STlPWURhTUE3SkVaSVlZWmpsRzJicm9YQWQ0eWhJTU5VMFhSZ3kzL0FHa0NyZ0w5CjY1ajE3L1NpVjZ4ZTJha0hZQ0FkNk1scXRyZVkzZ2ZuZkx5UTVuKzdMV2xzblJnaytLL28zZDRhelVzZkdqTGwKMENTclNHN1NRRzVQQzdQTDRlWEE2bGlVVlhzQlBuTElRWkxDUUhIVUpwZVl1eTVkRHpYUllrNUdqSUpNMHRzQwpMZEpteXRicnVLa1gvSjNKc01mdG9qOUJQOHZWcHRneEM0aWpQT3Z5YVdlTzJFaHpOKzNGT0dyTzhTNUI4TWRZCmNBMzY1dXhzMjlPN3FsRFdqbm1MCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
     headers:
       Content-Length:
       - "1999"
@@ -453,7 +486,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:37 GMT
+      - Thu, 16 Jun 2022 13:40:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee1f2707-02f6-4ccd-af84-6a1e2f3901da
+      - 84ebc1ed-eb6e-44f3-8bdf-e1edd06505ad
     status: 200 OK
     code: 200
     duration: ""
@@ -472,12 +505,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1391"
@@ -486,7 +519,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:37 GMT
+      - Thu, 16 Jun 2022 13:40:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91e679fd-e8b8-49d5-a2f1-5c9d47be0e30
+      - aaaabcf6-2327-428d-80be-80ef75508927
     status: 200 OK
     code: 200
     duration: ""
@@ -505,12 +538,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:10:03.701090Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:36:22.435434Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -519,7 +552,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:37 GMT
+      - Thu, 16 Jun 2022 13:40:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85bdb4f3-98ce-4643-9384-be9f9327d7bf
+      - 306706b8-496c-46f3-8e3c-56cc72667be0
     status: 200 OK
     code: 200
     duration: ""
@@ -538,12 +571,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1391"
@@ -552,7 +585,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:37 GMT
+      - Thu, 16 Jun 2022 13:40:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -562,7 +595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2815ac0b-d8a3-4e28-a912-9969f733979e
+      - 2d695389-feaa-4f2a-8b3e-064758b41bd9
     status: 200 OK
     code: 200
     duration: ""
@@ -571,12 +604,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
     method: GET
   response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVVDQwclhFdW0rSlN6NkNwSWdnbXlCQlpWOWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDROelpoWW1abE15MHpNekkwCkxUUTVOMll0T1dRMk5pMDBObVkzTm1WbVpqQmxPVGN1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE14TVRNeldoY05Nekl3TlRFM01UTXhNVE16V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVGczTm1GaVptVXpMVE16TWpRdE5EazNaaTA1WkRZMkxUUTJaamMyWldabU1HVTUKTnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMUXJwS2FEQ2ZJOVNXOExCR1VNT2FKQitwb1Irck1uQ1hRWmJWcDBlWHQ5NUpKMzdsY0g3cWJHCk9ncUFCd3FIdTEvZnNiWHc1SWVMZ0VtY0Fid3dGVkU0OUZXSk9JVkcrRU9YUmRoK2NsTmtoTitCU1I1L0NBRFUKQ2JrNnZvN0ZqL3ZuclFrZjg5bVdxZDBrN0xhUTBadzExYjRzVEwwcWE5SFhtQUpsczYyMzlEYXhybzJsc2s0WQpxSHprbDNZZXJiVmFnWjZCT3psUkI0R2lnaEd1SUxjajRIc1pxNlp4SUh3YWFpYmQwWThaOFJhYVZWU0ZLNytFCkhZNXY3V04vZHhqVXArOFF2MUo2YzRRRXRFSlU5bmN1czEydmRUeG5NNG8vVU14K2xqUUtuaVA5bzhuYXVwVkoKNlAwQmdXaEVyc0hKVUNLUnQ3bWZTMzJwNWFlMmR1VUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApPRGMyWVdKbVpUTXRNek15TkMwME9UZG1MVGxrTmpZdE5EWm1OelpsWm1Zd1pUazNMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucm5raHdUQXFBRXFod1F6bm9FeE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0EKNzNzM1F0YmpMczZOaktON2JBMVpZMUpNWjJ6TkN0WlRlUnBEUnVQQ2JBYlE0NGpGVnp3dENTd3VTWmFUcGxmaQpCQzNMeTVneTZGVHFKMXF1STlPWURhTUE3SkVaSVlZWmpsRzJicm9YQWQ0eWhJTU5VMFhSZ3kzL0FHa0NyZ0w5CjY1ajE3L1NpVjZ4ZTJha0hZQ0FkNk1scXRyZVkzZ2ZuZkx5UTVuKzdMV2xzblJnaytLL28zZDRhelVzZkdqTGwKMENTclNHN1NRRzVQQzdQTDRlWEE2bGlVVlhzQlBuTElRWkxDUUhIVUpwZVl1eTVkRHpYUllrNUdqSUpNMHRzQwpMZEpteXRicnVLa1gvSjNKc01mdG9qOUJQOHZWcHRneEM0aWpQT3Z5YVdlTzJFaHpOKzNGT0dyTzhTNUI4TWRZCmNBMzY1dXhzMjlPN3FsRFdqbm1MCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
     headers:
       Content-Length:
       - "1999"
@@ -585,7 +618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:37 GMT
+      - Thu, 16 Jun 2022 13:40:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -595,7 +628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef19cbcd-fcd0-4bef-b386-4016b6899e5a
+      - ae563e5f-5811-4ef1-b180-dc4c44e5ac97
     status: 200 OK
     code: 200
     duration: ""
@@ -604,12 +637,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:10:03.701090Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:36:22.435434Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -618,7 +651,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:38 GMT
+      - Thu, 16 Jun 2022 13:40:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -628,7 +661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c65a38fa-109b-41e6-b9a8-447f36be2829
+      - 40c75524-5386-48b4-8348-540910286171
     status: 200 OK
     code: 200
     duration: ""
@@ -637,12 +670,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1391"
@@ -651,7 +684,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:38 GMT
+      - Thu, 16 Jun 2022 13:40:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -661,7 +694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29bc778c-69bb-4229-908c-7518ec817637
+      - a3b01c38-38f7-41f6-90c8-57ef368e71e8
     status: 200 OK
     code: 200
     duration: ""
@@ -670,12 +703,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
     method: GET
   response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVVDQwclhFdW0rSlN6NkNwSWdnbXlCQlpWOWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDROelpoWW1abE15MHpNekkwCkxUUTVOMll0T1dRMk5pMDBObVkzTm1WbVpqQmxPVGN1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE14TVRNeldoY05Nekl3TlRFM01UTXhNVE16V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVGczTm1GaVptVXpMVE16TWpRdE5EazNaaTA1WkRZMkxUUTJaamMyWldabU1HVTUKTnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMUXJwS2FEQ2ZJOVNXOExCR1VNT2FKQitwb1Irck1uQ1hRWmJWcDBlWHQ5NUpKMzdsY0g3cWJHCk9ncUFCd3FIdTEvZnNiWHc1SWVMZ0VtY0Fid3dGVkU0OUZXSk9JVkcrRU9YUmRoK2NsTmtoTitCU1I1L0NBRFUKQ2JrNnZvN0ZqL3ZuclFrZjg5bVdxZDBrN0xhUTBadzExYjRzVEwwcWE5SFhtQUpsczYyMzlEYXhybzJsc2s0WQpxSHprbDNZZXJiVmFnWjZCT3psUkI0R2lnaEd1SUxjajRIc1pxNlp4SUh3YWFpYmQwWThaOFJhYVZWU0ZLNytFCkhZNXY3V04vZHhqVXArOFF2MUo2YzRRRXRFSlU5bmN1czEydmRUeG5NNG8vVU14K2xqUUtuaVA5bzhuYXVwVkoKNlAwQmdXaEVyc0hKVUNLUnQ3bWZTMzJwNWFlMmR1VUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApPRGMyWVdKbVpUTXRNek15TkMwME9UZG1MVGxrTmpZdE5EWm1OelpsWm1Zd1pUazNMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucm5raHdUQXFBRXFod1F6bm9FeE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0EKNzNzM1F0YmpMczZOaktON2JBMVpZMUpNWjJ6TkN0WlRlUnBEUnVQQ2JBYlE0NGpGVnp3dENTd3VTWmFUcGxmaQpCQzNMeTVneTZGVHFKMXF1STlPWURhTUE3SkVaSVlZWmpsRzJicm9YQWQ0eWhJTU5VMFhSZ3kzL0FHa0NyZ0w5CjY1ajE3L1NpVjZ4ZTJha0hZQ0FkNk1scXRyZVkzZ2ZuZkx5UTVuKzdMV2xzblJnaytLL28zZDRhelVzZkdqTGwKMENTclNHN1NRRzVQQzdQTDRlWEE2bGlVVlhzQlBuTElRWkxDUUhIVUpwZVl1eTVkRHpYUllrNUdqSUpNMHRzQwpMZEpteXRicnVLa1gvSjNKc01mdG9qOUJQOHZWcHRneEM0aWpQT3Z5YVdlTzJFaHpOKzNGT0dyTzhTNUI4TWRZCmNBMzY1dXhzMjlPN3FsRFdqbm1MCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
     headers:
       Content-Length:
       - "1999"
@@ -684,7 +717,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:38 GMT
+      - Thu, 16 Jun 2022 13:40:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -694,7 +727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b27eb83d-07d1-406d-a708-9ae86ed6acd8
+      - 68d17df8-5ea5-4513-827a-fd46dce965a6
     status: 200 OK
     code: 200
     duration: ""
@@ -705,12 +738,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: PATCH
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:13:38.932493Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:40:38.989720Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "324"
@@ -719,7 +752,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:38 GMT
+      - Thu, 16 Jun 2022 13:40:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,32 +762,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee96b4c5-5c3f-4102-857c-718959c3734c
+      - f1041e29-9b02-4d90-b65c-641a23fbe757
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my_private_network","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","tags":null,"subnets":null}'
+    body: '{"name":"my_private_network","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks
     method: POST
   response:
-    body: '{"message":"internal error"}'
+    body: '{"id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:40:38.995595Z","updated_at":"2022-06-16T13:40:38.995595Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "28"
+      - "309"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:39 GMT
+      - Thu, 16 Jun 2022 13:40:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -764,21 +797,21 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ae261e9-7ce6-48ff-b613-daaf859e25b1
-    status: 500 Internal Server Error
-    code: 500
+      - 6bfdf12b-1f58-46d5-b579-2ca956f54a8c
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:13:38.932493Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:40:38.989720Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "324"
@@ -787,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:39 GMT
+      - Thu, 16 Jun 2022 13:40:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -797,42 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 571ddbcf-f236-4b93-accb-36559f5116c8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"my_private_network","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","tags":null,"subnets":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks
-    method: POST
-  response:
-    body: '{"id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:13:41.037589Z","updated_at":"2022-05-20T13:13:41.037589Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "309"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:13:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a9686c45-1d8f-4683-a2d2-4a21f51c69f5
+      - 702a1699-8d42-4fb1-9fa3-f2b54e3630ce
     status: 200 OK
     code: 200
     duration: ""
@@ -841,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/51e88364-a863-4fc0-9128-ecbd1ba81a6b
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/1c639813-b39c-49d3-b3b6-51a9c78becb2
     method: GET
   response:
-    body: '{"id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:13:41.037589Z","updated_at":"2022-05-20T13:13:41.037589Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:40:38.995595Z","updated_at":"2022-06-16T13:40:38.995595Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -855,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:41 GMT
+      - Thu, 16 Jun 2022 13:40:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c93dfff-b5f0-418c-aae4-da7e8b814abb
+      - 53cb3181-50c6-42cf-a361-e5350918b1c1
     status: 200 OK
     code: 200
     duration: ""
@@ -874,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1391"
@@ -888,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:41 GMT
+      - Thu, 16 Jun 2022 13:40:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1428ca6-c185-4d4e-9e76-b7b48d49582f
+      - 84ef3462-df9e-4286-9dbf-ed36dc970cde
     status: 200 OK
     code: 200
     duration: ""
@@ -909,12 +907,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: PATCH
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1391"
@@ -923,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:41 GMT
+      - Thu, 16 Jun 2022 13:40:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e7f54af-8c20-479d-901d-c8dc387c185b
+      - 58b35c57-893d-4d45-8bac-bb24b3cc5057
     status: 200 OK
     code: 200
     duration: ""
@@ -942,12 +940,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1391"
@@ -956,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:41 GMT
+      - Thu, 16 Jun 2022 13:40:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -966,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d949f9c-b34a-42c0-a194-9dbc426d8522
+      - df84a260-7b59-4195-b580-f354e6fbd5db
     status: 200 OK
     code: 200
     duration: ""
@@ -975,9 +973,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/7cceaa40-e6a5-4de7-a8d8-cf348de86449
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/2b181e7b-3817-4b21-88dc-107bfdb749bd
     method: DELETE
   response:
     body: ""
@@ -987,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:41 GMT
+      - Thu, 16 Jun 2022 13:40:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97dafbe4-a565-48b6-b05d-d294ef035bd1
+      - 6c3dc602-6742-43de-9c82-2be81cd410d7
     status: 204 No Content
     code: 204
     duration: ""
@@ -1006,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"configuring","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"7cceaa40-e6a5-4de7-a8d8-cf348de86449","private_network":{"private_network_id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"configuring","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},{"ip":"192.168.1.42","port":5432,"name":null,"id":"2b181e7b-3817-4b21-88dc-107bfdb749bd","private_network":{"private_network_id":"938c07bf-9780-4c17-9349-fad6209ea8a9","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1397"
@@ -1020,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:13:42 GMT
+      - Thu, 16 Jun 2022 13:40:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6f1b02d-4a2a-4167-9acc-c0db470c9bfd
+      - 67676695-368e-4c62-bec8-a94cb68c9308
     status: 200 OK
     code: 200
     duration: ""
@@ -1039,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1172"
@@ -1053,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:12 GMT
+      - Thu, 16 Jun 2022 13:41:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,23 +1061,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da57086f-07bd-40bb-816c-c1904385954c
+      - 6bbcffe2-8b27-4de4-9b95-324ff94ddffb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24"}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/endpoints
     method: POST
   response:
-    body: '{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
+    body: '{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "220"
@@ -1088,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:12 GMT
+      - Thu, 16 Jun 2022 13:41:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1098,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb8d1794-43b0-4eb6-b9b6-b28dc229837f
+      - ebc28640-6dab-4b37-9746-63eb49c85737
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,12 +1105,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"initializing","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"initializing","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1400"
@@ -1121,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:12 GMT
+      - Thu, 16 Jun 2022 13:41:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ba90ddd-b371-41ed-974b-63dc30b6aa97
+      - 32fddf94-e17c-4fa7-b0ba-211bae0c68d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,12 +1138,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -1154,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:43 GMT
+      - Thu, 16 Jun 2022 13:41:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1164,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9bd61d5-79b2-493f-a467-5016354b5378
+      - 98512703-bdc3-4dde-9072-2d7768a72450
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,12 +1171,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
     method: GET
   response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVVDQwclhFdW0rSlN6NkNwSWdnbXlCQlpWOWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDROelpoWW1abE15MHpNekkwCkxUUTVOMll0T1dRMk5pMDBObVkzTm1WbVpqQmxPVGN1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE14TVRNeldoY05Nekl3TlRFM01UTXhNVE16V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVGczTm1GaVptVXpMVE16TWpRdE5EazNaaTA1WkRZMkxUUTJaamMyWldabU1HVTUKTnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMUXJwS2FEQ2ZJOVNXOExCR1VNT2FKQitwb1Irck1uQ1hRWmJWcDBlWHQ5NUpKMzdsY0g3cWJHCk9ncUFCd3FIdTEvZnNiWHc1SWVMZ0VtY0Fid3dGVkU0OUZXSk9JVkcrRU9YUmRoK2NsTmtoTitCU1I1L0NBRFUKQ2JrNnZvN0ZqL3ZuclFrZjg5bVdxZDBrN0xhUTBadzExYjRzVEwwcWE5SFhtQUpsczYyMzlEYXhybzJsc2s0WQpxSHprbDNZZXJiVmFnWjZCT3psUkI0R2lnaEd1SUxjajRIc1pxNlp4SUh3YWFpYmQwWThaOFJhYVZWU0ZLNytFCkhZNXY3V04vZHhqVXArOFF2MUo2YzRRRXRFSlU5bmN1czEydmRUeG5NNG8vVU14K2xqUUtuaVA5bzhuYXVwVkoKNlAwQmdXaEVyc0hKVUNLUnQ3bWZTMzJwNWFlMmR1VUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApPRGMyWVdKbVpUTXRNek15TkMwME9UZG1MVGxrTmpZdE5EWm1OelpsWm1Zd1pUazNMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucm5raHdUQXFBRXFod1F6bm9FeE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0EKNzNzM1F0YmpMczZOaktON2JBMVpZMUpNWjJ6TkN0WlRlUnBEUnVQQ2JBYlE0NGpGVnp3dENTd3VTWmFUcGxmaQpCQzNMeTVneTZGVHFKMXF1STlPWURhTUE3SkVaSVlZWmpsRzJicm9YQWQ0eWhJTU5VMFhSZ3kzL0FHa0NyZ0w5CjY1ajE3L1NpVjZ4ZTJha0hZQ0FkNk1scXRyZVkzZ2ZuZkx5UTVuKzdMV2xzblJnaytLL28zZDRhelVzZkdqTGwKMENTclNHN1NRRzVQQzdQTDRlWEE2bGlVVlhzQlBuTElRWkxDUUhIVUpwZVl1eTVkRHpYUllrNUdqSUpNMHRzQwpMZEpteXRicnVLa1gvSjNKc01mdG9qOUJQOHZWcHRneEM0aWpQT3Z5YVdlTzJFaHpOKzNGT0dyTzhTNUI4TWRZCmNBMzY1dXhzMjlPN3FsRFdqbm1MCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
     headers:
       Content-Length:
       - "1999"
@@ -1187,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:43 GMT
+      - Thu, 16 Jun 2022 13:41:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1197,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea76b398-4d3c-4dc7-a2c9-7e0ae07dfbd4
+      - aadef3d0-c627-42f0-8923-1abf383df0ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,12 +1204,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -1220,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:43 GMT
+      - Thu, 16 Jun 2022 13:41:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1230,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a049d718-f565-4c3f-aa31-a730193853ea
+      - 61def93e-ce81-4f2e-be65-c0705c4a2e60
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,45 +1237,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/1c639813-b39c-49d3-b3b6-51a9c78becb2
     method: GET
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:13:38.932493Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "324"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:14:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 550032db-3ea4-451d-a5ff-f5d77a406674
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/51e88364-a863-4fc0-9128-ecbd1ba81a6b
-    method: GET
-  response:
-    body: '{"id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:13:41.037589Z","updated_at":"2022-05-20T13:13:41.037589Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:40:38.995595Z","updated_at":"2022-06-16T13:40:38.995595Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -1286,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:43 GMT
+      - Thu, 16 Jun 2022 13:41:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1296,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba466135-a507-4144-827f-129e9ba7755a
+      - 570a1fac-30de-4e12-a173-9fea0fbe922c
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,78 +1270,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
-    headers:
-      Content-Length:
-      - "1393"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:14:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 998ab0e1-bcb5-465d-9cc1-09925edcfe8d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/certificate
-    method: GET
-  response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVVDQwclhFdW0rSlN6NkNwSWdnbXlCQlpWOWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDROelpoWW1abE15MHpNekkwCkxUUTVOMll0T1dRMk5pMDBObVkzTm1WbVpqQmxPVGN1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE14TVRNeldoY05Nekl3TlRFM01UTXhNVE16V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVGczTm1GaVptVXpMVE16TWpRdE5EazNaaTA1WkRZMkxUUTJaamMyWldabU1HVTUKTnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMUXJwS2FEQ2ZJOVNXOExCR1VNT2FKQitwb1Irck1uQ1hRWmJWcDBlWHQ5NUpKMzdsY0g3cWJHCk9ncUFCd3FIdTEvZnNiWHc1SWVMZ0VtY0Fid3dGVkU0OUZXSk9JVkcrRU9YUmRoK2NsTmtoTitCU1I1L0NBRFUKQ2JrNnZvN0ZqL3ZuclFrZjg5bVdxZDBrN0xhUTBadzExYjRzVEwwcWE5SFhtQUpsczYyMzlEYXhybzJsc2s0WQpxSHprbDNZZXJiVmFnWjZCT3psUkI0R2lnaEd1SUxjajRIc1pxNlp4SUh3YWFpYmQwWThaOFJhYVZWU0ZLNytFCkhZNXY3V04vZHhqVXArOFF2MUo2YzRRRXRFSlU5bmN1czEydmRUeG5NNG8vVU14K2xqUUtuaVA5bzhuYXVwVkoKNlAwQmdXaEVyc0hKVUNLUnQ3bWZTMzJwNWFlMmR1VUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApPRGMyWVdKbVpUTXRNek15TkMwME9UZG1MVGxrTmpZdE5EWm1OelpsWm1Zd1pUazNMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucm5raHdUQXFBRXFod1F6bm9FeE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0EKNzNzM1F0YmpMczZOaktON2JBMVpZMUpNWjJ6TkN0WlRlUnBEUnVQQ2JBYlE0NGpGVnp3dENTd3VTWmFUcGxmaQpCQzNMeTVneTZGVHFKMXF1STlPWURhTUE3SkVaSVlZWmpsRzJicm9YQWQ0eWhJTU5VMFhSZ3kzL0FHa0NyZ0w5CjY1ajE3L1NpVjZ4ZTJha0hZQ0FkNk1scXRyZVkzZ2ZuZkx5UTVuKzdMV2xzblJnaytLL28zZDRhelVzZkdqTGwKMENTclNHN1NRRzVQQzdQTDRlWEE2bGlVVlhzQlBuTElRWkxDUUhIVUpwZVl1eTVkRHpYUllrNUdqSUpNMHRzQwpMZEpteXRicnVLa1gvSjNKc01mdG9qOUJQOHZWcHRneEM0aWpQT3Z5YVdlTzJFaHpOKzNGT0dyTzhTNUI4TWRZCmNBMzY1dXhzMjlPN3FsRFdqbm1MCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
-    headers:
-      Content-Length:
-      - "1999"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:14:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07ae569f-0bb8-418c-8d3f-bcd5eb53077d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
-    method: GET
-  response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:13:38.932493Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:40:38.989720Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "324"
@@ -1385,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:44 GMT
+      - Thu, 16 Jun 2022 13:41:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1395,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7948f14f-7e7d-4328-a49e-bd30093d2b9e
+      - bd6c2a60-5139-4a23-a536-84e0ef2722ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,45 +1303,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/51e88364-a863-4fc0-9128-ecbd1ba81a6b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:13:41.037589Z","updated_at":"2022-05-20T13:13:41.037589Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "309"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:14:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3cbc8877-0686-4dba-94b2-6c1f35f216ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
-    method: GET
-  response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -1451,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:44 GMT
+      - Thu, 16 Jun 2022 13:41:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1461,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39b65de2-2571-44ed-a8f4-f00fa7221f38
+      - 31d1f772-55ea-4bf2-a0b2-c7a2aba597fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,12 +1336,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
     method: GET
   response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVVDQwclhFdW0rSlN6NkNwSWdnbXlCQlpWOWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDROelpoWW1abE15MHpNekkwCkxUUTVOMll0T1dRMk5pMDBObVkzTm1WbVpqQmxPVGN1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE14TVRNeldoY05Nekl3TlRFM01UTXhNVE16V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVGczTm1GaVptVXpMVE16TWpRdE5EazNaaTA1WkRZMkxUUTJaamMyWldabU1HVTUKTnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMUXJwS2FEQ2ZJOVNXOExCR1VNT2FKQitwb1Irck1uQ1hRWmJWcDBlWHQ5NUpKMzdsY0g3cWJHCk9ncUFCd3FIdTEvZnNiWHc1SWVMZ0VtY0Fid3dGVkU0OUZXSk9JVkcrRU9YUmRoK2NsTmtoTitCU1I1L0NBRFUKQ2JrNnZvN0ZqL3ZuclFrZjg5bVdxZDBrN0xhUTBadzExYjRzVEwwcWE5SFhtQUpsczYyMzlEYXhybzJsc2s0WQpxSHprbDNZZXJiVmFnWjZCT3psUkI0R2lnaEd1SUxjajRIc1pxNlp4SUh3YWFpYmQwWThaOFJhYVZWU0ZLNytFCkhZNXY3V04vZHhqVXArOFF2MUo2YzRRRXRFSlU5bmN1czEydmRUeG5NNG8vVU14K2xqUUtuaVA5bzhuYXVwVkoKNlAwQmdXaEVyc0hKVUNLUnQ3bWZTMzJwNWFlMmR1VUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApPRGMyWVdKbVpUTXRNek15TkMwME9UZG1MVGxrTmpZdE5EWm1OelpsWm1Zd1pUazNMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucm5raHdUQXFBRXFod1F6bm9FeE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0EKNzNzM1F0YmpMczZOaktON2JBMVpZMUpNWjJ6TkN0WlRlUnBEUnVQQ2JBYlE0NGpGVnp3dENTd3VTWmFUcGxmaQpCQzNMeTVneTZGVHFKMXF1STlPWURhTUE3SkVaSVlZWmpsRzJicm9YQWQ0eWhJTU5VMFhSZ3kzL0FHa0NyZ0w5CjY1ajE3L1NpVjZ4ZTJha0hZQ0FkNk1scXRyZVkzZ2ZuZkx5UTVuKzdMV2xzblJnaytLL28zZDRhelVzZkdqTGwKMENTclNHN1NRRzVQQzdQTDRlWEE2bGlVVlhzQlBuTElRWkxDUUhIVUpwZVl1eTVkRHpYUllrNUdqSUpNMHRzQwpMZEpteXRicnVLa1gvSjNKc01mdG9qOUJQOHZWcHRneEM0aWpQT3Z5YVdlTzJFaHpOKzNGT0dyTzhTNUI4TWRZCmNBMzY1dXhzMjlPN3FsRFdqbm1MCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
     headers:
       Content-Length:
       - "1999"
@@ -1484,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:44 GMT
+      - Thu, 16 Jun 2022 13:41:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1494,23 +1360,155 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7030e19-b547-4e73-b36b-85dca5d4af07
+      - b881b85b-658b-4eff-b519-287e8fb09ee9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
+    method: GET
+  response:
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:40:38.989720Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "324"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:41:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0d408a98-fca8-48e5-a02d-872ccde295b9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/1c639813-b39c-49d3-b3b6-51a9c78becb2
+    method: GET
+  response:
+    body: '{"id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:40:38.995595Z","updated_at":"2022-06-16T13:40:38.995595Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "309"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:41:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a2d50d76-7e14-43a6-9a8a-9d7788ab7b8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
+  response:
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1393"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:41:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 487e1c2d-97d8-4455-ab91-6a197f113973
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
+    method: GET
+  response:
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    headers:
+      Content-Length:
+      - "1999"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:41:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0bd1c7ba-7933-4ce0-a5a7-94e2ae50fcb2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
+    body: '{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -1519,7 +1517,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:45 GMT
+      - Thu, 16 Jun 2022 13:41:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1529,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d802dab-5b99-416e-8eb1-312a66cab2b6
+      - ffb3117c-0bdf-453e-b390-0304e649863a
     status: 200 OK
     code: 200
     duration: ""
@@ -1538,12 +1536,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/39d885ba-0c6e-48dc-85d3-2200e11dd866
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a1cbb7a3-370b-4f52-909f-5eada1d623cd
     method: GET
   response:
-    body: '{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
+    body: '{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -1552,7 +1550,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:45 GMT
+      - Thu, 16 Jun 2022 13:41:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,23 +1560,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a65e3b7f-dc24-4e01-bf01-964558106fc7
+      - 6c350a7e-e427-4fec-9224-3ddf034404e8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","tags":null}'
+    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","tags":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
-    body: '{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
+    body: '{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "356"
@@ -1587,7 +1585,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:45 GMT
+      - Thu, 16 Jun 2022 13:41:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1597,7 +1595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6063d421-7a35-4cf9-9457-d16bb3dce32e
+      - 2ca0ff07-096e-4e5d-9a59-66219dd3b726
     status: 200 OK
     code: 200
     duration: ""
@@ -1606,12 +1604,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/bb0800ba-dd2d-49e0-be09-0cdec8344e68
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/3b6f2ad7-1e53-41e1-881e-2b4325077f9e
     method: GET
   response:
-    body: '{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
+    body: '{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "356"
@@ -1620,7 +1618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:45 GMT
+      - Thu, 16 Jun 2022 13:41:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1630,56 +1628,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1da57f91-d985-46ea-9850-dade9cb540cb
+      - 53248f0a-1861-4ad2-afa1-4a1cd4a9aeb6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","enable_smtp":false,"enable_bastion":false,"bastion_port":0}'
+    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:45.943898Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "913"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:14:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5fc2a999-efd6-48bd-9190-33f50331f5cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
-    method: GET
-  response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:45.995424Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:41:46.242152Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"stopped","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":null,"can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "917"
@@ -1688,7 +1653,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:46 GMT
+      - Thu, 16 Jun 2022 13:41:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1698,7 +1663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6091e91f-0a50-4677-9a2c-c42520023ffd
+      - 01f67ae1-2281-47e4-b158-33886037089b
     status: 200 OK
     code: 200
     duration: ""
@@ -1707,21 +1672,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:46.634079Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:41:46.458245Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "925"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:51 GMT
+      - Thu, 16 Jun 2022 13:41:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1731,7 +1696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63838fb7-3b5d-48a3-a0c5-ae91ca999281
+      - 27286d13-a101-447d-a99c-9a69de6edf8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1740,21 +1705,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:46.634079Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:41:47.337239Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:51 GMT
+      - Thu, 16 Jun 2022 13:41:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1764,7 +1729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28513d47-8230-4310-b08b-4148514ed49e
+      - 0a6ab642-e584-41e2-91e9-4a0e4de749c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1773,21 +1738,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:46.634079Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:41:47.337239Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:51 GMT
+      - Thu, 16 Jun 2022 13:41:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1797,23 +1762,56 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c7fcff0-06bd-4ac7-a7c4-c121b7516f59
+      - c978985e-0170-4d95-adac-13c62760fd1f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","enable_masquerade":true,"dhcp_id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","enable_dhcp":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
+    method: GET
+  response:
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:41:47.337239Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "921"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:41:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 609a40c1-93b1-406a-ae44-2e14e2fba260
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","enable_masquerade":true,"dhcp_id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","enable_dhcp":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:51.450702Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:41:53.664814Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "934"
@@ -1822,7 +1820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:51 GMT
+      - Thu, 16 Jun 2022 13:41:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1832,7 +1830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81db53c9-d83b-48e9-90e0-64ae20b56737
+      - 31c04ed2-54f1-45f2-a2d5-e5cad30f201c
     status: 200 OK
     code: 200
     duration: ""
@@ -1841,21 +1839,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:51.518165Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:51.450702Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:41:53.727629Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:41:53.664814Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1855"
+      - "1859"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:51 GMT
+      - Thu, 16 Jun 2022 13:41:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1865,7 +1863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6759c7e3-ffea-40d2-bbc3-2237ab2df8d6
+      - 09f4ac98-afdb-4cb6-b097-ad8b8d6f3678
     status: 200 OK
     code: 200
     duration: ""
@@ -1874,21 +1872,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:51.518165Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:51.450702Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":null,"enable_masquerade":true,"status":"created","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:41:53.727629Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"configuring","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:41:59.546859Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"configuring","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1855"
+      - "1878"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:14:56 GMT
+      - Thu, 16 Jun 2022 13:41:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1898,7 +1896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f54508c7-7f7f-4944-ae3a-a3d8c7a8e869
+      - 9fe9881d-602c-44f3-bfd1-244f35f80929
     status: 200 OK
     code: 200
     duration: ""
@@ -1907,21 +1905,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:01 GMT
+      - Thu, 16 Jun 2022 13:42:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1931,7 +1929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b0f4ef1-4072-4004-b336-fad6ef2cf6bd
+      - 72e96355-d884-4969-8e1f-24306309341d
     status: 200 OK
     code: 200
     duration: ""
@@ -1940,45 +1938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
     method: GET
   response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b13e7cdc-f20d-4260-b9cf-2fbe0c3f96c5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
-    method: GET
-  response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -1987,7 +1952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:02 GMT
+      - Thu, 16 Jun 2022 13:42:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1997,7 +1962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f764b5ee-353b-4df9-8f41-9a8a7f0dfaa4
+      - 9bd40834-042e-4d16-bd79-2bbb7fc2bc8a
     status: 200 OK
     code: 200
     duration: ""
@@ -2006,45 +1971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1864"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de27020a-a228-469d-af1c-cae8045fb834
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
-    method: GET
-  response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -2053,7 +1985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:02 GMT
+      - Thu, 16 Jun 2022 13:42:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2063,7 +1995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bcedd13-8503-4a5f-ab9d-e902a1ed2689
+      - 5567d724-94ff-4f3f-b549-fbf23d3e73ee
     status: 200 OK
     code: 200
     duration: ""
@@ -2072,21 +2004,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:02 GMT
+      - Thu, 16 Jun 2022 13:42:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2096,7 +2028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67c3c839-e527-4966-98cb-7fbfb765184d
+      - 73d1eb96-fe9f-4c70-9ae7-303df780d60e
     status: 200 OK
     code: 200
     duration: ""
@@ -2105,21 +2037,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "947"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:02 GMT
+      - Thu, 16 Jun 2022 13:42:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2129,23 +2061,89 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e44984e6-5edf-45d8-8236-66aa8331808c
+      - 945410b0-12cf-4439-b3e6-7fd13a9b2b09
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
+    method: GET
+  response:
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4155c24c-3d97-4fa8-a1e2-73bafb1ee27d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
+    method: GET
+  response:
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 660b4fc7-a506-48a4-9cb3-8b6be3e33cc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"id":"5adf089c-4d75-42d0-9122-a38ffb3a6e3a","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","created_at":"2022-05-20T13:15:02.511903Z","updated_at":"2022-05-20T13:15:02.511903Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    body: '{"id":"e911c1d2-6426-40e3-ab69-e6e07aa51465","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","created_at":"2022-06-16T13:42:07.374436Z","updated_at":"2022-06-16T13:42:07.374436Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -2154,7 +2152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:02 GMT
+      - Thu, 16 Jun 2022 13:42:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2164,7 +2162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00b869e0-5f5b-4cd4-a9c2-949ef1d5a8d5
+      - 9f48a621-2981-4a4b-9d42-5e5e665f6689
     status: 200 OK
     code: 200
     duration: ""
@@ -2173,21 +2171,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:02 GMT
+      - Thu, 16 Jun 2022 13:42:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2197,7 +2195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ffa9ee0-7b06-45c0-880c-c0e0b2ab04c5
+      - 09e78a9b-ec4a-45b2-9485-256836b6d362
     status: 200 OK
     code: 200
     duration: ""
@@ -2206,12 +2204,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/5adf089c-4d75-42d0-9122-a38ffb3a6e3a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/e911c1d2-6426-40e3-ab69-e6e07aa51465
     method: GET
   response:
-    body: '{"id":"5adf089c-4d75-42d0-9122-a38ffb3a6e3a","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","created_at":"2022-05-20T13:15:02.511903Z","updated_at":"2022-05-20T13:15:02.511903Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    body: '{"id":"e911c1d2-6426-40e3-ab69-e6e07aa51465","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","created_at":"2022-06-16T13:42:07.374436Z","updated_at":"2022-06-16T13:42:07.374436Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -2220,7 +2218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:02 GMT
+      - Thu, 16 Jun 2022 13:42:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2230,7 +2228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c126f4eb-17bb-4fce-a3e5-87952055b62b
+      - 7d858938-bc75-4c71-9edc-f9101028140c
     status: 200 OK
     code: 200
     duration: ""
@@ -2239,12 +2237,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -2253,7 +2251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:03 GMT
+      - Thu, 16 Jun 2022 13:42:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2263,7 +2261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f5686f6-6f9c-432e-963b-fb1e49d713b5
+      - ac7ffbc2-b339-46ba-a8d8-9a0e9c7edff6
     status: 200 OK
     code: 200
     duration: ""
@@ -2272,45 +2270,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/1c639813-b39c-49d3-b3b6-51a9c78becb2
     method: GET
   response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:13:38.932493Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "324"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6e766d84-a3a6-42e8-a701-4df21a906260
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/51e88364-a863-4fc0-9128-ecbd1ba81a6b
-    method: GET
-  response:
-    body: '{"id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:13:41.037589Z","updated_at":"2022-05-20T13:13:41.037589Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:40:38.995595Z","updated_at":"2022-06-16T13:40:38.995595Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "309"
@@ -2319,7 +2284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:03 GMT
+      - Thu, 16 Jun 2022 13:42:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2329,7 +2294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 728cd04d-d916-45d3-bc03-9060800a6a90
+      - f2a4537d-133f-410b-89c1-00dcc39dfc0b
     status: 200 OK
     code: 200
     duration: ""
@@ -2338,342 +2303,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/39d885ba-0c6e-48dc-85d3-2200e11dd866
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "568"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 101dfb29-2625-42a3-a589-d9350f1e3088
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/bb0800ba-dd2d-49e0-be09-0cdec8344e68
-    method: GET
-  response:
-    body: '{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "390"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 561c8620-332a-4a96-9694-98b4cadab483
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
-    method: GET
-  response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1864"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 58b13403-3d4e-47c2-8410-52ac322bf54f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
-    method: GET
-  response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
-    headers:
-      Content-Length:
-      - "1393"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4cd97603-9f69-4fef-a90f-cb8fd79d0c58
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/certificate
-    method: GET
-  response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVVDQwclhFdW0rSlN6NkNwSWdnbXlCQlpWOWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDROelpoWW1abE15MHpNekkwCkxUUTVOMll0T1dRMk5pMDBObVkzTm1WbVpqQmxPVGN1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE14TVRNeldoY05Nekl3TlRFM01UTXhNVE16V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVGczTm1GaVptVXpMVE16TWpRdE5EazNaaTA1WkRZMkxUUTJaamMyWldabU1HVTUKTnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMUXJwS2FEQ2ZJOVNXOExCR1VNT2FKQitwb1Irck1uQ1hRWmJWcDBlWHQ5NUpKMzdsY0g3cWJHCk9ncUFCd3FIdTEvZnNiWHc1SWVMZ0VtY0Fid3dGVkU0OUZXSk9JVkcrRU9YUmRoK2NsTmtoTitCU1I1L0NBRFUKQ2JrNnZvN0ZqL3ZuclFrZjg5bVdxZDBrN0xhUTBadzExYjRzVEwwcWE5SFhtQUpsczYyMzlEYXhybzJsc2s0WQpxSHprbDNZZXJiVmFnWjZCT3psUkI0R2lnaEd1SUxjajRIc1pxNlp4SUh3YWFpYmQwWThaOFJhYVZWU0ZLNytFCkhZNXY3V04vZHhqVXArOFF2MUo2YzRRRXRFSlU5bmN1czEydmRUeG5NNG8vVU14K2xqUUtuaVA5bzhuYXVwVkoKNlAwQmdXaEVyc0hKVUNLUnQ3bWZTMzJwNWFlMmR1VUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApPRGMyWVdKbVpUTXRNek15TkMwME9UZG1MVGxrTmpZdE5EWm1OelpsWm1Zd1pUazNMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucm5raHdUQXFBRXFod1F6bm9FeE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0EKNzNzM1F0YmpMczZOaktON2JBMVpZMUpNWjJ6TkN0WlRlUnBEUnVQQ2JBYlE0NGpGVnp3dENTd3VTWmFUcGxmaQpCQzNMeTVneTZGVHFKMXF1STlPWURhTUE3SkVaSVlZWmpsRzJicm9YQWQ0eWhJTU5VMFhSZ3kzL0FHa0NyZ0w5CjY1ajE3L1NpVjZ4ZTJha0hZQ0FkNk1scXRyZVkzZ2ZuZkx5UTVuKzdMV2xzblJnaytLL28zZDRhelVzZkdqTGwKMENTclNHN1NRRzVQQzdQTDRlWEE2bGlVVlhzQlBuTElRWkxDUUhIVUpwZVl1eTVkRHpYUllrNUdqSUpNMHRzQwpMZEpteXRicnVLa1gvSjNKc01mdG9qOUJQOHZWcHRneEM0aWpQT3Z5YVdlTzJFaHpOKzNGT0dyTzhTNUI4TWRZCmNBMzY1dXhzMjlPN3FsRFdqbm1MCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
-    headers:
-      Content-Length:
-      - "1999"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9c6a2dd6-df4a-4e3f-8c2e-aad102f4ac0f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
-    method: GET
-  response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e5d008e2-217f-4146-a1d4-84c58053c2fb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
-    method: GET
-  response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1864"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bec8d409-4c35-4772-89c6-44bbb109b616
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
-    method: GET
-  response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3901ea17-45c0-4989-a978-5340b8a2dfb5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/5adf089c-4d75-42d0-9122-a38ffb3a6e3a
-    method: GET
-  response:
-    body: '{"id":"5adf089c-4d75-42d0-9122-a38ffb3a6e3a","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","created_at":"2022-05-20T13:15:02.511903Z","updated_at":"2022-05-20T13:15:02.511903Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 67c5699b-201f-4e05-9120-7999a712cd08
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/39d885ba-0c6e-48dc-85d3-2200e11dd866
-    method: GET
-  response:
-    body: '{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "568"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 811e7ca8-88d6-407b-ae89-f8a10ccfec4d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
-    method: GET
-  response:
-    body: '{"id":"d3cf80ba-8a92-451d-97ed-4dcefea1325d","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:10:03.701090Z","updated_at":"2022-05-20T13:13:38.932493Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:40:38.989720Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "324"
@@ -2682,7 +2317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:04 GMT
+      - Thu, 16 Jun 2022 13:42:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2692,7 +2327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f743787b-0175-475c-9405-c4798322fa10
+      - 7325d5fe-6697-48dd-add5-45cc59f70ecd
     status: 200 OK
     code: 200
     duration: ""
@@ -2701,45 +2336,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/51e88364-a863-4fc0-9128-ecbd1ba81a6b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/3b6f2ad7-1e53-41e1-881e-2b4325077f9e
     method: GET
   response:
-    body: '{"id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:13:41.037589Z","updated_at":"2022-05-20T13:13:41.037589Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "309"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 719239f5-b3c0-44a1-b65f-837cd6c766a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/bb0800ba-dd2d-49e0-be09-0cdec8344e68
-    method: GET
-  response:
-    body: '{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"}'
+    body: '{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "390"
@@ -2748,7 +2350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:04 GMT
+      - Thu, 16 Jun 2022 13:42:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2758,7 +2360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b860224-4d33-4c00-8f4b-0a0894d50a9d
+      - c0249a5e-b15e-4ddd-b40e-5d2d21478abb
     status: 200 OK
     code: 200
     duration: ""
@@ -2767,21 +2369,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/5adf089c-4d75-42d0-9122-a38ffb3a6e3a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a1cbb7a3-370b-4f52-909f-5eada1d623cd
     method: GET
   response:
-    body: '{"id":"5adf089c-4d75-42d0-9122-a38ffb3a6e3a","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","created_at":"2022-05-20T13:15:02.511903Z","updated_at":"2022-05-20T13:15:02.511903Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    body: '{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:04 GMT
+      - Thu, 16 Jun 2022 13:42:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2791,7 +2393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5332765e-2462-4cfb-a2c6-1ed9c5bf8a3b
+      - 92c4f72a-e9be-49f9-b376-f46c83f8adba
     status: 200 OK
     code: 200
     duration: ""
@@ -2800,21 +2402,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "1868"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:04 GMT
+      - Thu, 16 Jun 2022 13:42:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2824,7 +2426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 797946af-52d5-445c-979a-8a33ccf4d87d
+      - 41a76eaf-394c-4f98-b865-cd1501a34c09
     status: 200 OK
     code: 200
     duration: ""
@@ -2833,45 +2435,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "947"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 62fabb17-c5aa-4eb7-86e7-ec2199a98257
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
-    method: GET
-  response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -2880,7 +2449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:04 GMT
+      - Thu, 16 Jun 2022 13:42:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2890,7 +2459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f44eab07-e958-4eec-8570-7bba763fd3bb
+      - 745807ae-689e-4dca-bdc1-8496775f668e
     status: 200 OK
     code: 200
     duration: ""
@@ -2899,21 +2468,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "947"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:04 GMT
+      - Thu, 16 Jun 2022 13:42:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2923,7 +2492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 664e796d-41ed-4d73-973a-f16e048db5de
+      - 25a6dc58-e5e6-4e4d-ba71-1ab2be087441
     status: 200 OK
     code: 200
     duration: ""
@@ -2932,12 +2501,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
     method: GET
   response:
-    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVVDQwclhFdW0rSlN6NkNwSWdnbXlCQlpWOWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDROelpoWW1abE15MHpNekkwCkxUUTVOMll0T1dRMk5pMDBObVkzTm1WbVpqQmxPVGN1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05USXdNVE14TVRNeldoY05Nekl3TlRFM01UTXhNVE16V2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVGczTm1GaVptVXpMVE16TWpRdE5EazNaaTA1WkRZMkxUUTJaamMyWldabU1HVTUKTnk1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFMUXJwS2FEQ2ZJOVNXOExCR1VNT2FKQitwb1Irck1uQ1hRWmJWcDBlWHQ5NUpKMzdsY0g3cWJHCk9ncUFCd3FIdTEvZnNiWHc1SWVMZ0VtY0Fid3dGVkU0OUZXSk9JVkcrRU9YUmRoK2NsTmtoTitCU1I1L0NBRFUKQ2JrNnZvN0ZqL3ZuclFrZjg5bVdxZDBrN0xhUTBadzExYjRzVEwwcWE5SFhtQUpsczYyMzlEYXhybzJsc2s0WQpxSHprbDNZZXJiVmFnWjZCT3psUkI0R2lnaEd1SUxjajRIc1pxNlp4SUh3YWFpYmQwWThaOFJhYVZWU0ZLNytFCkhZNXY3V04vZHhqVXArOFF2MUo2YzRRRXRFSlU5bmN1czEydmRUeG5NNG8vVU14K2xqUUtuaVA5bzhuYXVwVkoKNlAwQmdXaEVyc0hKVUNLUnQ3bWZTMzJwNWFlMmR1VUNBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApPRGMyWVdKbVpUTXRNek15TkMwME9UZG1MVGxrTmpZdE5EWm1OelpsWm1Zd1pUazNMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpucm5raHdUQXFBRXFod1F6bm9FeE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0EKNzNzM1F0YmpMczZOaktON2JBMVpZMUpNWjJ6TkN0WlRlUnBEUnVQQ2JBYlE0NGpGVnp3dENTd3VTWmFUcGxmaQpCQzNMeTVneTZGVHFKMXF1STlPWURhTUE3SkVaSVlZWmpsRzJicm9YQWQ0eWhJTU5VMFhSZ3kzL0FHa0NyZ0w5CjY1ajE3L1NpVjZ4ZTJha0hZQ0FkNk1scXRyZVkzZ2ZuZkx5UTVuKzdMV2xzblJnaytLL28zZDRhelVzZkdqTGwKMENTclNHN1NRRzVQQzdQTDRlWEE2bGlVVlhzQlBuTElRWkxDUUhIVUpwZVl1eTVkRHpYUllrNUdqSUpNMHRzQwpMZEpteXRicnVLa1gvSjNKc01mdG9qOUJQOHZWcHRneEM0aWpQT3Z5YVdlTzJFaHpOKzNGT0dyTzhTNUI4TWRZCmNBMzY1dXhzMjlPN3FsRFdqbm1MCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
     headers:
       Content-Length:
       - "1999"
@@ -2946,7 +2515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:04 GMT
+      - Thu, 16 Jun 2022 13:42:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2956,7 +2525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 151eb51a-f95c-4e2c-b480-c1255b439b40
+      - 9976ef57-f730-4d55-87d1-201a2b538960
     status: 200 OK
     code: 200
     duration: ""
@@ -2965,12 +2534,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9bb7b381-fc0b-4e02-8eb6-dfefef266302
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
+    method: GET
+  response:
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -2979,7 +2581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:04 GMT
+      - Thu, 16 Jun 2022 13:42:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2989,7 +2591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eefa4f23-6f40-4444-b5c9-577302f5a79c
+      - 2912e29d-dad2-4f98-b34e-ecb71c43d51e
     status: 200 OK
     code: 200
     duration: ""
@@ -2998,12 +2600,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/5adf089c-4d75-42d0-9122-a38ffb3a6e3a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/e911c1d2-6426-40e3-ab69-e6e07aa51465
     method: GET
   response:
-    body: '{"id":"5adf089c-4d75-42d0-9122-a38ffb3a6e3a","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","created_at":"2022-05-20T13:15:02.511903Z","updated_at":"2022-05-20T13:15:02.511903Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    body: '{"id":"e911c1d2-6426-40e3-ab69-e6e07aa51465","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","created_at":"2022-06-16T13:42:07.374436Z","updated_at":"2022-06-16T13:42:07.374436Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -3012,7 +2614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3022,7 +2624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14123763-a4c5-45fc-9926-74d93d12ca75
+      - 8770ac50-4d0b-4162-af03-e6bc22d1d73a
     status: 200 OK
     code: 200
     duration: ""
@@ -3031,21 +2633,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/e911c1d2-6426-40e3-ab69-e6e07aa51465
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"e911c1d2-6426-40e3-ab69-e6e07aa51465","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","created_at":"2022-06-16T13:42:07.374436Z","updated_at":"2022-06-16T13:42:07.374436Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3055,7 +2657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51e02c1e-70ba-4d38-899d-a4091da3f48d
+      - 07bc907a-9dbd-4c14-8bd9-d73cd493b901
     status: 200 OK
     code: 200
     duration: ""
@@ -3064,83 +2666,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/5adf089c-4d75-42d0-9122-a38ffb3a6e3a
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7bcacbf1-5eea-40b1-9d0a-43f63aa00d65
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/d3cf80ba-8a92-451d-97ed-4dcefea1325d
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8baa6f86-1e2f-4b64-b636-36f2c95053bd
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"938c07bf-9780-4c17-9349-fad6209ea8a9","name":"my_private_network_to_be_replaced","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:36:22.435434Z","updated_at":"2022-06-16T13:40:38.989720Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1864"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3150,7 +2690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a4e68d6-dbf7-4033-a26f-a0ccd4383868
+      - cda33a16-1e1a-409a-874d-b3e38a3e390a
     status: 200 OK
     code: 200
     duration: ""
@@ -3159,12 +2699,144 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/3b6f2ad7-1e53-41e1-881e-2b4325077f9e
     method: GET
   response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:14:57.769527Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"ready","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "390"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6810ff0e-7e6c-4f4a-a058-c32cb498a24b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a1cbb7a3-370b-4f52-909f-5eada1d623cd
+    method: GET
+  response:
+    body: '{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "568"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd9a814d-ffd0-4d44-b2b2-1e5b802cf093
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/1c639813-b39c-49d3-b3b6-51a9c78becb2
+    method: GET
+  response:
+    body: '{"id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:40:38.995595Z","updated_at":"2022-06-16T13:40:38.995595Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "309"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ab9a995-0d31-4263-8ab1-d977a31dbe38
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
+    method: GET
+  response:
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9bcefc89-4b9e-4211-823b-fd1f64b6f46a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
+    method: GET
+  response:
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "947"
@@ -3173,7 +2845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3183,7 +2855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4a08c2e-db4c-40f1-b82f-92f2e6b64d83
+      - 50652f01-ef39-499e-95e8-cdfa207e2227
     status: 200 OK
     code: 200
     duration: ""
@@ -3192,12 +2864,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
       - "1393"
@@ -3206,7 +2878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3216,7 +2888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2924f1ba-b078-4dd7-b66b-acb2585cf439
+      - 10d95401-433c-4af5-a61f-31b76e65e903
     status: 200 OK
     code: 200
     duration: ""
@@ -3225,9 +2897,174 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
+    method: GET
+  response:
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 532cdb73-7421-4ec3-adb7-b98ce18c7364
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
+    method: GET
+  response:
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    headers:
+      Content-Length:
+      - "1999"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b890ccfd-b792-423a-a990-caa2fdb8022f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
+    method: GET
+  response:
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a945b5b2-19a7-40ee-9756-ec4578f5edf8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/e911c1d2-6426-40e3-ab69-e6e07aa51465
+    method: GET
+  response:
+    body: '{"id":"e911c1d2-6426-40e3-ab69-e6e07aa51465","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","created_at":"2022-06-16T13:42:07.374436Z","updated_at":"2022-06-16T13:42:07.374436Z","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "283"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d0380b6-9130-4ece-8db3-56ab2c855b84
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
+    method: GET
+  response:
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 55a15c84-15d8-4a45-b972-e70c72af8466
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/e911c1d2-6426-40e3-ab69-e6e07aa51465
     method: DELETE
   response:
     body: ""
@@ -3237,7 +3074,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3247,7 +3084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c124cae-5b41-42d9-a84d-cec8c69a306a
+      - 4e755ee1-315f-4e01-936d-b02d8bf447b3
     status: 204 No Content
     code: 204
     duration: ""
@@ -3256,21 +3093,19 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/938c07bf-9780-4c17-9349-fad6209ea8a9
     method: DELETE
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"deleting","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: ""
     headers:
-      Content-Length:
-      - "1396"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3280,7 +3115,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9758a045-4c62-4a1c-a8e6-15b59f0b9047
+      - 72b7dc24-dc14-40ca-967a-d19f9b42e6bc
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
+    method: GET
+  response:
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1868"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14518ffb-946e-4141-888b-82a862078e13
     status: 200 OK
     code: 200
     duration: ""
@@ -3289,12 +3157,144 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
     method: GET
   response:
-    body: '{"id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","created_at":"2022-05-20T13:14:51.450702Z","updated_at":"2022-05-20T13:15:05.611878Z","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","mac_address":"02:00:00:00:a4:0f","enable_masquerade":true,"status":"detaching","dhcp":{"id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.189279Z","updated_at":"2022-05-20T13:14:45.189279Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:00.058160Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"ready","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ab3a6d3-7852-46e5-943e-e566b29e0d8a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
+  response:
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1393"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bacc38be-c1ba-4560-986a-d3af8edebeca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0?cleanup_dhcp=true
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c2d1b589-642c-43f8-b916-6a4c082d5a03
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"backup_schedule_frequency":null,"backup_schedule_retention":null,"is_backup_schedule_disabled":null,"name":null,"tags":null,"logs_policy":null,"backup_same_region":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: PATCH
+  response:
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1393"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3e9382fa-4515-4ef5-abd3-a7c322829b00
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
+    method: GET
+  response:
+    body: '{"id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","created_at":"2022-06-16T13:41:53.664814Z","updated_at":"2022-06-16T13:42:10.835850Z","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","mac_address":"02:00:00:00:af:04","enable_masquerade":true,"status":"detaching","dhcp":{"id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.354763Z","updated_at":"2022-06-16T13:41:45.354763Z","subnet":"192.168.1.0/24","address":"192.168.1.1","pool_low":"192.168.1.2","pool_high":"192.168.1.254","enable_dynamic":true,"valid_lifetime":"3600s","renew_timer":"3000s","rebind_timer":"3060s","push_default_route":true,"push_dns_server":true,"dns_servers_override":[],"dns_search":[],"dns_local_name":"priv","zone":"nl-ams-1"},"enable_dhcp":true,"address":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "951"
@@ -3303,7 +3303,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3313,7 +3313,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9fad941-4cd3-4545-be5b-6803718ed179
+      - 681096ca-3f8c-4ed8-95c1-9742446adcb2
     status: 200 OK
     code: 200
     duration: ""
@@ -3322,21 +3322,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"id":"876abfe3-3324-497f-9d66-46f76eff0e97","name":"test-rdb","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"deleting","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"f62141d0-b093-4168-a10f-a0bc3eec61e5","private_network":{"private_network_id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.129.49","port":50944,"name":null,"id":"e351eaca-c58e-423f-87f2-f6fecdde4d10","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-05-20T13:10:05.314047Z","region":"nl-ams"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
-      - "1396"
+      - "1393"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:05 GMT
+      - Thu, 16 Jun 2022 13:42:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3346,7 +3346,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d387508d-3796-456d-9bea-63987c7948cb
+      - 0fc53398-78d3-49c5-b38c-764cb6d3c4aa
     status: 200 OK
     code: 200
     duration: ""
@@ -3355,12 +3355,76 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/731b2204-7adc-473c-8c1c-3de2c9d4f1e3
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/1f6043f5-036e-4725-91c8-aa6fa13a5c26
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4b14a59c-a8eb-4b57-852f-0fa0c9b3ec7b
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"731b2204-7adc-473c-8c1c-3de2c9d4f1e3","type":"not_found"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"configuring","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"192.168.1.254","port":5432,"name":null,"id":"1f6043f5-036e-4725-91c8-aa6fa13a5c26","private_network":{"private_network_id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1399"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7347cdc6-c98d-43b5-a4ca-39f35a33f6de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/8457e2fe-7c64-4498-94ed-6726a49e05c0
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"8457e2fe-7c64-4498-94ed-6726a49e05c0","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3369,7 +3433,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:10 GMT
+      - Thu, 16 Jun 2022 13:42:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3379,7 +3443,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f8e6b5c-a796-453a-8972-9d1328b343cd
+      - acf6cf37-0da2-448c-9cbf-6cbb82c8ad32
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3388,21 +3452,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:10 GMT
+      - Thu, 16 Jun 2022 13:42:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3412,7 +3476,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03ef57e3-c004-49e6-aba0-94a0a4ffdf80
+      - aa5a9c4e-f6ed-4dec-947f-11932d8a2a11
     status: 200 OK
     code: 200
     duration: ""
@@ -3421,12 +3485,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/39d885ba-0c6e-48dc-85d3-2200e11dd866
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/a1cbb7a3-370b-4f52-909f-5eada1d623cd
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"39d885ba-0c6e-48dc-85d3-2200e11dd866","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"a1cbb7a3-370b-4f52-909f-5eada1d623cd","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3435,7 +3499,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:11 GMT
+      - Thu, 16 Jun 2022 13:42:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3445,7 +3509,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 019d3761-b008-4ba5-810b-e3a96869f07f
+      - b58510fd-0bb2-48d3-9203-cd66d6c04913
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3454,21 +3518,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.943898Z","updated_at":"2022-05-20T13:14:57.898668Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"bb0800ba-dd2d-49e0-be09-0cdec8344e68","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:14:45.691181Z","updated_at":"2022-05-20T13:14:45.691181Z","tags":[],"address":"51.15.47.221","reverse":"221-47-15-51.instances.scw.cloud","gateway_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":0,"smtp_enabled":false,"zone":"nl-ams-1"}'
+    body: '{"id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:46.242152Z","updated_at":"2022-06-16T13:42:00.202702Z","type":{"name":"VPC-GW-S","bandwidth":100000000,"zone":"nl-ams-1"},"status":"running","name":"foobar","tags":[],"ip":{"id":"3b6f2ad7-1e53-41e1-881e-2b4325077f9e","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:41:45.850499Z","updated_at":"2022-06-16T13:41:45.850499Z","tags":[],"address":"51.15.108.59","reverse":"59-108-15-51.instances.scw.cloud","gateway_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","zone":"nl-ams-1"},"gateway_networks":[],"upstream_dns_servers":[],"version":"0.2.21","can_upgrade_to":null,"bastion_enabled":false,"bastion_port":61000,"smtp_enabled":false,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "917"
+      - "921"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:11 GMT
+      - Thu, 16 Jun 2022 13:42:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3478,7 +3542,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0743fa9-bccc-4565-932f-9b04d420cc01
+      - a85a65ec-58b2-419e-9aa3-5d424de6bd16
     status: 200 OK
     code: 200
     duration: ""
@@ -3487,9 +3551,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3499,7 +3563,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:11 GMT
+      - Thu, 16 Jun 2022 13:42:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3509,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6650f689-6dec-4077-a176-8acbaf0eb96a
+      - 667cb18c-f60a-4c2e-9d07-17ccc61f2786
     status: 204 No Content
     code: 204
     duration: ""
@@ -3518,12 +3582,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/359acc3c-a2e6-4f57-96e7-00c73cda8485
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3942628c-76c3-4631-a26f-07b9b2ee93d5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"359acc3c-a2e6-4f57-96e7-00c73cda8485","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"3942628c-76c3-4631-a26f-07b9b2ee93d5","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3532,7 +3596,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:11 GMT
+      - Thu, 16 Jun 2022 13:42:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3542,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7800cff-5686-41de-8a7a-226c2e1653b5
+      - ba5a8699-8ceb-47fb-83f8-d2b7b7684115
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3551,9 +3615,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/bb0800ba-dd2d-49e0-be09-0cdec8344e68
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/3b6f2ad7-1e53-41e1-881e-2b4325077f9e
     method: DELETE
   response:
     body: ""
@@ -3563,7 +3627,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:11 GMT
+      - Thu, 16 Jun 2022 13:42:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3573,7 +3637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 278503a2-ed69-4495-9f73-d429505bcd49
+      - 48e3ce54-d08a-4d78-b651-ca0997f661bc
     status: 204 No Content
     code: 204
     duration: ""
@@ -3582,21 +3646,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/876abfe3-3324-497f-9d66-46f76eff0e97
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"876abfe3-3324-497f-9d66-46f76eff0e97","type":"not_found"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
-      - "129"
+      - "1172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:36 GMT
+      - Thu, 16 Jun 2022 13:42:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3606,40 +3670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a03a3ed-4f84-4425-bf40-711e5118e489
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/51e88364-a863-4fc0-9128-ecbd1ba81a6b
-    method: GET
-  response:
-    body: '{"id":"51e88364-a863-4fc0-9128-ecbd1ba81a6b","name":"my_private_network","tags":[],"organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","created_at":"2022-05-20T13:13:41.037589Z","updated_at":"2022-05-20T13:13:41.037589Z","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","subnets":[],"zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "309"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 May 2022 13:15:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c247d69-978c-4282-81a1-ce3397b59b9f
+      - 309edc35-6c06-4312-b0ac-6445d11f1790
     status: 200 OK
     code: 200
     duration: ""
@@ -3648,22 +3679,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/51e88364-a863-4fc0-9128-ecbd1ba81a6b
-    method: DELETE
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
   response:
-    body: '{"help_message":"Private Network must be empty to be deleted","message":"precondition
-      is not respected","precondition":"resource_still_in_use","type":"precondition_failed"}'
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
     headers:
       Content-Length:
-      - "172"
+      - "1172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 May 2022 13:15:37 GMT
+      - Thu, 16 Jun 2022 13:42:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3673,7 +3703,335 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7858735c-6c0a-4a16-9081-439396bdcdcc
-    status: 412 Precondition Failed
-    code: 412
+      - 0d6cef1d-4ac6-4b01-956b-53dc0a750ecb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
+    method: GET
+  response:
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    headers:
+      Content-Length:
+      - "1999"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b1729000-bef7-441e-a50c-103ffffbd5c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/1c639813-b39c-49d3-b3b6-51a9c78becb2
+    method: GET
+  response:
+    body: '{"id":"1c639813-b39c-49d3-b3b6-51a9c78becb2","name":"my_private_network","tags":[],"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-06-16T13:40:38.995595Z","updated_at":"2022-06-16T13:40:38.995595Z","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","subnets":[],"zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "309"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d3ab8436-db61-49f7-8903-482782557b5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
+  response:
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1172"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d61db054-2836-49a9-944d-ca2aef4d9c51
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea/certificate
+    method: GET
+  response:
+    body: '{"name":"ssl_certificate","content_type":"application/x-pem-file","content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrekNDQXVPZ0F3SUJBZ0lVWlI5NEF2YlQ0aTFRQWNXTEdzWnFxaWJzNHZjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWURWUVFJREFWUVlYSnBjekVPTUF3R0ExVUVCd3dGVUdGeQphWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVVVd1F3WURWUVFERER4eWR5MDFabVU1T0dNNFlpMDFOMkpqCkxUUXpPRFl0T0dVeE9DMDJaR1l4TVRZME5HWm1aV0V1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdRd0hoY04KTWpJd05qRTJNVE16TnpRMVdoY05Nekl3TmpFek1UTXpOelExV2pDQmh6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTQpCZ05WQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4ClJUQkRCZ05WQkFNTVBISjNMVFZtWlRrNFl6aGlMVFUzWW1NdE5ETTROaTA0WlRFNExUWmtaakV4TmpRMFptWmwKWVM1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpEQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQwpBUW9DZ2dFQkFLcXVkaFRNTGdiY2U5VnN6dENnZklTcHFwNXptTTRKRW5HdHZCNlJGVHhJazBuaWRHZGdNajhCCkNUZEVHREV0c3JCc2k3U3B4NlRmb1M3eFlBa2RWbUZxNEtrT0ZoV3NpTWd6Q3JlNnQ3ODJRYTJuUEFVbUpSemsKMENxcFU3eUJ2dk0rQTZoY0hHb0VUNlE5QUxTZkpmZVNsditpQm4rT2pvb01YRUN1SnJqV2ZvdkpRVGErNUNzZgovTnFiVWpRWmpWVEc5WUZJdUZWM0NmL1ZPVTJTc1dhVkVYSmprbEFwZGIxaFVWUWgyQy9LMlhoL3pheWRtYlAyCmdLS21YVDJnWXFIS3dBRmdXVkNGY1VRNVowSmZOTGJHMXpBeC94WnVWNjNCNGpBZHhZSnJnYkR4bXhxQ25idlcKeENlZ24xVVJndS8rSUFXYm9YYzFNWDlHRjNiTTNsOENBd0VBQWFOZE1Gc3dXUVlEVlIwUkJGSXdVSUk4Y25jdApOV1psT1Roak9HSXROVGRpWXkwME16ZzJMVGhsTVRndE5tUm1NVEUyTkRSbVptVmhMbkprWWk1dWJDMWhiWE11CmMyTjNMbU5zYjNWa2h3UXpEMzdGaHdUQXFBRXFod1F6bm9EdU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQmMKTis0RUpVcGVCSGMzdGVnYkIvRFF1WTNwZWNoZzNaN0lwSDM1Nzl2T2pWNkdjRTVicTBNZWN4YTFmUXNTMUpTMQozRGFkb2J1bGczbG93UWU0MjNzb2h1YnVqSWVuRGVTS29GdG15eld4a2pZSkxuMjNGR0g5SFBrQkpPTEhKdzE2ClhlekFHRmxHUldueXRZYTNhSFk0cU1rZDdIbzYrYXBpMDNXOHlBVEJDMlRMODY3MXJ4TWQ3ZFdod3ZSQ0llWk4KdVArZGVIeEh6M0JGQXRJdUlzNGZlL2RkdmJRWURLNkRFeml1U3J2QlEvWDJpVDBsaU1aNVRwZEJlbk5scjk3NgpkL0VMaWtEMXl4SlpRcEx5ZXUrMWJYdmpzSzZ1MXA3NTZPUHFxT21rLzA4Q1lURjlVMUpSZFA0ZmRheDJNdytaCk14bzZpTkRsOUlTWXl0bDBESld2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"}'
+    headers:
+      Content-Length:
+      - "1999"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0b0c3a2a-7810-4f23-96a6-37d38478aebd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
+  response:
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1172"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ddb9e28-efdc-4d1c-b5c3-8a08447d463e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/nl-ams-1/private-networks/1c639813-b39c-49d3-b3b6-51a9c78becb2
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a7e3591-35e0-47a6-aa5b-cf853dda17a9
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: DELETE
+  response:
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1175"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b30f2475-09b7-434a-bdaa-9f8f1938ca58
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
+  response:
+    body: '{"id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","name":"test-rdb","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","engine":"PostgreSQL-11","endpoint":{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}},"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"settings":[{"name":"work_mem","value":"4"},{"name":"max_connections","value":"100"},{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"}],"backup_schedule":{"frequency":24,"retention":7,"disabled":true},"is_ha_cluster":false,"read_replicas":[],"node_type":"db-dev-s","volume":{"type":"bssd","size":10000000000},"init_settings":[],"endpoints":[{"ip":"51.158.128.238","port":3891,"name":null,"id":"05e3f7ec-a7b7-4aa6-8cd1-2180ba59cbca","load_balancer":{}}],"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"backup_same_region":false,"maintenances":[],"created_at":"2022-06-16T13:36:25.748524Z","region":"nl-ams"}'
+    headers:
+      Content-Length:
+      - "1175"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:42:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b11d6cdc-d825-4711-bf53-522ffd167653
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:43:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08ca87f6-771a-4112-b4e8-69816f9c2871
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/5fe98c8b-57bc-4386-8e18-6df11644ffea
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"5fe98c8b-57bc-4386-8e18-6df11644ffea","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jun 2022 13:43:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee98be03-fa43-4399-992d-ea6af25b2b42
+    status: 404 Not Found
+    code: 404
     duration: ""


### PR DESCRIPTION
rdb instances do not detach vpc before deletion so deleting vpc would fail when trying to delete both at the same time