### PR TITLE
feat(iam): add iam group resource

### DIFF
--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -33,6 +33,7 @@ func addBetaResources(provider *schema.Provider) {
 	}
 	betaResources := map[string]*schema.Resource{
 		"scaleway_iam_application": resourceScalewayIamApplication(),
+		"scaleway_iam_group":       resourceScalewayIamGroup(),
 	}
 	betaDataSources := map[string]*schema.Resource{}
 	for resourceName, resource := range betaResources {

--- a/scaleway/resource_iam_group.go
+++ b/scaleway/resource_iam_group.go
@@ -1,0 +1,135 @@
+package scaleway
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func resourceScalewayIamGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScalewayIamGroupCreate,
+		ReadContext:   resourceScalewayIamGroupRead,
+		UpdateContext: resourceScalewayIamGroupUpdate,
+		DeleteContext: resourceScalewayIamGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Description: "The name of the iam group",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the iam group",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time of the creation of the group",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time of the last update of the group",
+			},
+			"user_ids": {
+				Type:        schema.TypeList,
+				Description: "List of IDs of the users attached to the group",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validationUUID(),
+				},
+			},
+			"application_ids": {
+				Type:        schema.TypeList,
+				Description: "List of IDs of the applications attached to the group",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validationUUID(),
+				},
+			},
+			"organization_id": organizationIDSchema(),
+		},
+	}
+}
+
+func resourceScalewayIamGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+	group, err := api.CreateGroup(&iam.CreateGroupRequest{
+		OrganizationID: d.Get("organization_id").(string),
+		Name:           expandOrGenerateString(d.Get("name"), "group-"),
+		Description:    d.Get("description").(string),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(group.ID)
+
+	return resourceScalewayIamGroupRead(ctx, d, meta)
+}
+
+func resourceScalewayIamGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+	group, err := api.GetGroup(&iam.GetGroupRequest{
+		GroupID: d.Id(),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	_ = d.Set("name", group.Name)
+	_ = d.Set("description", group.Description)
+	_ = d.Set("created_at", flattenTime(group.CreatedAt))
+	_ = d.Set("updated_at", flattenTime(group.UpdatedAt))
+	_ = d.Set("organization_id", group.OrganizationID)
+	_ = d.Set("user_ids", group.UserIDs)
+	_ = d.Set("application_ids", group.ApplicationIDs)
+
+	return nil
+}
+
+func resourceScalewayIamGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+
+	req := &iam.UpdateGroupRequest{
+		GroupID: d.Id(),
+	}
+
+	if d.HasChange("name") {
+		req.Name = expandStringPtr(d.Get("name"))
+	}
+	if d.HasChange("description") {
+		req.Description = expandStringPtr(d.Get("description"))
+	}
+
+	_, err := api.UpdateGroup(req, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceScalewayIamGroupRead(ctx, d, meta)
+}
+
+func resourceScalewayIamGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+
+	err := api.DeleteGroup(&iam.DeleteGroupRequest{
+		GroupID: d.Id(),
+	})
+	if err != nil && !is404Error(err) {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/scaleway/resource_iam_group_test.go
+++ b/scaleway/resource_iam_group_test.go
@@ -1,0 +1,121 @@
+package scaleway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func init() {
+	resource.AddTestSweepers("scaleway_iam_group", &resource.Sweeper{
+		Name: "scaleway_iam_group",
+		F:    testSweepIamGroup,
+	})
+}
+
+func testSweepIamGroup(_ string) error {
+	return sweep(func(scwClient *scw.Client) error {
+		api := iam.NewAPI(scwClient)
+
+		listApps, err := api.ListGroups(&iam.ListGroupsRequest{})
+		if err != nil {
+			return fmt.Errorf("failed to list groups: %w", err)
+		}
+		for _, app := range listApps.Groups {
+			err = api.DeleteGroup(&iam.DeleteGroupRequest{
+				GroupID: app.ID,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to delete group: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+func TestAccScalewayIamGroup_Basic(t *testing.T) {
+	SkipBetaTest(t)
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:      testAccCheckScalewayIamGroupDestroy(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttrSet("scaleway_iam_group.main", "name"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", ""),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_basic"
+							description = "basic description"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_basic"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "basic description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckScalewayIamGroupExists(tt *TestTools, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", name)
+		}
+
+		iamAPI := iamAPI(tt.Meta)
+
+		_, err := iamAPI.GetGroup(&iam.GetGroupRequest{
+			GroupID: rs.Primary.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("could not find group: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckScalewayIamGroupDestroy(tt *TestTools) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "scaleway_iam_group" {
+				continue
+			}
+
+			iamAPI := iamAPI(tt.Meta)
+
+			_, err := iamAPI.GetGroup(&iam.GetGroupRequest{
+				GroupID: rs.Primary.ID,
+			})
+
+			// If no error resource still exist
+			if err == nil {
+				return fmt.Errorf("resource %s(%s) still exist", rs.Type, rs.Primary.ID)
+			}
+
+			// Unexpected api error we return it
+			if !is404Error(err) {
+				return err
+			}
+		}
+
+		return nil
+	}
+}

--- a/scaleway/testdata/iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/iam-group-basic.cassette.yaml
@@ -1,0 +1,372 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups
+    method: POST
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6277b33d-f227-4f8e-87e7-17f1d45517ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b812d307-0200-4f94-b471-38dc61833cd6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14559e1d-247b-41e0-ae38-dc6d669d17f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56c8b83e-83e2-47e8-a863-d2ac7bee9861
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d7d4da43-5600-42e6-8819-d6e2f7a53c2c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_basic","description":"basic description"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: PATCH
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:30.054011Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+      description","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57e78d97-536a-4032-a3d2-0aacf51c1e60
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:30.054011Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+      description","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77a2b0c7-b694-4796-b0bd-719b30b3d90f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:30.054011Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+      description","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4628656-bd40-4aa8-a64c-08cacbdcdde1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:30.054011Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+      description","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - edc880ec-a049-41c0-90ff-489e9b81b031
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54e70ed8-4924-4301-9f9b-1c9218c98c79
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8d56fc5-5ca2-423c-aa8b-8b74ae041de3
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
Adding resource for IAM groups that will be used this way :
```
{
  "id": "string",
  "created_at": "string",
  "updated_at": "string",
  "organization_id": "string",
  "name": "string",
  "description": "string",
  "user_ids": [
    "string"
  ],
  "application_ids": [
    "string"
  ]
}
```

Left to do:
- [x] "resource_iam_group"
- [ ] "datasource_iam_group"