### PR TITLE
fix(instance_image): fix nightly tests

### DIFF
--- a/scaleway/testdata/instance-image-block-volume.cassette.yaml
+++ b/scaleway/testdata/instance-image-block-volume.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-vol-gracious-robinson","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"b_ssd","size":20000000000}'
+    body: '{"name":"tf-vol-keen-noyce","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"b_ssd","size":20000000000}'
     form: {}
     headers:
       Content-Type:
@@ -13,22 +13,22 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes
     method: POST
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:32.827047+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:22.624626+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:32 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -38,7 +38,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bef491e-0e22-4c93-b6c1-3b3b47b7ec88
+      - ff054782-a197-4cfc-b3e7-dd9695242cb6
     status: 201 Created
     code: 201
     duration: ""
@@ -49,23 +49,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:32.827047+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:22.624626+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:33 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -75,7 +75,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b724af4-74a6-4761-adeb-9eab34708290
+      - ebc49e70-c0ce-4dc4-97ff-e0a53ce3c9e4
     status: 200 OK
     code: 200
     duration: ""
@@ -86,23 +86,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:32.827047+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:22.624626+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:33 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -112,12 +112,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 873b5ff2-47c8-4cc0-95e7-a728df4c6874
+      - 42c97ef2-ee73-473b-a0ba-bf39a09dc644
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-lucid-payne","volume_id":"5f842ff0-83d6-4688-8fac-27f3f73206b8","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
+    body: '{"name":"tf-snap-magical-lederberg","volume_id":"3aa7b17f-bb3e-487a-9d67-57e785671639","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
     form: {}
     headers:
       Content-Type:
@@ -128,25 +128,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:33.424893+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:23.209924+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "snapshotting", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8",
-      "name": "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}, "task": {"id": "57fffa11-8976-4d76-a5f8-05203ac0fe9b", "description":
+      "snapshotting", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639",
+      "name": "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details":
+      null}, "task": {"id": "ca1db699-eafa-4a67-836c-683f6be90823", "description":
       "rbd_volume_cold_snapshot", "status": "pending", "href_from": "/snapshots",
-      "href_result": "snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e", "started_at":
-      "2022-07-07T12:01:33.584887+00:00", "terminated_at": null}}'
+      "href_result": "snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "started_at":
+      "2022-07-15T12:55:23.379018+00:00", "terminated_at": null}}'
     headers:
       Content-Length:
-      - "817"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:33 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -156,7 +156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4529a457-e3b8-4a2e-aac8-4dc91047c4a6
+      - 56be1a05-76e8-415b-b806-b23f703798d8
     status: 201 Created
     code: 201
     duration: ""
@@ -167,25 +167,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:33.424893+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:23.209924+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "snapshotting", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8",
-      "name": "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
+      "snapshotting", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639",
+      "name": "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "532"
+      - "531"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:34 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -195,7 +195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d26f0eeb-3426-4e8f-a1a0-0459ad2b31e9
+      - 9a988cf7-7548-4f4d-9436-4879f7adbe2a
     status: 200 OK
     code: 200
     duration: ""
@@ -206,25 +206,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:35.073800+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:24.744002+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name":
-      "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name":
+      "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:39 GMT
+      - Fri, 15 Jul 2022 12:55:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2f9026c-eac5-41c8-ad54-49967a00d937
+      - 1de26e0e-591d-4043-a27c-fe2afc2a6bd8
     status: 200 OK
     code: 200
     duration: ""
@@ -245,25 +244,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:35.073800+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:24.744002+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name":
-      "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name":
+      "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:39 GMT
+      - Fri, 15 Jul 2022 12:55:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,12 +271,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56229d70-d29e-444b-90f8-c0d6ade8e2fb
+      - 49e2b33a-353f-4733-9ad5-16050a25acc8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test_image_basic","root_volume":"33615e12-05c5-4687-95eb-cb2cbebfe69e","arch":"x86_64","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":["tag1","tag2","tag3"]}'
+    body: '{"name":"test_image_basic","root_volume":"7c03df82-e5e7-4da1-a66d-00e6b24b74d0","arch":"x86_64","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":["tag1","tag2","tag3"]}'
     form: {}
     headers:
       Content-Type:
@@ -289,25 +287,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images
     method: POST
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_basic",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_basic",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:39.725075+00:00",
-      "modification_date": "2022-07-07T12:01:39.725075+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:28.919599+00:00",
+      "modification_date": "2022-07-15T12:55:28.919599+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["tag1", "tag2", "tag3"],
       "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "622"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:39 GMT
+      - Fri, 15 Jul 2022 12:55:29 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -317,7 +315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 606aba74-4e77-4dec-9f00-5035ad6d745d
+      - 6a55ed7f-4ad3-429e-982f-650fd9b270b5
     status: 201 Created
     code: 201
     duration: ""
@@ -328,26 +326,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_basic",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_basic",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:39.725075+00:00",
-      "modification_date": "2022-07-07T12:01:39.725075+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:28.919599+00:00",
+      "modification_date": "2022-07-15T12:55:28.919599+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["tag1", "tag2", "tag3"],
       "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "622"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:39 GMT
+      - Fri, 15 Jul 2022 12:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -357,7 +355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a09ff5bd-31ab-4bef-91d5-34892d8e7d36
+      - 88406d55-7ed9-49ab-90ee-435d780b5fa2
     status: 200 OK
     code: 200
     duration: ""
@@ -368,26 +366,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_basic",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_basic",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:39.725075+00:00",
-      "modification_date": "2022-07-07T12:01:39.725075+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:28.919599+00:00",
+      "modification_date": "2022-07-15T12:55:28.919599+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["tag1", "tag2", "tag3"],
       "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "622"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:40 GMT
+      - Fri, 15 Jul 2022 12:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,7 +395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 781176eb-d818-4e9f-9a0c-cdf7face439d
+      - 8591b920-eaa6-4b7b-b001-9167b3d6aaac
     status: 200 OK
     code: 200
     duration: ""
@@ -408,23 +406,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:35.073800+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:24.744002+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:40 GMT
+      - Fri, 15 Jul 2022 12:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a966da57-94e4-4425-92e7-a7b1f8b93265
+      - feb0804d-416b-4dd3-b3b7-4edc7642038e
     status: 200 OK
     code: 200
     duration: ""
@@ -445,25 +443,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:35.073800+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:24.744002+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name":
-      "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name":
+      "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:40 GMT
+      - Fri, 15 Jul 2022 12:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53429790-c234-48f9-923a-b11f6a3daa42
+      - d2fea86b-a2dd-4b4a-8558-a18ce9e3c665
     status: 200 OK
     code: 200
     duration: ""
@@ -484,26 +481,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_basic",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_basic",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:39.725075+00:00",
-      "modification_date": "2022-07-07T12:01:39.725075+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:28.919599+00:00",
+      "modification_date": "2022-07-15T12:55:28.919599+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["tag1", "tag2", "tag3"],
       "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "622"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:40 GMT
+      - Fri, 15 Jul 2022 12:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -513,7 +510,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff08d004-5ce3-4aa0-9452-36adc9db7143
+      - ce65918b-b40c-40b7-b169-1413ec4aabbc
     status: 200 OK
     code: 200
     duration: ""
@@ -524,23 +521,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:35.073800+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:24.744002+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:40 GMT
+      - Fri, 15 Jul 2022 12:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -550,7 +547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efb254ef-886a-4093-aa4a-4ba3f3bb0b6d
+      - a48ada33-97b1-4d9f-af48-abbdc53742c6
     status: 200 OK
     code: 200
     duration: ""
@@ -561,25 +558,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:35.073800+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:24.744002+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name":
-      "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name":
+      "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:41 GMT
+      - Fri, 15 Jul 2022 12:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -589,7 +585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e6b59d7-ed82-417f-a138-b9edc38411e7
+      - 4f9e8cc2-2210-4b02-816e-5db452106fb9
     status: 200 OK
     code: 200
     duration: ""
@@ -600,26 +596,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_basic",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_basic",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:39.725075+00:00",
-      "modification_date": "2022-07-07T12:01:39.725075+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:28.919599+00:00",
+      "modification_date": "2022-07-15T12:55:28.919599+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["tag1", "tag2", "tag3"],
       "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "622"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:41 GMT
+      - Fri, 15 Jul 2022 12:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1603977f-3a13-427c-99eb-5eb05b260774
+      - 5c53b287-848d-49c2-957a-5295f4f65745
     status: 200 OK
     code: 200
     duration: ""
@@ -640,23 +636,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:35.073800+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:24.744002+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:41 GMT
+      - Fri, 15 Jul 2022 12:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -666,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa47ad1b-3fc3-42c2-b34e-14fe33623a60
+      - 33091d6e-0ac7-4fcc-b436-ffc8163ca498
     status: 200 OK
     code: 200
     duration: ""
@@ -677,25 +673,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:35.073800+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:24.744002+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name":
-      "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name":
+      "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:42 GMT
+      - Fri, 15 Jul 2022 12:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -705,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2ee99bb-c3ad-412b-a587-2e5972152275
+      - 795c936a-7c5c-4608-b15d-a202b41935fb
     status: 200 OK
     code: 200
     duration: ""
@@ -716,26 +711,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_basic",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_basic",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:39.725075+00:00",
-      "modification_date": "2022-07-07T12:01:39.725075+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:28.919599+00:00",
+      "modification_date": "2022-07-15T12:55:28.919599+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["tag1", "tag2", "tag3"],
       "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "622"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:42 GMT
+      - Fri, 15 Jul 2022 12:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -745,7 +740,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2f65702-c38f-469d-8581-9af6deec82d7
+      - 14004af3-2245-4ddb-8ae0-f611117397fb
     status: 200 OK
     code: 200
     duration: ""
@@ -756,26 +751,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_basic",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_basic",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:39.725075+00:00",
-      "modification_date": "2022-07-07T12:01:39.725075+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:28.919599+00:00",
+      "modification_date": "2022-07-15T12:55:28.919599+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["tag1", "tag2", "tag3"],
       "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "622"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:42 GMT
+      - Fri, 15 Jul 2022 12:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -785,7 +780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9305b22f-500a-46f1-a7ec-bfeda322b74b
+      - 4be92226-a54b-4a9a-afde-9f29303b9b4e
     status: 200 OK
     code: 200
     duration: ""
@@ -796,26 +791,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_basic",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_basic",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:39.725075+00:00",
-      "modification_date": "2022-07-07T12:01:39.725075+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:28.919599+00:00",
+      "modification_date": "2022-07-15T12:55:28.919599+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["tag1", "tag2", "tag3"],
       "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "622"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:42 GMT
+      - Fri, 15 Jul 2022 12:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,12 +820,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a1f820e-e808-4040-a061-5d6999357e0a
+      - 97ceafd3-748b-4bb3-8daa-9e524b46b9a1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"zone":"nl-ams-1","id":"97fcc374-35aa-40f6-a95c-d960b076333b","name":"test_image_renamed","arch":"arm","creation_date":"2022-07-07T12:01:39.725075Z","modification_date":"2022-07-07T12:01:39.725075Z","extra_volumes":{},"organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","public":true,"root_volume":{"id":"33615e12-05c5-4687-95eb-cb2cbebfe69e","name":"tf-snap-lucid-payne","size":20000000000,"volume_type":"b_ssd"},"state":"available","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":["new
+    body: '{"zone":"nl-ams-1","id":"c06c86dc-21ce-4b2c-a452-276e7e4cb18d","name":"test_image_renamed","arch":"arm","creation_date":"2022-07-15T12:55:28.919599Z","modification_date":"2022-07-15T12:55:28.919599Z","extra_volumes":{},"organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","public":true,"root_volume":{"id":"7c03df82-e5e7-4da1-a66d-00e6b24b74d0","name":"tf-snap-magical-lederberg","size":20000000000,"volume_type":"b_ssd"},"state":"available","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":["new
       tag"]}'
     form: {}
     headers:
@@ -839,25 +834,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: PUT
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_renamed",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_renamed",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      true, "arch": "arm", "creation_date": "2022-07-07T12:01:39.725075+00:00", "modification_date":
-      "2022-07-07T12:01:42.584138+00:00", "default_bootscript": null, "from_server":
+      true, "arch": "arm", "creation_date": "2022-07-15T12:55:28.919599+00:00", "modification_date":
+      "2022-07-15T12:55:32.776638+00:00", "default_bootscript": null, "from_server":
       null, "state": "available", "tags": ["new tag"], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "607"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:42 GMT
+      - Fri, 15 Jul 2022 12:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc590d5e-ca4a-4b88-b5b6-f4d94a902aca
+      - 78542814-3bb2-4aba-983d-b4ad18ef25fc
     status: 200 OK
     code: 200
     duration: ""
@@ -878,25 +873,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_renamed",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_renamed",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      true, "arch": "arm", "creation_date": "2022-07-07T12:01:39.725075+00:00", "modification_date":
-      "2022-07-07T12:01:42.584138+00:00", "default_bootscript": null, "from_server":
+      true, "arch": "arm", "creation_date": "2022-07-15T12:55:28.919599+00:00", "modification_date":
+      "2022-07-15T12:55:32.776638+00:00", "default_bootscript": null, "from_server":
       null, "state": "available", "tags": ["new tag"], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "607"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:42 GMT
+      - Fri, 15 Jul 2022 12:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -906,7 +901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fca00ad-911c-4db3-a925-506f77d0b0ae
+      - 52abcb06-09cc-4a82-b90d-47f717758fba
     status: 200 OK
     code: 200
     duration: ""
@@ -917,25 +912,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_renamed",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_renamed",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      true, "arch": "arm", "creation_date": "2022-07-07T12:01:39.725075+00:00", "modification_date":
-      "2022-07-07T12:01:42.584138+00:00", "default_bootscript": null, "from_server":
+      true, "arch": "arm", "creation_date": "2022-07-15T12:55:28.919599+00:00", "modification_date":
+      "2022-07-15T12:55:32.776638+00:00", "default_bootscript": null, "from_server":
       null, "state": "available", "tags": ["new tag"], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "607"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:42 GMT
+      - Fri, 15 Jul 2022 12:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -945,7 +940,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5edf70d1-4399-45c9-bae3-35356cec0836
+      - 83e1451a-e32f-4faa-895e-6327fb5631c6
     status: 200 OK
     code: 200
     duration: ""
@@ -956,23 +951,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:35.073800+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:24.744002+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:43 GMT
+      - Fri, 15 Jul 2022 12:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -982,7 +977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c39aece1-efce-41eb-b3e3-92ebd3fadec8
+      - 80110f55-7c56-4566-8b74-a59e6a1155f1
     status: 200 OK
     code: 200
     duration: ""
@@ -993,25 +988,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:35.073800+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:24.744002+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name":
-      "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name":
+      "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:43 GMT
+      - Fri, 15 Jul 2022 12:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1021,7 +1015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 604ea704-dbdb-48ee-a480-b37087c470ee
+      - a8d4a522-9e41-4534-8556-4a53a2af4ac8
     status: 200 OK
     code: 200
     duration: ""
@@ -1032,25 +1026,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_renamed",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_renamed",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      true, "arch": "arm", "creation_date": "2022-07-07T12:01:39.725075+00:00", "modification_date":
-      "2022-07-07T12:01:42.584138+00:00", "default_bootscript": null, "from_server":
+      true, "arch": "arm", "creation_date": "2022-07-15T12:55:28.919599+00:00", "modification_date":
+      "2022-07-15T12:55:32.776638+00:00", "default_bootscript": null, "from_server":
       null, "state": "available", "tags": ["new tag"], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "607"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:43 GMT
+      - Fri, 15 Jul 2022 12:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d8aa077-485c-4598-9f45-b2919f9a6eae
+      - 4e1088cc-755b-48ed-af3c-1916dace1179
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,23 +1065,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:35.073800+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:24.744002+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:43 GMT
+      - Fri, 15 Jul 2022 12:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1097,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb104758-7980-48e4-a395-389e0deecd3f
+      - 527c842c-86b2-4806-b922-ee4e6e6da64d
     status: 200 OK
     code: 200
     duration: ""
@@ -1108,25 +1102,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:35.073800+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:24.744002+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name":
-      "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name":
+      "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:43 GMT
+      - Fri, 15 Jul 2022 12:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1136,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46ae1db0-d6c7-46ab-b439-7400b25f05cb
+      - 6adb6eac-d62b-4098-b5db-1c4a491a2b61
     status: 200 OK
     code: 200
     duration: ""
@@ -1147,25 +1140,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_renamed",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_renamed",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      true, "arch": "arm", "creation_date": "2022-07-07T12:01:39.725075+00:00", "modification_date":
-      "2022-07-07T12:01:42.584138+00:00", "default_bootscript": null, "from_server":
+      true, "arch": "arm", "creation_date": "2022-07-15T12:55:28.919599+00:00", "modification_date":
+      "2022-07-15T12:55:32.776638+00:00", "default_bootscript": null, "from_server":
       null, "state": "available", "tags": ["new tag"], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "607"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:43 GMT
+      - Fri, 15 Jul 2022 12:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1175,7 +1168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3d552da-286d-4304-b5d8-5b7201f00433
+      - be9e5462-b587-4059-93c2-904ca34e5d35
     status: 200 OK
     code: 200
     duration: ""
@@ -1186,25 +1179,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"image": {"id": "97fcc374-35aa-40f6-a95c-d960b076333b", "name": "test_image_renamed",
+    body: '{"image": {"id": "c06c86dc-21ce-4b2c-a452-276e7e4cb18d", "name": "test_image_renamed",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
+      "root_volume": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
       "volume_type": "b_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      true, "arch": "arm", "creation_date": "2022-07-07T12:01:39.725075+00:00", "modification_date":
-      "2022-07-07T12:01:42.584138+00:00", "default_bootscript": null, "from_server":
+      true, "arch": "arm", "creation_date": "2022-07-15T12:55:28.919599+00:00", "modification_date":
+      "2022-07-15T12:55:32.776638+00:00", "default_bootscript": null, "from_server":
       null, "state": "available", "tags": ["new tag"], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "607"
+      - "613"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:43 GMT
+      - Fri, 15 Jul 2022 12:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1214,7 +1207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be2bb507-5bff-45fa-8b76-4a9e051df134
+      - 34304bdf-e082-40b9-ad6c-956b1d9256d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1225,7 +1218,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: DELETE
   response:
     body: ""
@@ -1233,7 +1226,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:01:44 GMT
+      - Fri, 15 Jul 2022 12:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1243,7 +1236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c5b71fe-368c-458a-889e-a6c73b3fac32
+      - 38a1ead3-c7e7-4b9d-bf06-a4b3ea6816d7
     status: 204 No Content
     code: 204
     duration: ""
@@ -1254,10 +1247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"97fcc374-35aa-40f6-a95c-d960b076333b\"
+    body: '{"type": "unknown_resource", "message": "\"c06c86dc-21ce-4b2c-a452-276e7e4cb18d\"
       not found"}'
     headers:
       Content-Length:
@@ -1267,7 +1260,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:44 GMT
+      - Fri, 15 Jul 2022 12:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1277,7 +1270,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca754da5-b107-42c6-ae54-e3d76b562e5c
+      - 5b412fc5-9ee8-4198-817f-199f5d910bc6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1288,25 +1281,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"snapshot": {"id": "33615e12-05c5-4687-95eb-cb2cbebfe69e", "name": "tf-snap-lucid-payne",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:33.424893+00:00",
-      "modification_date": "2022-07-07T12:01:35.073800+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "7c03df82-e5e7-4da1-a66d-00e6b24b74d0", "name": "tf-snap-magical-lederberg",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:23.209924+00:00",
+      "modification_date": "2022-07-15T12:55:24.744002+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name":
-      "tf-vol-gracious-robinson"}, "tags": [], "zone": "nl-ams-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name":
+      "tf-vol-keen-noyce"}, "tags": [], "zone": "nl-ams-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:44 GMT
+      - Fri, 15 Jul 2022 12:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1316,7 +1308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77116a98-6319-454d-8e35-b6e4882979a7
+      - 31488226-b0fd-402f-b1f7-18fadad82e31
     status: 200 OK
     code: 200
     duration: ""
@@ -1327,7 +1319,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: DELETE
   response:
     body: ""
@@ -1335,7 +1327,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:01:44 GMT
+      - Fri, 15 Jul 2022 12:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1345,7 +1337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 107deac1-b84c-4ce7-baef-a1efbcb051e6
+      - bbae2e2f-0aa1-4b42-8cd9-496d7213ca0b
     status: 204 No Content
     code: 204
     duration: ""
@@ -1356,10 +1348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"33615e12-05c5-4687-95eb-cb2cbebfe69e\"
+    body: '{"type": "unknown_resource", "message": "\"7c03df82-e5e7-4da1-a66d-00e6b24b74d0\"
       not found"}'
     headers:
       Content-Length:
@@ -1369,7 +1361,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:44 GMT
+      - Fri, 15 Jul 2022 12:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1379,7 +1371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9debc78-800d-4fd1-8d82-8cc3476c209e
+      - 630fa775-772c-49e3-97be-99c63f987d33
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1390,23 +1382,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"volume": {"id": "5f842ff0-83d6-4688-8fac-27f3f73206b8", "name": "tf-vol-gracious-robinson",
+    body: '{"volume": {"id": "3aa7b17f-bb3e-487a-9d67-57e785671639", "name": "tf-vol-keen-noyce",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:32.827047+00:00", "modification_date":
-      "2022-07-07T12:01:35.073800+00:00", "tags": [], "zone": "nl-ams-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.624626+00:00", "modification_date":
+      "2022-07-15T12:55:24.744002+00:00", "tags": [], "zone": "nl-ams-1"}}'
     headers:
       Content-Length:
-      - "446"
+      - "439"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:44 GMT
+      - Fri, 15 Jul 2022 12:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1416,7 +1408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3edf758c-1333-41f1-9a75-fed756b5ec65
+      - 981fc0d3-945f-486c-bac4-05c536a4e63c
     status: 200 OK
     code: 200
     duration: ""
@@ -1427,7 +1419,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: DELETE
   response:
     body: ""
@@ -1435,7 +1427,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:01:45 GMT
+      - Fri, 15 Jul 2022 12:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1445,7 +1437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5ba6773-42f7-4552-aa17-020aecd18b7d
+      - 5fccf2ec-3e1c-45fc-b035-abda422b8a94
     status: 204 No Content
     code: 204
     duration: ""
@@ -1456,10 +1448,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/97fcc374-35aa-40f6-a95c-d960b076333b
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/c06c86dc-21ce-4b2c-a452-276e7e4cb18d
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"97fcc374-35aa-40f6-a95c-d960b076333b\"
+    body: '{"type": "unknown_resource", "message": "\"c06c86dc-21ce-4b2c-a452-276e7e4cb18d\"
       not found"}'
     headers:
       Content-Length:
@@ -1469,7 +1461,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:45 GMT
+      - Fri, 15 Jul 2022 12:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1479,7 +1471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e112957-9f9b-4e62-8c77-22a0c2de8f79
+      - 826e468d-3137-4db2-81b1-1dec478937d2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1490,10 +1482,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/33615e12-05c5-4687-95eb-cb2cbebfe69e
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/7c03df82-e5e7-4da1-a66d-00e6b24b74d0
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"33615e12-05c5-4687-95eb-cb2cbebfe69e\"
+    body: '{"type": "unknown_resource", "message": "\"7c03df82-e5e7-4da1-a66d-00e6b24b74d0\"
       not found"}'
     headers:
       Content-Length:
@@ -1503,7 +1495,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:45 GMT
+      - Fri, 15 Jul 2022 12:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1513,7 +1505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55ac35fd-3ab1-4bf0-8f38-deed0b327373
+      - 415cb29e-0098-4292-8ea9-67e4af8af9d1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1524,10 +1516,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/5f842ff0-83d6-4688-8fac-27f3f73206b8
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/3aa7b17f-bb3e-487a-9d67-57e785671639
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "Volume ''5f842ff0-83d6-4688-8fac-27f3f73206b8''
+    body: '{"type": "unknown_resource", "message": "Volume ''3aa7b17f-bb3e-487a-9d67-57e785671639''
       not found."}'
     headers:
       Content-Length:
@@ -1537,7 +1529,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:45 GMT
+      - Fri, 15 Jul 2022 12:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1547,7 +1539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 447dfddf-5ac0-486a-9b6e-3972b1f0acbd
+      - bfa47a51-1a80-489f-9f7f-9d827d8af28e
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-image-server-with-block-volume.cassette.yaml
+++ b/scaleway/testdata/instance-image-server-with-block-volume.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-vol-sad-jones","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"b_ssd","size":21000000000}'
+    body: '{"name":"tf-vol-gallant-dewdney","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"b_ssd","size":21000000000}'
     form: {}
     headers:
       Content-Type:
@@ -13,22 +13,22 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:55.696244+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:22.601116+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:55 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -38,7 +38,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d255c4c-f775-4969-a1fe-f141f96c658a
+      - e362ae99-0913-4570-9f30-948e4b2fc29a
     status: 201 Created
     code: 201
     duration: ""
@@ -49,23 +49,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: GET
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:55.696244+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:22.601116+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:55 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -75,7 +75,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df01a1e3-5606-43b7-abcb-d30aa16836b0
+      - bcf8ec2a-50ef-464e-ac3a-f924a2c55dc5
     status: 200 OK
     code: 200
     duration: ""
@@ -86,23 +86,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: GET
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:55.696244+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:22.601116+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:56 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -112,7 +112,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aae8b359-527c-496e-ad65-bee19f34bb89
+      - 5f4581d0-db6d-4b09-825e-ad9053683804
     status: 200 OK
     code: 200
     duration: ""
@@ -828,46 +828,46 @@ interactions:
       "Rocky Linux 8", "label": "rockylinux_8", "logo": "https://marketplace-logos.s3.nl-ams.scw.cloud/rockylinux.png",
       "description": "Rocky Linux is a community-driven effort to bring you enterprise-grade,
       production-ready Linux.", "organization": {"id": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "name": "Instances User Resources Build System"}, "versions": [{"id": "8c94a517-442e-448c-80e1-57c3c9a9a92f",
-      "name": "2022-06-15T14:40:42.854386+00:00", "local_images": [{"id": "47b9dce8-fb9b-48a1-a416-5d5847086952",
-      "zone": "pl-waw-1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "9194c6b5-9062-4e95-809e-74c3c40baca3",
+      "name": "Instances User Resources Build System"}, "versions": [{"id": "8ad85252-b11b-404e-bfe3-a0652722d3c0",
+      "name": "2022-07-11T08:48:40.108217+00:00", "local_images": [{"id": "ad2f008b-a159-402a-9677-8c0a16b25fc4",
       "zone": "fr-par-3", "arch": "x86_64", "compatible_commercial_types": ["GP1-L",
       "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M", "START1-S", "START1-XS",
       "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S",
       "ENT1-M", "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S",
-      "PRO2-M", "PRO2-L", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "97e3f42f-9d81-4702-ad49-35946748fd86",
-      "zone": "ams1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
-      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "fab3df2d-1631-45fc-aecc-2c1ce23310c9",
+      "PRO2-M", "PRO2-L", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "af0e5949-58a2-45f3-bda9-5919ef45c309",
       "zone": "nl-ams-2", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
       "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
       "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
       "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
       "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "8adde02e-eec5-4f62-9db9-aa9bdcaace9b",
-      "zone": "par1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
-      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "a660dcf6-12fe-4562-ac5c-26ae3e7b146f",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "40927774-00c4-421b-ade6-e608796f4321",
       "zone": "fr-par-2", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
       "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
       "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
       "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
       "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}], "creation_date": "2022-06-15T14:40:42.919695+00:00",
-      "modification_date": "2022-06-15T14:40:42.919695+00:00"}], "categories": ["distribution"],
-      "current_public_version": "8c94a517-442e-448c-80e1-57c3c9a9a92f", "creation_date":
-      "2021-06-25T10:16:16.254240+00:00", "modification_date": "2022-06-20T08:54:15.619535+00:00",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "454429e7-d794-4cb8-9831-85e60a1825c0",
+      "zone": "pl-waw-1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "34d14210-007a-43c0-9e56-d1548998ae80",
+      "zone": "ams1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "bbb2da3b-5de5-48a2-b6be-0df60a28d84a",
+      "zone": "par1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}], "creation_date": "2022-07-11T08:48:40.175715+00:00",
+      "modification_date": "2022-07-11T08:48:40.175715+00:00"}], "categories": ["distribution"],
+      "current_public_version": "8ad85252-b11b-404e-bfe3-a0652722d3c0", "creation_date":
+      "2021-06-25T10:16:16.254240+00:00", "modification_date": "2022-07-12T09:03:50.736296+00:00",
       "valid_until": null}, {"id": "3f1b9623-71ba-4fe3-b994-27fcdaa850ba", "name":
       "Ubuntu 20.04 Focal Fossa", "label": "ubuntu_focal", "logo": "https://marketplace-logos.s3.nl-ams.scw.cloud/ubuntu.png",
       "description": "Ubuntu is the ideal distribution for scale-out computing, Ubuntu
@@ -1044,7 +1044,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:55 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Link:
       - </images?page=1&per_page=50&>; rel="last"
       Server:
@@ -1056,7 +1056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 485a91a5-f53c-49a3-a27d-96bd39bd53af
+      - 83015bd1-4bfd-4435-9c81-3ceb64c70659
       X-Total-Count:
       - "23"
     status: 200 OK
@@ -1400,7 +1400,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:56 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="last"
       Server:
@@ -1412,14 +1412,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dc47469-9e9a-400a-b096-7d044e8f6153
+      - bf1985bb-2ace-4a0a-b1cb-1ff52e3f8c7b
       X-Total-Count:
       - "36"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-relaxed-mccarthy","volume_id":"b7d4e727-7c7e-412e-96ea-9fc67ca1a579","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
+    body: '{"name":"tf-snap-competent-minsky","volume_id":"a57e04ac-6f7b-4938-800c-2de850110934","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
     form: {}
     headers:
       Content-Type:
@@ -1430,25 +1430,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:56.220553+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:22.997411+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "snapshotting", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579",
-      "name": "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "92c3d6ce-d39d-4a93-9881-26954fb3ea6e", "description":
+      "snapshotting", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934",
+      "name": "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "bb6691b7-6882-4d27-b3f4-c585e781f894", "description":
       "rbd_volume_cold_snapshot", "status": "pending", "href_from": "/snapshots",
-      "href_result": "snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e", "started_at":
-      "2022-07-07T12:01:56.378173+00:00", "terminated_at": null}}'
+      "href_result": "snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01", "started_at":
+      "2022-07-15T12:55:23.191860+00:00", "terminated_at": null}}'
     headers:
       Content-Length:
-      - "814"
+      - "820"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:56 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3baabe40-eea6-4dfb-bd68-31bfa5b7005b
+      - 2d2c60d3-6830-41db-8abf-4355b75f827f
     status: 201 Created
     code: 201
     duration: ""
@@ -1469,25 +1469,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:56.220553+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:22.997411+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "snapshotting", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579",
-      "name": "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "snapshotting", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934",
+      "name": "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "529"
+      - "535"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:56 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1497,12 +1497,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8690899d-10e5-41b5-83f3-dbfbc0643bd0
+      - e2ff403b-c3e5-4a0c-9886-a18f2ed4e7ef
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-tender-rhodes","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"881d7a33-4cfa-4046-b5cf-c33cb9c62fb6","volumes":{"0":{"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    body: '{"name":"tf-srv-sharp-turing","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"881d7a33-4cfa-4046-b5cf-c33cb9c62fb6","volumes":{"0":{"name":"tf-vol-loving-allen","size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
     form: {}
     headers:
       Content-Type:
@@ -1513,26 +1513,26 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -1544,15 +1544,15 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2541"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:56 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,7 +1562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3f018ec-a6b3-43a7-906e-384c38298cc2
+      - 2a6c0b9b-38a5-4ff6-bc5d-2f3dc8b6a90d
     status: 201 Created
     code: 201
     duration: ""
@@ -1573,29 +1573,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -1607,13 +1607,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2541"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:57 GMT
+      - Fri, 15 Jul 2022 12:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c44e38ee-bb24-47f2-84b7-f096a585c067
+      - 29ff2a2d-df5b-471f-8e79-04e88883fa3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,29 +1634,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -1668,13 +1668,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2541"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:57 GMT
+      - Fri, 15 Jul 2022 12:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1684,9 +1684,49 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fadea9f-0983-412b-886e-89a64a89bb02
+      - 62e9f7e6-d13c-434c-a16b-3e63cc3eaf8c
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: '{"action":"poweron"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/action
+    method: POST
+  response:
+    body: '{"task": {"id": "59717d04-20b4-4abe-899d-43efd4cbd4a4", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/b0fba900-420c-439d-b3a8-93b55393dc70/action",
+      "href_result": "/servers/b0fba900-420c-439d-b3a8-93b55393dc70", "started_at":
+      "2022-07-15T12:55:24.669942+00:00", "terminated_at": null}}'
+    headers:
+      Content-Length:
+      - "322"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:24 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/59717d04-20b4-4abe-899d-43efd4cbd4a4
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44c60a34-8f12-470b-9f9f-9ecea3aa1a31
+    status: 202 Accepted
+    code: 202
     duration: ""
 - request:
     body: ""
@@ -1695,29 +1735,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:24.255649+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -1725,17 +1765,17 @@ interactions:
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
       "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2563"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:57 GMT
+      - Fri, 15 Jul 2022 12:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1745,7 +1785,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 963fe42f-b376-4999-bb66-4a2079260bf9
+      - 9a145285-0012-4686-814b-31e4278445ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1756,7 +1796,272 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e2ba9263-ff07-4c56-b242-217c32925c80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5f809372-95de-4a2e-b4f0-ebe1e9a08139
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "ipv6": null, "extra_networks": [],
+      "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": "10.69.56.19",
+      "creation_date": "2022-07-15T12:55:23.365465+00:00", "modification_date": "2022-07-15T12:55:24.255649+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 545744c7-93ac-4961-ae0f-8a5b14bf08c3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:31.871127+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2703"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - adbcf86c-c7f2-4f48-a2a1-388e79ec7dba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:23.365465+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:31.871127+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2703"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb00f1f6-ace6-4225-98c6-9846cd19f894
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -1768,7 +2073,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:57 GMT
+      - Fri, 15 Jul 2022 12:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1778,7 +2083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37e39733-1398-471a-80fc-8202daf7978d
+      - adabc583-9f66-463a-a6b0-b47ab04989d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1789,7 +2094,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -1801,7 +2106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:57 GMT
+      - Fri, 15 Jul 2022 12:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1811,12 +2116,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aadb519e-ae6b-4355-a55d-79d604362e70
+      - a89fb434-b649-432f-b934-ab550ab06218
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-focused-haibt","volume_id":"c72fab5a-a8b2-47cc-9971-c735be2088b9","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
+    body: '{"name":"tf-snap-musing-chatterjee","volume_id":"d0633bbe-673b-4ad0-84f4-7c74a8b97b90","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
     form: {}
     headers:
       Content-Type:
@@ -1827,24 +2132,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:35.819780+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "965753da-cd8c-4ce3-b45e-a9e85c3775a4", "description":
-      "nop", "status": "pending", "href_from": "/snapshots", "href_result": "snapshots/9668f07a-4203-4f95-9058-21f810df6f0f",
-      "started_at": "2022-07-07T12:01:58.211391+00:00", "terminated_at": null}}'
+      "snapshotting", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "57a6140a-1d71-4eeb-85dc-293b7dade023", "description":
+      "volume_hot_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/64e63318-8269-447d-a528-6b1fe74cfb90", "started_at": "2022-07-15T12:55:36.017783+00:00",
+      "terminated_at": null}}'
     headers:
       Content-Length:
-      - "804"
+      - "813"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:58 GMT
+      - Fri, 15 Jul 2022 12:55:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +2160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8d2fbc7-7dfa-4395-8153-13865e0d6a1c
+      - 81588632-a5aa-4552-a22a-6a9863df4f81
     status: 201 Created
     code: 201
     duration: ""
@@ -1865,25 +2171,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:35.819780+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "snapshotting", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "540"
+      - "533"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:58 GMT
+      - Fri, 15 Jul 2022 12:55:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1893,7 +2199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbe25e03-30c2-4715-a7ea-6e146d07f37c
+      - 5aa40d35-26a6-48fe-945c-1febdb31c508
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,25 +2210,101 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90", "name":
+      "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+    headers:
+      Content-Length:
+      - "530"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 277fa1fc-9b8b-4825-a595-f03d2527058c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90", "name":
+      "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+    headers:
+      Content-Length:
+      - "530"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90dfd7d2-02be-4562-9bfe-261ded2e7a30
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "540"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:58 GMT
+      - Fri, 15 Jul 2022 12:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1932,126 +2314,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70b387d2-47ce-49e8-ba51-a53e1b2507e9
+      - 85f9ac8d-2b0f-4ca4-9fe3-38461e2415ff
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "526"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:02:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b3f20584-c9f8-4c96-9fa1-ef5a6b6f1eb1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "526"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:02:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 451fc52c-a4c2-4939-a457-ddbb738d6edf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "526"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:02:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4c09f1fb-e9d5-40f4-b59e-9bbf8a08fd9a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-image-objective-sanderson","root_volume":"9668f07a-4203-4f95-9058-21f810df6f0f","arch":"x86_64","extra_volumes":{"1":{"id":"f026442f-5ba3-4945-a14d-9653e4a01d6e","name":"tf-vol-sad-jones","size":21000000000,"volume_type":"b_ssd"}},"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    body: '{"name":"tf-image-competent-rosalind","root_volume":"64e63318-8269-447d-a528-6b1fe74cfb90","arch":"x86_64","extra_volumes":{"1":{"id":"5dc08c79-a968-4aeb-b1e6-b159e7176e01","name":"tf-vol-gallant-dewdney","size":21000000000,"volume_type":"b_ssd"}},"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
     form: {}
     headers:
       Content-Type:
@@ -2062,26 +2330,26 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
     method: POST
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
+      "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
       "volume_type": "b_ssd", "size": 21000000000}}, "public": false, "arch": "x86_64",
-      "creation_date": "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "creation_date": "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "746"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:02 GMT
+      - Fri, 15 Jul 2022 12:55:41 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4de3ea0f-dbd1-4a54-a0f5-bd90a81692f8
+      - cb8c2c25-e7ec-46fb-8ca6-c6de6a68e519
     status: 201 Created
     code: 201
     duration: ""
@@ -2102,27 +2370,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
+      "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
       "volume_type": "b_ssd", "size": 21000000000}}, "public": false, "arch": "x86_64",
-      "creation_date": "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "creation_date": "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "746"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:02 GMT
+      - Fri, 15 Jul 2022 12:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2132,7 +2400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da05036c-75b5-40e4-982d-ba3051f57022
+      - a1c00b7c-018b-4a2c-85c7-930bb5cb4130
     status: 200 OK
     code: 200
     duration: ""
@@ -2143,27 +2411,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
+      "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
       "volume_type": "b_ssd", "size": 21000000000}}, "public": false, "arch": "x86_64",
-      "creation_date": "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "creation_date": "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "746"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:02 GMT
+      - Fri, 15 Jul 2022 12:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2173,7 +2441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15269179-2b87-4cf1-8870-78fd8d512b83
+      - f20870bc-b493-4e46-83d6-a46c621200ee
     status: 200 OK
     code: 200
     duration: ""
@@ -2184,23 +2452,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: GET
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:59.715029+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:26.425300+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:02 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2210,7 +2478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbbc674a-b9e6-43d9-bbea-64ec627d4977
+      - ecdc55cb-a8e4-4f60-9e8a-b0894f0be4d6
     status: 200 OK
     code: 200
     duration: ""
@@ -2221,47 +2489,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:31.871127+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:02 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2271,7 +2540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7269e8d1-b5dd-4732-b69c-b4560e695c0e
+      - 4fcd6d0d-d5bb-428b-8e46-c22699da57d3
     status: 200 OK
     code: 200
     duration: ""
@@ -2282,63 +2551,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "526"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 09dfe194-8b89-4799-9519-9c716985e368
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "540"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2348,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26236198-6d22-489d-a51d-a6e9f9767f2d
+      - 2e1594dc-854e-4ed4-9a61-eafce63233df
     status: 200 OK
     code: 200
     duration: ""
@@ -2359,27 +2590,65 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90", "name":
+      "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+    headers:
+      Content-Length:
+      - "530"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82650c85-b7c5-498d-858e-e69c76bb9fdc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
+    method: GET
+  response:
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
+      "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
       "volume_type": "b_ssd", "size": 21000000000}}, "public": false, "arch": "x86_64",
-      "creation_date": "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "creation_date": "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "746"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2389,7 +2658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81832856-9901-4e26-bb26-ff37711b00b8
+      - 79ccc0c4-93af-4eb2-8657-3ac3c9ac075b
     status: 200 OK
     code: 200
     duration: ""
@@ -2400,23 +2669,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: GET
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:59.715029+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:26.425300+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2426,7 +2695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 734e10cb-eae8-4894-9f67-9facf00a0928
+      - 39e59739-41eb-469b-90a1-3c612d769033
     status: 200 OK
     code: 200
     duration: ""
@@ -2437,24 +2706,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
     headers:
       Content-Length:
-      - "526"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2464,7 +2734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ce39c6d-c45e-49c4-a13c-3e2ce51a2870
+      - 975db32c-a645-4319-9d7a-52064e4dcdf4
     status: 200 OK
     code: 200
     duration: ""
@@ -2475,47 +2745,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:31.871127+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2525,7 +2796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62349b65-8a8e-43c8-9104-81648ad77d09
+      - e31c3392-96b4-425e-8225-61c1ff47682e
     status: 200 OK
     code: 200
     duration: ""
@@ -2536,7 +2807,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -2548,7 +2819,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2558,7 +2829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35647810-6c63-4ed8-a758-cbe9bcd29a7f
+      - c0bc0afa-716f-4359-8d10-bd43c5a827b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2569,7 +2840,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -2581,7 +2852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2591,7 +2862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a35e3b06-f099-4e54-b4ae-80b4d72f1376
+      - 82567bc8-0e5c-443c-8dc5-29f872f05e23
     status: 200 OK
     code: 200
     duration: ""
@@ -2602,25 +2873,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90", "name":
+      "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "540"
+      - "530"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:03 GMT
+      - Fri, 15 Jul 2022 12:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2630,7 +2900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1ec9417-583d-4811-a721-669735e581c4
+      - b5eb2cde-7d2a-4429-b692-3e709f05687a
     status: 200 OK
     code: 200
     duration: ""
@@ -2641,27 +2911,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
+      "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
       "volume_type": "b_ssd", "size": 21000000000}}, "public": false, "arch": "x86_64",
-      "creation_date": "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "creation_date": "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "746"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:04 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2671,7 +2941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c20a5e22-e116-4a48-931a-0b6c5583c70e
+      - dfe19932-3cac-425e-a2cf-01c940429d17
     status: 200 OK
     code: 200
     duration: ""
@@ -2682,23 +2952,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: GET
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:59.715029+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:26.425300+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:04 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2708,7 +2978,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08c3f473-e049-49bf-b471-04794d2f90d2
+      - 7eb3efd2-5a5c-430c-922b-cd36a254c0fc
     status: 200 OK
     code: 200
     duration: ""
@@ -2719,24 +2989,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
     headers:
       Content-Length:
-      - "526"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:04 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2746,7 +3017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fb9cc56-e235-4631-a43c-c6cc14d16c63
+      - 3295ca30-e4bf-4429-b3b0-4a5072f2cbfe
     status: 200 OK
     code: 200
     duration: ""
@@ -2757,47 +3028,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:31.871127+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:04 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2807,7 +3079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8132e2e-7b06-4966-98ba-06c86cf59e8d
+      - 27c3e6d4-5050-4694-ad22-632bde9e3414
     status: 200 OK
     code: 200
     duration: ""
@@ -2818,7 +3090,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -2830,7 +3102,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:04 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2840,7 +3112,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0542a58f-f7b6-4fe4-a54a-721faf4cfde5
+      - 1f812e5f-4141-4c54-9701-a9b793abe01e
     status: 200 OK
     code: 200
     duration: ""
@@ -2851,7 +3123,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -2863,7 +3135,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:04 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2873,7 +3145,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43e364d7-3d87-4e04-ad7f-cbdadc3e0a27
+      - cd300627-c34b-4b0e-bfdb-d7f7d9847b53
     status: 200 OK
     code: 200
     duration: ""
@@ -2884,25 +3156,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90", "name":
+      "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "540"
+      - "530"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:04 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2912,7 +3183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33e4adba-da94-40de-9855-66f38dd6ce51
+      - 762a7987-e274-4b19-81ea-dc9a8c4610d2
     status: 200 OK
     code: 200
     duration: ""
@@ -2923,27 +3194,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
+      "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
       "volume_type": "b_ssd", "size": 21000000000}}, "public": false, "arch": "x86_64",
-      "creation_date": "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "creation_date": "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "746"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:04 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2953,12 +3224,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d962a504-4706-44a2-85a9-3f5e73eaacfe
+      - e7ec0301-4d1b-4f74-9f92-9a7fb09da75c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-vol-magical-brahmagupta","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"b_ssd","size":22000000000}'
+    body: '{"name":"tf-vol-pedantic-babbage","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"b_ssd","size":22000000000}'
     form: {}
     headers:
       Content-Type:
@@ -2969,22 +3240,22 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name": "tf-vol-magical-brahmagupta",
+    body: '{"volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name": "tf-vol-pedantic-babbage",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 22000000000,
-      "state": "available", "creation_date": "2022-07-07T12:02:04.898311+00:00", "modification_date":
-      "2022-07-07T12:02:04.898311+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:43.829475+00:00", "modification_date":
+      "2022-07-15T12:55:43.829475+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "448"
+      - "445"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:05 GMT
+      - Fri, 15 Jul 2022 12:55:43 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6f49dbb-6ae4-4567-8607-4b85743d93ac
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4d67bf5c-7965-4534-a3bf-4426847cfbbf
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2994,7 +3265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a75ca464-d83f-415a-a5a3-2314d2e1790b
+      - 7e66c35b-5e99-48f8-9eb6-e09b689e9e40
     status: 201 Created
     code: 201
     duration: ""
@@ -3005,23 +3276,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6f49dbb-6ae4-4567-8607-4b85743d93ac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4d67bf5c-7965-4534-a3bf-4426847cfbbf
     method: GET
   response:
-    body: '{"volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name": "tf-vol-magical-brahmagupta",
+    body: '{"volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name": "tf-vol-pedantic-babbage",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 22000000000,
-      "state": "available", "creation_date": "2022-07-07T12:02:04.898311+00:00", "modification_date":
-      "2022-07-07T12:02:04.898311+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:43.829475+00:00", "modification_date":
+      "2022-07-15T12:55:43.829475+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "448"
+      - "445"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:05 GMT
+      - Fri, 15 Jul 2022 12:55:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3031,7 +3302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e39c8576-be37-4dc3-8e88-444baa685a23
+      - 77a5f651-b284-42d7-a101-0b9afe7ad40b
     status: 200 OK
     code: 200
     duration: ""
@@ -3042,23 +3313,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6f49dbb-6ae4-4567-8607-4b85743d93ac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4d67bf5c-7965-4534-a3bf-4426847cfbbf
     method: GET
   response:
-    body: '{"volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name": "tf-vol-magical-brahmagupta",
+    body: '{"volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name": "tf-vol-pedantic-babbage",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 22000000000,
-      "state": "available", "creation_date": "2022-07-07T12:02:04.898311+00:00", "modification_date":
-      "2022-07-07T12:02:04.898311+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:43.829475+00:00", "modification_date":
+      "2022-07-15T12:55:43.829475+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "448"
+      - "445"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:05 GMT
+      - Fri, 15 Jul 2022 12:55:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3068,12 +3339,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d87db6fb-89ef-4eca-8f70-364937f95dbb
+      - ccce7d70-6ffa-4234-b3b8-8b56065fa50b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-elastic-bouman","volume_id":"f6f49dbb-6ae4-4567-8607-4b85743d93ac","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
+    body: '{"name":"tf-snap-gallant-burnell","volume_id":"4d67bf5c-7965-4534-a3bf-4426847cfbbf","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
     form: {}
     headers:
       Content-Type:
@@ -3084,25 +3355,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:02:05.356527+00:00",
-      "modification_date": "2022-07-07T12:02:05.356527+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:44.251195+00:00",
+      "modification_date": "2022-07-15T12:55:44.251195+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
-      "snapshotting", "base_volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac",
-      "name": "tf-vol-magical-brahmagupta"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "133c2cf2-e01e-4843-b008-84fe48e8d070", "description":
+      "snapshotting", "base_volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf",
+      "name": "tf-vol-pedantic-babbage"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "e065ba72-3f7f-4ad6-b6b2-41e5a5133700", "description":
       "rbd_volume_cold_snapshot", "status": "pending", "href_from": "/snapshots",
-      "href_result": "snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c", "started_at":
-      "2022-07-07T12:02:05.546369+00:00", "terminated_at": null}}'
+      "href_result": "snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688", "started_at":
+      "2022-07-15T12:55:44.438798+00:00", "terminated_at": null}}'
     headers:
       Content-Length:
-      - "822"
+      - "820"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:05 GMT
+      - Fri, 15 Jul 2022 12:55:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3112,7 +3383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55c8ae86-7242-4d52-a806-565d8317ae5d
+      - 4ffee2f3-df7d-4b38-8827-5043051fe36f
     status: 201 Created
     code: 201
     duration: ""
@@ -3123,25 +3394,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"snapshot": {"id": "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:02:05.356527+00:00",
-      "modification_date": "2022-07-07T12:02:05.356527+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:44.251195+00:00",
+      "modification_date": "2022-07-15T12:55:44.251195+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
-      "snapshotting", "base_volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac",
-      "name": "tf-vol-magical-brahmagupta"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "snapshotting", "base_volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf",
+      "name": "tf-vol-pedantic-babbage"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "537"
+      - "535"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:05 GMT
+      - Fri, 15 Jul 2022 12:55:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3151,7 +3422,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5893fd48-8123-4067-b9ce-261f86b600b5
+      - 0e9e7780-2cc2-41ae-b6f8-e5e0c3617575
     status: 200 OK
     code: 200
     duration: ""
@@ -3162,25 +3433,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"snapshot": {"id": "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:02:05.356527+00:00",
-      "modification_date": "2022-07-07T12:02:08.654129+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:44.251195+00:00",
+      "modification_date": "2022-07-15T12:55:48.133774+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
-      "available", "base_volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name":
-      "tf-vol-magical-brahmagupta"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name":
+      "tf-vol-pedantic-babbage"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "534"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:10 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3190,7 +3461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea604441-4e68-4381-bdeb-4d911b3f7fc1
+      - a750fad2-e471-48a4-b0ba-238b72e197f6
     status: 200 OK
     code: 200
     duration: ""
@@ -3201,25 +3472,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"snapshot": {"id": "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:02:05.356527+00:00",
-      "modification_date": "2022-07-07T12:02:08.654129+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:44.251195+00:00",
+      "modification_date": "2022-07-15T12:55:48.133774+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
-      "available", "base_volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name":
-      "tf-vol-magical-brahmagupta"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name":
+      "tf-vol-pedantic-babbage"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "534"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:10 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3229,7 +3500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e4440bc-7ddf-47da-8329-efb37ce812d4
+      - 2de6eab7-41c2-419a-8a0e-0fe405a3b9f8
     status: 200 OK
     code: 200
     duration: ""
@@ -3240,27 +3511,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
+      "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
       "volume_type": "b_ssd", "size": 21000000000}}, "public": false, "arch": "x86_64",
-      "creation_date": "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "creation_date": "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "746"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3270,7 +3541,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3071f8c-4cc7-414b-86e1-9dc0837d89eb
+      - 677cfa48-f899-4061-89e4-56d90b029bad
     status: 200 OK
     code: 200
     duration: ""
@@ -3281,25 +3552,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"snapshot": {"id": "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:02:05.356527+00:00",
-      "modification_date": "2022-07-07T12:02:08.654129+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:44.251195+00:00",
+      "modification_date": "2022-07-15T12:55:48.133774+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
-      "available", "base_volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name":
-      "tf-vol-magical-brahmagupta"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name":
+      "tf-vol-pedantic-babbage"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "534"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1406a238-65d1-4942-88ac-b1e36a36ee3f
+      - 32889da7-428e-40d5-b7de-c59ca31d2d3e
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,27 +3591,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
+      "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
       "volume_type": "b_ssd", "size": 21000000000}}, "public": false, "arch": "x86_64",
-      "creation_date": "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "creation_date": "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "746"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3350,12 +3621,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6188486d-e8c9-4789-a5d3-2368a9d80300
+      - 2184c7e5-5e01-4347-8140-e4a602afda33
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"zone":"fr-par-1","id":"259ffafb-76de-4d27-b3dd-7cdedc93c03a","name":"tf-image-objective-sanderson","arch":"x86_64","creation_date":"2022-07-07T12:02:02.074745Z","modification_date":"2022-07-07T12:02:02.074745Z","extra_volumes":{"1":{"id":"d44001b9-7442-4f7f-bc63-1cef88b3552c","name":"tf-vol-magical-brahmagupta","size":22000000000,"volume_type":"b_ssd"}},"organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","public":false,"root_volume":{"id":"9668f07a-4203-4f95-9058-21f810df6f0f","name":"tf-snap-focused-haibt","size":20000000000,"volume_type":"l_ssd"},"state":"available","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[]}'
+    body: '{"zone":"fr-par-1","id":"8ecf540f-82b6-480e-a4bc-1c2d15ca67f3","name":"tf-image-competent-rosalind","arch":"x86_64","creation_date":"2022-07-15T12:55:41.521778Z","modification_date":"2022-07-15T12:55:41.521778Z","extra_volumes":{"1":{"id":"2f7999b3-7fce-4e74-b64f-51568bd15688","name":"tf-vol-pedantic-babbage","size":22000000000,"volume_type":"b_ssd"}},"organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","public":false,"root_volume":{"id":"64e63318-8269-447d-a528-6b1fe74cfb90","name":"tf-snap-musing-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[]}'
     form: {}
     headers:
       Content-Type:
@@ -3363,27 +3634,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: PUT
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman", "volume_type":
+      "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell", "volume_type":
       "b_ssd", "size": 22000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "744"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3393,7 +3664,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fecd333-4096-4382-9ae2-7d2634c44c88
+      - 278cace8-cede-4bfe-a8dd-187ff636ab64
     status: 200 OK
     code: 200
     duration: ""
@@ -3404,27 +3675,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman", "volume_type":
+      "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell", "volume_type":
       "b_ssd", "size": 22000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "744"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3434,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e2a57c5-3dd9-4cf8-a10f-900b48af231f
+      - 0002c171-a7e4-4386-b4db-361a32a8e6fe
     status: 200 OK
     code: 200
     duration: ""
@@ -3445,27 +3716,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman", "volume_type":
+      "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell", "volume_type":
       "b_ssd", "size": 22000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "744"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3475,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a9d03de-783f-4ba4-9863-0aa35dd3422e
+      - 5ffc8f63-6af6-407f-981c-08fb668edf32
     status: 200 OK
     code: 200
     duration: ""
@@ -3486,23 +3757,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: GET
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:59.715029+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:26.425300+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3512,7 +3783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7acfce82-886a-44c0-910c-a7c1ea0fc8c4
+      - 1eabbf9f-0891-480c-ae2c-fe1bd00f8056
     status: 200 OK
     code: 200
     duration: ""
@@ -3523,23 +3794,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6f49dbb-6ae4-4567-8607-4b85743d93ac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4d67bf5c-7965-4534-a3bf-4426847cfbbf
     method: GET
   response:
-    body: '{"volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name": "tf-vol-magical-brahmagupta",
+    body: '{"volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name": "tf-vol-pedantic-babbage",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 22000000000,
-      "state": "available", "creation_date": "2022-07-07T12:02:04.898311+00:00", "modification_date":
-      "2022-07-07T12:02:08.654129+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:43.829475+00:00", "modification_date":
+      "2022-07-15T12:55:48.133774+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "448"
+      - "445"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3549,7 +3820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 038cf6b0-1c79-43d2-a169-350e0c7128f4
+      - 315dd9ce-5cd0-4557-80c2-da9cb7855f69
     status: 200 OK
     code: 200
     duration: ""
@@ -3560,47 +3831,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:31.871127+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:11 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3610,7 +3882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ce3c3d-7e94-4d58-8ae0-762b1450fae5
+      - d9291c91-33f5-401e-84b0-9683520c7b5a
     status: 200 OK
     code: 200
     duration: ""
@@ -3621,63 +3893,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "526"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 98f48a92-3b10-410e-a7fa-18fd0a6fdaea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:02:05.356527+00:00",
-      "modification_date": "2022-07-07T12:02:08.654129+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
-      "available", "base_volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name":
-      "tf-vol-magical-brahmagupta"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "534"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3687,7 +3921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66b5363d-be08-4422-a706-6bee79d1ec66
+      - 0627ee00-de5d-474a-92a2-8aef2b55a983
     status: 200 OK
     code: 200
     duration: ""
@@ -3698,25 +3932,63 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:44.251195+00:00",
+      "modification_date": "2022-07-15T12:55:48.133774+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
+      "available", "base_volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name":
+      "tf-vol-pedantic-babbage"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fc47af0d-5ee3-4a8e-a3ab-251de6fe3499
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90", "name":
+      "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "540"
+      - "530"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3726,7 +3998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fde72dc-e906-4d4e-8f51-3b6b327b9baa
+      - b9c5ae01-83c0-412a-8f07-67ae6c5707f2
     status: 200 OK
     code: 200
     duration: ""
@@ -3737,27 +4009,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman", "volume_type":
+      "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell", "volume_type":
       "b_ssd", "size": 22000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "744"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3767,7 +4039,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1dcd4d5-006e-4c11-a61e-56375fe243b2
+      - 3a3b9366-bda5-4109-b2df-221f28fa0cc6
     status: 200 OK
     code: 200
     duration: ""
@@ -3778,23 +4050,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: GET
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:59.715029+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:26.425300+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +4076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4585ed80-a16b-425b-ab00-ec86b5e16334
+      - 57f240da-44a3-421a-b239-a687e69de25f
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,23 +4087,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6f49dbb-6ae4-4567-8607-4b85743d93ac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4d67bf5c-7965-4534-a3bf-4426847cfbbf
     method: GET
   response:
-    body: '{"volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name": "tf-vol-magical-brahmagupta",
+    body: '{"volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name": "tf-vol-pedantic-babbage",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 22000000000,
-      "state": "available", "creation_date": "2022-07-07T12:02:04.898311+00:00", "modification_date":
-      "2022-07-07T12:02:08.654129+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:43.829475+00:00", "modification_date":
+      "2022-07-15T12:55:48.133774+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "448"
+      - "445"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3841,7 +4113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89297c3c-95a0-4e81-a9e1-16593086f918
+      - 27632414-dcc8-4cfc-b1f9-db826d606bf7
     status: 200 OK
     code: 200
     duration: ""
@@ -3852,63 +4124,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "526"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17806772-35d2-46d0-bf26-174df8173837
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:02:05.356527+00:00",
-      "modification_date": "2022-07-07T12:02:08.654129+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
-      "available", "base_volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name":
-      "tf-vol-magical-brahmagupta"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "534"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3918,7 +4152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1f42a8d-2782-4293-8640-76341d78ea77
+      - 43ffa128-7e18-4e71-ab9b-80772092d76f
     status: 200 OK
     code: 200
     duration: ""
@@ -3929,47 +4163,87 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"snapshot": {"id": "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:44.251195+00:00",
+      "modification_date": "2022-07-15T12:55:48.133774+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
+      "available", "base_volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name":
+      "tf-vol-pedantic-babbage"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - efab278a-9c3c-4a74-995d-e52e971bc501
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:31.871127+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3979,7 +4253,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a89d1b2b-e142-4933-a807-1ccc0638889f
+      - 44345bdc-edb0-4ead-9061-fecbfd44be4d
     status: 200 OK
     code: 200
     duration: ""
@@ -3990,7 +4264,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -4002,7 +4276,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4012,7 +4286,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c819c593-5159-45d8-9967-d4e55faf8610
+      - e78cd32e-5ea1-4749-b80a-d51d532bb3b9
     status: 200 OK
     code: 200
     duration: ""
@@ -4023,7 +4297,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -4035,7 +4309,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:12 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4045,7 +4319,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b33d931-11cd-4771-b793-c29380689ad5
+      - aa66b038-756f-4b38-ac82-55722266e412
     status: 200 OK
     code: 200
     duration: ""
@@ -4056,25 +4330,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90", "name":
+      "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "540"
+      - "530"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4084,7 +4357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80da1206-0bd7-470a-aa9b-23afe3cc1842
+      - 54c53f08-181c-4299-9b45-c5f48f4c380a
     status: 200 OK
     code: 200
     duration: ""
@@ -4095,27 +4368,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman", "volume_type":
+      "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell", "volume_type":
       "b_ssd", "size": 22000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "744"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4125,7 +4398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04ae096c-a3b8-4db4-ade8-12d6f36c2865
+      - 18bee90b-f005-4c79-9195-3c19bd5d76a5
     status: 200 OK
     code: 200
     duration: ""
@@ -4136,24 +4409,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"snapshot": {"id": "f026442f-5ba3-4945-a14d-9653e4a01d6e", "name": "tf-snap-relaxed-mccarthy",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:01:56.220553+00:00",
-      "modification_date": "2022-07-07T12:01:59.715029+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "5dc08c79-a968-4aeb-b1e6-b159e7176e01", "name": "tf-snap-competent-minsky",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:22.997411+00:00",
+      "modification_date": "2022-07-15T12:55:26.425300+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 21000000000, "state":
-      "available", "base_volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name":
-      "tf-vol-sad-jones"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+      "available", "base_volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name":
+      "tf-vol-gallant-dewdney"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
     headers:
       Content-Length:
-      - "526"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4163,7 +4437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1de4e381-221b-42ea-8235-04e07a0faaf6
+      - 156babd9-e21c-4b21-936f-a4eabb039eca
     status: 200 OK
     code: 200
     duration: ""
@@ -4174,27 +4448,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"image": {"id": "259ffafb-76de-4d27-b3dd-7cdedc93c03a", "name": "tf-image-objective-sanderson",
+    body: '{"image": {"id": "8ecf540f-82b6-480e-a4bc-1c2d15ca67f3", "name": "tf-image-competent-rosalind",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
+      "root_volume": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman", "volume_type":
+      "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell", "volume_type":
       "b_ssd", "size": 22000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:02:02.074745+00:00", "modification_date": "2022-07-07T12:02:02.074745+00:00",
+      "2022-07-15T12:55:41.521778+00:00", "modification_date": "2022-07-15T12:55:41.521778+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "744"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4204,7 +4478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8aa34ab2-0938-4968-9f3f-72c2d0aa535c
+      - 90a06964-1203-49a1-9902-61088bc86499
     status: 200 OK
     code: 200
     duration: ""
@@ -4215,7 +4489,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: DELETE
   response:
     body: ""
@@ -4223,7 +4497,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +4507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5220915-721c-4c98-88a3-10a6ca8d2b03
+      - dd01a8a5-f882-46c6-b36a-3d3ee0b4098d
     status: 204 No Content
     code: 204
     duration: ""
@@ -4244,7 +4518,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: DELETE
   response:
     body: ""
@@ -4252,7 +4526,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4262,7 +4536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49e7d5d8-2cdd-4d55-b9e7-95b34128ccba
+      - 678d497f-d6b3-4ab8-9b14-c307c0b47fe3
     status: 204 No Content
     code: 204
     duration: ""
@@ -4273,10 +4547,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"259ffafb-76de-4d27-b3dd-7cdedc93c03a\"
+    body: '{"type": "unknown_resource", "message": "\"8ecf540f-82b6-480e-a4bc-1c2d15ca67f3\"
       not found"}'
     headers:
       Content-Length:
@@ -4286,7 +4560,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4296,7 +4570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb7c0949-0f98-4a73-88c6-9411922c5b12
+      - ed75867f-213f-4abd-8508-5c43ef4f112f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4307,10 +4581,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"f026442f-5ba3-4945-a14d-9653e4a01d6e\"
+    body: '{"type": "unknown_resource", "message": "\"5dc08c79-a968-4aeb-b1e6-b159e7176e01\"
       not found"}'
     headers:
       Content-Length:
@@ -4320,7 +4594,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4330,7 +4604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e5a0b2e-234a-4c13-ac09-e0a02f91ffe0
+      - 60974d33-f86b-487c-9601-bcaeafba2125
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4341,64 +4615,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"snapshot": {"id": "9668f07a-4203-4f95-9058-21f810df6f0f", "name": "tf-snap-focused-haibt",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:57.972140+00:00",
-      "modification_date": "2022-07-07T12:01:57.972140+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "c72fab5a-a8b2-47cc-9971-c735be2088b9", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
-    headers:
-      Content-Length:
-      - "540"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0d519637-58ff-4b78-b305-64e241d16d8a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "d44001b9-7442-4f7f-bc63-1cef88b3552c", "name": "tf-snap-elastic-bouman",
-      "volume_type": "b_ssd", "creation_date": "2022-07-07T12:02:05.356527+00:00",
-      "modification_date": "2022-07-07T12:02:08.654129+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2f7999b3-7fce-4e74-b64f-51568bd15688", "name": "tf-snap-gallant-burnell",
+      "volume_type": "b_ssd", "creation_date": "2022-07-15T12:55:44.251195+00:00",
+      "modification_date": "2022-07-15T12:55:48.133774+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 22000000000, "state":
-      "available", "base_volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name":
-      "tf-vol-magical-brahmagupta"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name":
+      "tf-vol-pedantic-babbage"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "534"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4408,7 +4643,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2439b7c3-2930-4372-90a7-44805a03d607
+      - 5f1feed1-34cc-4e9a-95e1-73f7b7d9202c
     status: 200 OK
     code: 200
     duration: ""
@@ -4419,23 +4654,61 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"volume": {"id": "b7d4e727-7c7e-412e-96ea-9fc67ca1a579", "name": "tf-vol-sad-jones",
+    body: '{"snapshot": {"id": "64e63318-8269-447d-a528-6b1fe74cfb90", "name": "tf-snap-musing-chatterjee",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:35.819780+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90", "name":
+      "tf-vol-loving-allen"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+    headers:
+      Content-Length:
+      - "530"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61419100-3b84-4b17-b1c6-85edb58de60d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
+    method: GET
+  response:
+    body: '{"volume": {"id": "a57e04ac-6f7b-4938-800c-2de850110934", "name": "tf-vol-gallant-dewdney",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 21000000000,
-      "state": "available", "creation_date": "2022-07-07T12:01:55.696244+00:00", "modification_date":
-      "2022-07-07T12:01:59.715029+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:22.601116+00:00", "modification_date":
+      "2022-07-15T12:55:26.425300+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "438"
+      - "444"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4445,7 +4718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9924883-87fd-4cfe-97a2-2bd3d02d050a
+      - 223a9cef-e685-4bdf-ab67-91f894d4354a
     status: 200 OK
     code: 200
     duration: ""
@@ -4456,7 +4729,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: DELETE
   response:
     body: ""
@@ -4464,7 +4737,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:02:13 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4474,7 +4747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee47e71d-ca90-45f8-abc4-8435e33a1eb4
+      - f29e17ab-d72b-4453-a6fa-d5e6410dfc56
     status: 204 No Content
     code: 204
     duration: ""
@@ -4485,7 +4758,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: DELETE
   response:
     body: ""
@@ -4493,7 +4766,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4503,7 +4776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82a823bc-6ca0-43f4-a3b6-ef8bb584b840
+      - fde143d7-2349-49d9-865c-f62858293076
     status: 204 No Content
     code: 204
     duration: ""
@@ -4514,7 +4787,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: DELETE
   response:
     body: ""
@@ -4522,7 +4795,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4532,7 +4805,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6041fdc-26bd-4124-9c6a-b77c976fb550
+      - 7c9cc5cf-433f-456d-8e9e-83ff05a31df2
     status: 204 No Content
     code: 204
     duration: ""
@@ -4543,10 +4816,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"9668f07a-4203-4f95-9058-21f810df6f0f\"
+    body: '{"type": "unknown_resource", "message": "\"64e63318-8269-447d-a528-6b1fe74cfb90\"
       not found"}'
     headers:
       Content-Length:
@@ -4556,7 +4829,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4566,7 +4839,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bfd729b-7dce-43d8-8a7e-64674ea4d81b
+      - a24e7065-287e-433d-a6f8-c74599691dc1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4577,10 +4850,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"d44001b9-7442-4f7f-bc63-1cef88b3552c\"
+    body: '{"type": "unknown_resource", "message": "\"2f7999b3-7fce-4e74-b64f-51568bd15688\"
       not found"}'
     headers:
       Content-Length:
@@ -4590,7 +4863,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4600,7 +4873,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a504318a-93ef-4501-8aca-db15955207a8
+      - d69a838a-fd6a-40b9-94c3-bb4674480484
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4611,23 +4884,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6f49dbb-6ae4-4567-8607-4b85743d93ac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4d67bf5c-7965-4534-a3bf-4426847cfbbf
     method: GET
   response:
-    body: '{"volume": {"id": "f6f49dbb-6ae4-4567-8607-4b85743d93ac", "name": "tf-vol-magical-brahmagupta",
+    body: '{"volume": {"id": "4d67bf5c-7965-4534-a3bf-4426847cfbbf", "name": "tf-vol-pedantic-babbage",
       "volume_type": "b_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 22000000000,
-      "state": "available", "creation_date": "2022-07-07T12:02:04.898311+00:00", "modification_date":
-      "2022-07-07T12:02:08.654129+00:00", "tags": [], "zone": "fr-par-1"}}'
+      "state": "available", "creation_date": "2022-07-15T12:55:43.829475+00:00", "modification_date":
+      "2022-07-15T12:55:48.133774+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "448"
+      - "445"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4637,7 +4910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a106abd-8b6b-4bcb-8959-4d5dbd2c0ff5
+      - 2cdb6928-b095-4049-baf5-11431797d3a5
     status: 200 OK
     code: 200
     duration: ""
@@ -4648,29 +4921,594 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:31.871127+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2703"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e5d0de4f-24ce-4cf6-92f9-2778ce739a3c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4d67bf5c-7965-4534-a3bf-4426847cfbbf
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Fri, 15 Jul 2022 12:55:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0fb166bd-5ea4-4418-aca4-1fe1aa015b52
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"action":"poweroff"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70/action
+    method: POST
+  response:
+    body: '{"task": {"id": "47f1da24-5508-4b8b-afea-dd6273d519eb", "description":
+      "server_poweroff", "status": "pending", "href_from": "/servers/b0fba900-420c-439d-b3a8-93b55393dc70/action",
+      "href_result": "/servers/b0fba900-420c-439d-b3a8-93b55393dc70", "started_at":
+      "2022-07-15T12:55:53.329997+00:00", "terminated_at": null}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:53 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/47f1da24-5508-4b8b-afea-dd6273d519eb
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1aab0ac4-cec2-465f-8cbc-44281720109b
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:52.957129+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 068ec3ac-9e8d-4604-9fb8-daf04835f3f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:52.957129+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8443860d-167f-492a-b1bb-ebcaf00dd361
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:52.957129+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86a3f2e8-fa1f-448f-9e8f-a915096b821f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:52.957129+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 38903131-8022-41c1-9853-4e8714094a93
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:52.957129+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5eb5f5c2-2a33-4db7-a7fc-20d7dae54e3d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:52.957129+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bfa8c522-2c63-4633-b77b-128f0378afb3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.69.56.19", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:52.957129+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "38", "hypervisor_id": "1501", "node_id": "10"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f29dbee7-3220-4f77-8532-bc198ac0e74e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
+    method: GET
+  response:
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:56:26.402008+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -4682,13 +5520,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2541"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:56:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4698,7 +5536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b5a611d-82af-4c12-9d70-4c7b2443f711
+      - 3bbe5e79-2fca-4fb2-8503-6274dda37f70
     status: 200 OK
     code: 200
     duration: ""
@@ -4709,58 +5547,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6f49dbb-6ae4-4567-8607-4b85743d93ac
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d642f386-e7af-4263-aa59-88e804fbd1b8
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes",
+    body: '{"server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-tender-rhodes", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-sharp-turing", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "c72fab5a-a8b2-47cc-9971-c735be2088b9",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "4a5963e4-5a2e-4513-b1b3-35ed434b23e3", "name": "tf-srv-tender-rhodes"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "d0633bbe-673b-4ad0-84f4-7c74a8b97b90",
+      "name": "tf-vol-loving-allen", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "b0fba900-420c-439d-b3a8-93b55393dc70", "name": "tf-srv-sharp-turing"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:55:38.169934+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:56.358948+00:00",
-      "modification_date": "2022-07-07T12:01:56.358948+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.365465+00:00",
+      "modification_date": "2022-07-15T12:56:26.402008+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -4772,13 +5581,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2558"
+      - "2541"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:56:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4788,7 +5597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a909aff-b264-4f0e-84b9-402b14fc4120
+      - ebdd2a5d-b3fd-4c70-9ff3-59a45b574566
     status: 200 OK
     code: 200
     duration: ""
@@ -4799,7 +5608,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: DELETE
   response:
     body: ""
@@ -4807,7 +5616,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:56:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4817,7 +5626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e98fa312-3cad-465a-b1a4-baf4cbc91da8
+      - 84a19258-f412-42c2-abed-762299be668f
     status: 204 No Content
     code: 204
     duration: ""
@@ -4828,10 +5637,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"4a5963e4-5a2e-4513-b1b3-35ed434b23e3\"
+    body: '{"type": "unknown_resource", "message": "\"b0fba900-420c-439d-b3a8-93b55393dc70\"
       not found"}'
     headers:
       Content-Length:
@@ -4841,7 +5650,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:14 GMT
+      - Fri, 15 Jul 2022 12:56:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4851,7 +5660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e80f662-448e-4ac8-af0e-9824526e6843
+      - 9622153f-23db-41b4-a43a-e6fe82c2f757
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4862,7 +5671,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c72fab5a-a8b2-47cc-9971-c735be2088b9
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d0633bbe-673b-4ad0-84f4-7c74a8b97b90
     method: DELETE
   response:
     body: ""
@@ -4870,7 +5679,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:02:15 GMT
+      - Fri, 15 Jul 2022 12:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4880,7 +5689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9a91680-f4e3-4642-94fc-c208746fca32
+      - abff8eac-d2b5-4881-8c57-24a9eda6e59b
     status: 204 No Content
     code: 204
     duration: ""
@@ -4891,10 +5700,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/259ffafb-76de-4d27-b3dd-7cdedc93c03a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8ecf540f-82b6-480e-a4bc-1c2d15ca67f3
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"259ffafb-76de-4d27-b3dd-7cdedc93c03a\"
+    body: '{"type": "unknown_resource", "message": "\"8ecf540f-82b6-480e-a4bc-1c2d15ca67f3\"
       not found"}'
     headers:
       Content-Length:
@@ -4904,7 +5713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:15 GMT
+      - Fri, 15 Jul 2022 12:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4914,7 +5723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfed681e-c5c0-4ca5-bd9b-921e9db0e6f0
+      - c4fd72f6-623c-46c2-bdc6-ee4daa58f5af
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4925,10 +5734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f026442f-5ba3-4945-a14d-9653e4a01d6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/5dc08c79-a968-4aeb-b1e6-b159e7176e01
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"f026442f-5ba3-4945-a14d-9653e4a01d6e\"
+    body: '{"type": "unknown_resource", "message": "\"5dc08c79-a968-4aeb-b1e6-b159e7176e01\"
       not found"}'
     headers:
       Content-Length:
@@ -4938,7 +5747,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:15 GMT
+      - Fri, 15 Jul 2022 12:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4948,7 +5757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e7d78eb-0e8a-483c-abeb-4747fadf9588
+      - fe8c1429-970a-424f-a6f7-43287aa38ad8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4959,10 +5768,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d44001b9-7442-4f7f-bc63-1cef88b3552c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2f7999b3-7fce-4e74-b64f-51568bd15688
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"d44001b9-7442-4f7f-bc63-1cef88b3552c\"
+    body: '{"type": "unknown_resource", "message": "\"2f7999b3-7fce-4e74-b64f-51568bd15688\"
       not found"}'
     headers:
       Content-Length:
@@ -4972,7 +5781,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:15 GMT
+      - Fri, 15 Jul 2022 12:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4982,7 +5791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0e9f2ca-c93e-4e06-ad6c-9af718be33d5
+      - fc665af6-d3b5-4c80-9e3e-172feea83b71
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4993,10 +5802,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9668f07a-4203-4f95-9058-21f810df6f0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/64e63318-8269-447d-a528-6b1fe74cfb90
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"9668f07a-4203-4f95-9058-21f810df6f0f\"
+    body: '{"type": "unknown_resource", "message": "\"64e63318-8269-447d-a528-6b1fe74cfb90\"
       not found"}'
     headers:
       Content-Length:
@@ -5006,7 +5815,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:15 GMT
+      - Fri, 15 Jul 2022 12:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5016,7 +5825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d877c47-02db-4336-87ff-3c0738a2fc91
+      - fc2fe8d0-a688-4669-9e5e-3158c0ee3181
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5027,10 +5836,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b7d4e727-7c7e-412e-96ea-9fc67ca1a579
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a57e04ac-6f7b-4938-800c-2de850110934
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "Volume ''b7d4e727-7c7e-412e-96ea-9fc67ca1a579''
+    body: '{"type": "unknown_resource", "message": "Volume ''a57e04ac-6f7b-4938-800c-2de850110934''
       not found."}'
     headers:
       Content-Length:
@@ -5040,7 +5849,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:15 GMT
+      - Fri, 15 Jul 2022 12:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5050,7 +5859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4918b10-6d61-4e40-b5dc-592fe806385e
+      - a4de2497-847a-460c-aa1c-5e39c2c0c125
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5061,10 +5870,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6f49dbb-6ae4-4567-8607-4b85743d93ac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4d67bf5c-7965-4534-a3bf-4426847cfbbf
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "Volume ''f6f49dbb-6ae4-4567-8607-4b85743d93ac''
+    body: '{"type": "unknown_resource", "message": "Volume ''4d67bf5c-7965-4534-a3bf-4426847cfbbf''
       not found."}'
     headers:
       Content-Length:
@@ -5074,7 +5883,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:15 GMT
+      - Fri, 15 Jul 2022 12:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5084,7 +5893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f36e8e86-4643-462c-85f0-e5c7d70622d4
+      - 28e7c54f-6151-480a-8b24-d81f73f2c6f4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5095,10 +5904,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4a5963e4-5a2e-4513-b1b3-35ed434b23e3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b0fba900-420c-439d-b3a8-93b55393dc70
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"4a5963e4-5a2e-4513-b1b3-35ed434b23e3\"
+    body: '{"type": "unknown_resource", "message": "\"b0fba900-420c-439d-b3a8-93b55393dc70\"
       not found"}'
     headers:
       Content-Length:
@@ -5108,7 +5917,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:02:15 GMT
+      - Fri, 15 Jul 2022 12:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5118,7 +5927,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e5aedac-901e-4297-b3e7-8de5a7ac8305
+      - 7bb9008b-92bf-43f1-b126-d9725b3fc77c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-image-server-with-local-volume.cassette.yaml
+++ b/scaleway/testdata/instance-image-server-with-local-volume.cassette.yaml
@@ -713,46 +713,46 @@ interactions:
       "Rocky Linux 8", "label": "rockylinux_8", "logo": "https://marketplace-logos.s3.nl-ams.scw.cloud/rockylinux.png",
       "description": "Rocky Linux is a community-driven effort to bring you enterprise-grade,
       production-ready Linux.", "organization": {"id": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "name": "Instances User Resources Build System"}, "versions": [{"id": "8c94a517-442e-448c-80e1-57c3c9a9a92f",
-      "name": "2022-06-15T14:40:42.854386+00:00", "local_images": [{"id": "47b9dce8-fb9b-48a1-a416-5d5847086952",
-      "zone": "pl-waw-1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "9194c6b5-9062-4e95-809e-74c3c40baca3",
+      "name": "Instances User Resources Build System"}, "versions": [{"id": "8ad85252-b11b-404e-bfe3-a0652722d3c0",
+      "name": "2022-07-11T08:48:40.108217+00:00", "local_images": [{"id": "ad2f008b-a159-402a-9677-8c0a16b25fc4",
       "zone": "fr-par-3", "arch": "x86_64", "compatible_commercial_types": ["GP1-L",
       "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M", "START1-S", "START1-XS",
       "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S",
       "ENT1-M", "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S",
-      "PRO2-M", "PRO2-L", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "97e3f42f-9d81-4702-ad49-35946748fd86",
-      "zone": "ams1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
-      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "fab3df2d-1631-45fc-aecc-2c1ce23310c9",
+      "PRO2-M", "PRO2-L", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "af0e5949-58a2-45f3-bda9-5919ef45c309",
       "zone": "nl-ams-2", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
       "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
       "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
       "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
       "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "8adde02e-eec5-4f62-9db9-aa9bdcaace9b",
-      "zone": "par1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
-      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "a660dcf6-12fe-4562-ac5c-26ae3e7b146f",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "40927774-00c4-421b-ade6-e608796f4321",
       "zone": "fr-par-2", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
       "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
       "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
       "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
       "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}], "creation_date": "2022-06-15T14:40:42.919695+00:00",
-      "modification_date": "2022-06-15T14:40:42.919695+00:00"}], "categories": ["distribution"],
-      "current_public_version": "8c94a517-442e-448c-80e1-57c3c9a9a92f", "creation_date":
-      "2021-06-25T10:16:16.254240+00:00", "modification_date": "2022-06-20T08:54:15.619535+00:00",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "454429e7-d794-4cb8-9831-85e60a1825c0",
+      "zone": "pl-waw-1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "34d14210-007a-43c0-9e56-d1548998ae80",
+      "zone": "ams1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "bbb2da3b-5de5-48a2-b6be-0df60a28d84a",
+      "zone": "par1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}], "creation_date": "2022-07-11T08:48:40.175715+00:00",
+      "modification_date": "2022-07-11T08:48:40.175715+00:00"}], "categories": ["distribution"],
+      "current_public_version": "8ad85252-b11b-404e-bfe3-a0652722d3c0", "creation_date":
+      "2021-06-25T10:16:16.254240+00:00", "modification_date": "2022-07-12T09:03:50.736296+00:00",
       "valid_until": null}, {"id": "3f1b9623-71ba-4fe3-b994-27fcdaa850ba", "name":
       "Ubuntu 20.04 Focal Fossa", "label": "ubuntu_focal", "logo": "https://marketplace-logos.s3.nl-ams.scw.cloud/ubuntu.png",
       "description": "Ubuntu is the ideal distribution for scale-out computing, Ubuntu
@@ -929,7 +929,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:33 GMT
+      - Fri, 15 Jul 2022 12:54:20 GMT
       Link:
       - </images?page=1&per_page=50&>; rel="last"
       Server:
@@ -941,9 +941,365 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4836555-6162-4eeb-b973-166548cd148c
+      - f9fb1a25-9dcc-4d3b-957c-e70c8c503e5c
       X-Total-Count:
       - "23"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers
+    method: GET
+  response:
+    body: '{"servers": {"DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
+      "ram": 8589934592, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size":
+      80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "baremetal": false, "monthly_price": 31.39, "hourly_price":
+      0.043, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
+      "local", "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
+      4294967296, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "baremetal": false, "monthly_price": 16.06, "hourly_price": 0.022, "capabilities":
+      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "local",
+      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      2147483648, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "baremetal": false, "monthly_price": 8.03, "hourly_price": 0.011, "capabilities":
+      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "local",
+      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      12884901888, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size":
+      120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "baremetal": false, "monthly_price": 47.45, "hourly_price":
+      0.065, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
+      "local", "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
+      "ram": 412316860416, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal":
+      false, "monthly_price": 2452.8, "hourly_price": 3.36, "capabilities": {"boot_types":
+      ["rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      false, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth":
+      20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 20000000000}]}}, "ENT1-L":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      817.6, "hourly_price": 1.12, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}}, "ENT1-M":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      408.8, "hourly_price": 0.56, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 3200000000}]}}, "ENT1-S":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      204.4, "hourly_price": 0.28, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}}, "ENT1-XL":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      1635.2, "hourly_price": 2.24, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}}, "GP1-L":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
+      false, "monthly_price": 522.68, "hourly_price": 0.716, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth":
+      5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 5000000000}]}}, "GP1-M":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
+      false, "monthly_price": 268.64, "hourly_price": 0.368, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth":
+      1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1500000000}]}}, "GP1-S":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
+      false, "monthly_price": 134.32, "hourly_price": 0.184, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}}, "GP1-VIZ":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
+      false, "monthly_price": 72.0, "hourly_price": 0.1, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}}, "GP1-XL":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
+      false, "monthly_price": 1108.14, "hourly_price": 1.518, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth":
+      10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 10000000000}]}}, "GP1-XS":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
+      false, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}}, "PLAY2-MICRO":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "PLAY2-NANO":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "PLAY2-PICO":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}}, "PRO2-L":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 6000000000}]}}, "PRO2-M":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 3000000000}]}}, "PRO2-S":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 1500000000}]}}, "PRO2-XS":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 700000000}]}}, "PRO2-XXS":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
+      40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["rescue", "local"],
+      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
+      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": null},
+      {"internal_bandwidth": null, "internet_bandwidth": 350000000}]}}, "RENDER-S":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu":
+      1, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
+      false, "monthly_price": 788.4, "hourly_price": 1.08, "capabilities": {"boot_types":
+      ["local", "rescue"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
+      1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}, "STARDUST1-S":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
+      false, "monthly_price": 1.8469, "hourly_price": 0.00253, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": true, "private_network": 8},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}}, "START1-L":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": null,
+      "volumes_constraint": {"min_size": 200000000000, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
+      "baremetal": false, "monthly_price": 24.674, "hourly_price": 0.0338, "capabilities":
+      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "bootscript",
+      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
+      false, "private_network": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      null, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      null, "internet_bandwidth": 400000000}]}}, "START1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": null, "volumes_constraint":
+      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "baremetal":
+      false, "monthly_price": 12.264, "hourly_price": 0.0168, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "bootscript", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": false, "private_network": 0},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": null, "sum_internet_bandwidth":
+      300000000, "interfaces": [{"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      2147483648, "gpu": null, "volumes_constraint": {"min_size": 50000000000, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      200000000000}}, "baremetal": false, "monthly_price": 6.059, "hourly_price":
+      0.0083, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
+      "bootscript", "hot_snapshots_local_volume": true, "placement_groups": true,
+      "block_storage": false, "private_network": 0}, "network": {"ipv6_support": true,
+      "sum_internal_bandwidth": null, "sum_internet_bandwidth": 200000000, "interfaces":
+      [{"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "START1-XS":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": null,
+      "volumes_constraint": {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "baremetal":
+      false, "monthly_price": 2.993, "hourly_price": 0.0041, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "bootscript", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": false, "private_network": 0},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": null, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
+      6, "ram": 8589934592, "gpu": null, "volumes_constraint": {"min_size": 200000000000,
+      "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
+      "max_size": 200000000000}}, "baremetal": false, "monthly_price": 14.4, "hourly_price":
+      0.02, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
+      "bootscript", "hot_snapshots_local_volume": true, "placement_groups": true,
+      "block_storage": false, "private_network": 0}, "network": {"ipv6_support": true,
+      "sum_internal_bandwidth": null, "sum_internet_bandwidth": 200000000, "interfaces":
+      [{"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": null, "volumes_constraint":
+      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "baremetal":
+      false, "monthly_price": 8.64, "hourly_price": 0.012, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "bootscript", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": false, "private_network": 0},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": null, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
+      2, "ram": 2147483648, "gpu": null, "volumes_constraint": {"min_size": 50000000000,
+      "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
+      "max_size": 200000000000}}, "baremetal": false, "monthly_price": 4.32, "hourly_price":
+      0.006, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
+      "bootscript", "hot_snapshots_local_volume": true, "placement_groups": true,
+      "block_storage": false, "private_network": 0}, "network": {"ipv6_support": true,
+      "sum_internal_bandwidth": null, "sum_internet_bandwidth": 200000000, "interfaces":
+      [{"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "X64-120GB":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu":
+      null, "volumes_constraint": {"min_size": 500000000000, "max_size": 1000000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
+      "baremetal": false, "monthly_price": 281.342, "hourly_price": 0.3854, "capabilities":
+      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "bootscript",
+      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
+      false, "private_network": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      null, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      null, "internet_bandwidth": 1000000000}]}}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "baremetal":
+      false, "monthly_price": 38.836, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["bootscript", "rescue", "local"], "default_boot_type": "bootscript", "hot_snapshots_local_volume":
+      true, "placement_groups": true, "block_storage": false, "private_network": 0},
+      "network": {"ipv6_support": true, "sum_internal_bandwidth": null, "sum_internet_bandwidth":
+      250000000, "interfaces": [{"internal_bandwidth": null, "internet_bandwidth":
+      250000000}]}}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      32212254720, "gpu": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      200000000000}}, "baremetal": false, "monthly_price": 77.818, "hourly_price":
+      0.1066, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
+      "bootscript", "hot_snapshots_local_volume": true, "placement_groups": true,
+      "block_storage": false, "private_network": 0}, "network": {"ipv6_support": true,
+      "sum_internal_bandwidth": null, "sum_internet_bandwidth": 500000000, "interfaces":
+      [{"internal_bandwidth": null, "internet_bandwidth": 500000000}]}}, "X64-60GB":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu":
+      null, "volumes_constraint": {"min_size": 400000000000, "max_size": 700000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
+      "baremetal": false, "monthly_price": 140.16, "hourly_price": 0.192, "capabilities":
+      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "bootscript",
+      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
+      false, "private_network": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      null, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      null, "internet_bandwidth": 1000000000}]}}}}'
+    headers:
+      Content-Length:
+      - "26609"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:20 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6779dc69-4e2e-498d-af0a-d6168c6fb51a
+      X-Total-Count:
+      - "36"
     status: 200 OK
     code: 200
     duration: ""
@@ -1659,46 +2015,46 @@ interactions:
       "Rocky Linux 8", "label": "rockylinux_8", "logo": "https://marketplace-logos.s3.nl-ams.scw.cloud/rockylinux.png",
       "description": "Rocky Linux is a community-driven effort to bring you enterprise-grade,
       production-ready Linux.", "organization": {"id": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "name": "Instances User Resources Build System"}, "versions": [{"id": "8c94a517-442e-448c-80e1-57c3c9a9a92f",
-      "name": "2022-06-15T14:40:42.854386+00:00", "local_images": [{"id": "47b9dce8-fb9b-48a1-a416-5d5847086952",
-      "zone": "pl-waw-1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "9194c6b5-9062-4e95-809e-74c3c40baca3",
+      "name": "Instances User Resources Build System"}, "versions": [{"id": "8ad85252-b11b-404e-bfe3-a0652722d3c0",
+      "name": "2022-07-11T08:48:40.108217+00:00", "local_images": [{"id": "ad2f008b-a159-402a-9677-8c0a16b25fc4",
       "zone": "fr-par-3", "arch": "x86_64", "compatible_commercial_types": ["GP1-L",
       "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M", "START1-S", "START1-XS",
       "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S",
       "ENT1-M", "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S",
-      "PRO2-M", "PRO2-L", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "97e3f42f-9d81-4702-ad49-35946748fd86",
-      "zone": "ams1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
-      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "fab3df2d-1631-45fc-aecc-2c1ce23310c9",
+      "PRO2-M", "PRO2-L", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "af0e5949-58a2-45f3-bda9-5919ef45c309",
       "zone": "nl-ams-2", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
       "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
       "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
       "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
       "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "8adde02e-eec5-4f62-9db9-aa9bdcaace9b",
-      "zone": "par1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
-      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "a660dcf6-12fe-4562-ac5c-26ae3e7b146f",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "40927774-00c4-421b-ade6-e608796f4321",
       "zone": "fr-par-2", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
       "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
       "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
       "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
       "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}], "creation_date": "2022-06-15T14:40:42.919695+00:00",
-      "modification_date": "2022-06-15T14:40:42.919695+00:00"}], "categories": ["distribution"],
-      "current_public_version": "8c94a517-442e-448c-80e1-57c3c9a9a92f", "creation_date":
-      "2021-06-25T10:16:16.254240+00:00", "modification_date": "2022-06-20T08:54:15.619535+00:00",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "454429e7-d794-4cb8-9831-85e60a1825c0",
+      "zone": "pl-waw-1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "34d14210-007a-43c0-9e56-d1548998ae80",
+      "zone": "ams1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "bbb2da3b-5de5-48a2-b6be-0df60a28d84a",
+      "zone": "par1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}], "creation_date": "2022-07-11T08:48:40.175715+00:00",
+      "modification_date": "2022-07-11T08:48:40.175715+00:00"}], "categories": ["distribution"],
+      "current_public_version": "8ad85252-b11b-404e-bfe3-a0652722d3c0", "creation_date":
+      "2021-06-25T10:16:16.254240+00:00", "modification_date": "2022-07-12T09:03:50.736296+00:00",
       "valid_until": null}, {"id": "3f1b9623-71ba-4fe3-b994-27fcdaa850ba", "name":
       "Ubuntu 20.04 Focal Fossa", "label": "ubuntu_focal", "logo": "https://marketplace-logos.s3.nl-ams.scw.cloud/ubuntu.png",
       "description": "Ubuntu is the ideal distribution for scale-out computing, Ubuntu
@@ -1875,7 +2231,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:33 GMT
+      - Fri, 15 Jul 2022 12:54:21 GMT
       Link:
       - </images?page=1&per_page=50&>; rel="last"
       Server:
@@ -1887,7 +2243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 727f05fb-68dd-440b-b9f9-f73541ed3ba9
+      - 0982ea79-e5cf-4bbf-9bef-5e3731ceb3e4
       X-Total-Count:
       - "23"
     status: 200 OK
@@ -2231,7 +2587,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:33 GMT
+      - Fri, 15 Jul 2022 12:54:21 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="last"
       Server:
@@ -2243,370 +2599,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bef6fc05-1663-49e0-a312-e0f7238fb295
+      - 246b0e31-0fa8-4226-8a6c-a829c9061b39
       X-Total-Count:
       - "36"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers
-    method: GET
-  response:
-    body: '{"servers": {"DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size":
-      80000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      800000000000}}, "baremetal": false, "monthly_price": 31.39, "hourly_price":
-      0.043, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
-      "local", "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
-      4294967296, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size": 40000000000},
-      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
-      "baremetal": false, "monthly_price": 16.06, "hourly_price": 0.022, "capabilities":
-      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "local",
-      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
-      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
-      "baremetal": false, "monthly_price": 8.03, "hourly_price": 0.011, "capabilities":
-      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "local",
-      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      12884901888, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size":
-      120000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      800000000000}}, "baremetal": false, "monthly_price": 47.45, "hourly_price":
-      0.065, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
-      "local", "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": null, "volumes_constraint": {"min_size": 0, "max_size":
-      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal":
-      false, "monthly_price": 2452.8, "hourly_price": 3.36, "capabilities": {"boot_types":
-      ["rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      false, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth":
-      20000000000, "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 20000000000}]}}, "ENT1-L":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      817.6, "hourly_price": 1.12, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
-      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}}, "ENT1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      408.8, "hourly_price": 0.56, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
-      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 3200000000}]}}, "ENT1-S":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      204.4, "hourly_price": 0.28, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
-      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}}, "ENT1-XL":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      1635.2, "hourly_price": 2.24, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
-      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}}, "GP1-L":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
-      false, "monthly_price": 522.68, "hourly_price": 0.716, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth":
-      5000000000, "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 5000000000}]}}, "GP1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
-      false, "monthly_price": 268.64, "hourly_price": 0.368, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth":
-      1500000000, "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1500000000}]}}, "GP1-S":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
-      false, "monthly_price": 134.32, "hourly_price": 0.184, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
-      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}}, "GP1-VIZ":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
-      false, "monthly_price": 72.0, "hourly_price": 0.1, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
-      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}}, "GP1-XL":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
-      false, "monthly_price": 1108.14, "hourly_price": 1.518, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth":
-      10000000000, "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 10000000000}]}}, "GP1-XS":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
-      false, "monthly_price": 66.43, "hourly_price": 0.091, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
-      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}}, "PLAY2-MICRO":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
-      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "PLAY2-NANO":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
-      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "PLAY2-PICO":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
-      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}}, "PRO2-L":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
-      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 6000000000}]}}, "PRO2-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
-      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 3000000000}]}}, "PRO2-S":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
-      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 1500000000}]}}, "PRO2-XS":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
-      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 700000000}]}}, "PRO2-XXS":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "baremetal": false, "monthly_price":
-      40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["rescue", "local"],
-      "default_boot_type": "local", "hot_snapshots_local_volume": false, "placement_groups":
-      true, "block_storage": true, "private_network": 8}, "network": {"ipv6_support":
-      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
-      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": null},
-      {"internal_bandwidth": null, "internet_bandwidth": 350000000}]}}, "RENDER-S":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu":
-      1, "volumes_constraint": {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
-      false, "monthly_price": 788.4, "hourly_price": 1.08, "capabilities": {"boot_types":
-      ["local", "rescue"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
-      1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}, "STARDUST1-S":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "baremetal":
-      false, "monthly_price": 1.8469, "hourly_price": 0.00253, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "local", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": true, "private_network": 8},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
-      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}}, "START1-L":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": null,
-      "volumes_constraint": {"min_size": 200000000000, "max_size": 200000000000},
-      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
-      "baremetal": false, "monthly_price": 24.674, "hourly_price": 0.0338, "capabilities":
-      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "bootscript",
-      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
-      false, "private_network": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      null, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      null, "internet_bandwidth": 400000000}]}}, "START1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": null, "volumes_constraint":
-      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "baremetal":
-      false, "monthly_price": 12.264, "hourly_price": 0.0168, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "bootscript", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": false, "private_network": 0},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": null, "sum_internet_bandwidth":
-      300000000, "interfaces": [{"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": null, "volumes_constraint": {"min_size": 50000000000, "max_size":
-      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "baremetal": false, "monthly_price": 6.059, "hourly_price":
-      0.0083, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
-      "bootscript", "hot_snapshots_local_volume": true, "placement_groups": true,
-      "block_storage": false, "private_network": 0}, "network": {"ipv6_support": true,
-      "sum_internal_bandwidth": null, "sum_internet_bandwidth": 200000000, "interfaces":
-      [{"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "START1-XS":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": null,
-      "volumes_constraint": {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "baremetal":
-      false, "monthly_price": 2.993, "hourly_price": 0.0041, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "bootscript", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": false, "private_network": 0},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": null, "sum_internet_bandwidth":
-      100000000, "interfaces": [{"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": null, "volumes_constraint": {"min_size": 200000000000,
-      "max_size": 200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "baremetal": false, "monthly_price": 14.4, "hourly_price":
-      0.02, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
-      "bootscript", "hot_snapshots_local_volume": true, "placement_groups": true,
-      "block_storage": false, "private_network": 0}, "network": {"ipv6_support": true,
-      "sum_internal_bandwidth": null, "sum_internet_bandwidth": 200000000, "interfaces":
-      [{"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M": {"alt_names":
-      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": null, "volumes_constraint":
-      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "baremetal":
-      false, "monthly_price": 8.64, "hourly_price": 0.012, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "bootscript", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": false, "private_network": 0},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": null, "sum_internet_bandwidth":
-      200000000, "interfaces": [{"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": null, "volumes_constraint": {"min_size": 50000000000,
-      "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "baremetal": false, "monthly_price": 4.32, "hourly_price":
-      0.006, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
-      "bootscript", "hot_snapshots_local_volume": true, "placement_groups": true,
-      "block_storage": false, "private_network": 0}, "network": {"ipv6_support": true,
-      "sum_internal_bandwidth": null, "sum_internet_bandwidth": 200000000, "interfaces":
-      [{"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "X64-120GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 12, "ram": 128849018880, "gpu":
-      null, "volumes_constraint": {"min_size": 500000000000, "max_size": 1000000000000},
-      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
-      "baremetal": false, "monthly_price": 281.342, "hourly_price": 0.3854, "capabilities":
-      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "bootscript",
-      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
-      false, "private_network": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      null, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      null, "internet_bandwidth": 1000000000}]}}, "X64-15GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": null, "volumes_constraint":
-      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "baremetal":
-      false, "monthly_price": 38.836, "hourly_price": 0.0532, "capabilities": {"boot_types":
-      ["bootscript", "rescue", "local"], "default_boot_type": "bootscript", "hot_snapshots_local_volume":
-      true, "placement_groups": true, "block_storage": false, "private_network": 0},
-      "network": {"ipv6_support": true, "sum_internal_bandwidth": null, "sum_internet_bandwidth":
-      250000000, "interfaces": [{"internal_bandwidth": null, "internet_bandwidth":
-      250000000}]}}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      32212254720, "gpu": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "baremetal": false, "monthly_price": 77.818, "hourly_price":
-      0.1066, "capabilities": {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type":
-      "bootscript", "hot_snapshots_local_volume": true, "placement_groups": true,
-      "block_storage": false, "private_network": 0}, "network": {"ipv6_support": true,
-      "sum_internal_bandwidth": null, "sum_internet_bandwidth": 500000000, "interfaces":
-      [{"internal_bandwidth": null, "internet_bandwidth": 500000000}]}}, "X64-60GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu":
-      null, "volumes_constraint": {"min_size": 400000000000, "max_size": 700000000000},
-      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
-      "baremetal": false, "monthly_price": 140.16, "hourly_price": 0.192, "capabilities":
-      {"boot_types": ["bootscript", "rescue", "local"], "default_boot_type": "bootscript",
-      "hot_snapshots_local_volume": true, "placement_groups": true, "block_storage":
-      false, "private_network": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      null, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      null, "internet_bandwidth": 1000000000}]}}}}'
-    headers:
-      Content-Length:
-      - "26609"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:16:34 GMT
-      Link:
-      - </products/servers?page=1&per_page=50&>; rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ec2f8aee-4aa7-41d0-a741-1fd6cd68bb62
-      X-Total-Count:
-      - "36"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-srv-practical-newton","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"881d7a33-4cfa-4046-b5cf-c33cb9c62fb6","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    body: '{"name":"tf-srv-thirsty-jones","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"881d7a33-4cfa-4046-b5cf-c33cb9c62fb6","volumes":{"0":{"name":"tf-vol-sad-beaver","size":15000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
     form: {}
     headers:
       Content-Type:
@@ -2617,26 +2617,26 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton",
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-practical-newton", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton"},
-      "size": 15000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -2648,15 +2648,15 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:34 GMT
+      - Fri, 15 Jul 2022 12:54:21 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2666,7 +2666,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52e42a0a-a54e-40de-b53f-07a8696b9d7d
+      - eedf5602-0156-402c-ae26-251b78ba0630
     status: 201 Created
     code: 201
     duration: ""
@@ -2677,29 +2677,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: GET
   response:
-    body: '{"server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton",
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-practical-newton", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton"},
-      "size": 15000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -2711,13 +2711,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:34 GMT
+      - Fri, 15 Jul 2022 12:54:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2727,73 +2727,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57bddcac-fd61-4a58-8324-e41a3e703ba1
+      - e8c0fbc4-57eb-4358-8493-4bb9378c1d37
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
-    method: GET
-  response:
-    body: '{"server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-practical-newton", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
-      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
-      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
-      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
-      "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton"},
-      "size": 15000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2567"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:16:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3abe9dc9-ea19-4026-90cd-56a4f212b26a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-srv-optimistic-buck","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"881d7a33-4cfa-4046-b5cf-c33cb9c62fb6","volumes":{"0":{"size":10000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    body: '{"name":"tf-srv-cranky-thompson","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"881d7a33-4cfa-4046-b5cf-c33cb9c62fb6","volumes":{"0":{"name":"tf-vol-dreamy-poitras","size":10000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
     form: {}
     headers:
       Content-Type:
@@ -2804,26 +2743,26 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck",
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-optimistic-buck", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck"},
-      "size": 10000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -2835,15 +2774,15 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2564"
+      - "2552"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:35 GMT
+      - Fri, 15 Jul 2022 12:54:21 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2853,7 +2792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc189ca9-a7b5-46ae-8af8-0a7353fa23c3
+      - 0adec9e5-97b2-4d44-9d7f-1e8dc8354ed0
     status: 201 Created
     code: 201
     duration: ""
@@ -2864,29 +2803,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: GET
   response:
-    body: '{"server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton",
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-practical-newton", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton"},
-      "size": 15000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -2898,13 +2837,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:35 GMT
+      - Fri, 15 Jul 2022 12:54:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2914,7 +2853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6b3eefd-b276-4d1a-b0cb-8009e2e6d2ac
+      - 21528d4c-f0b6-4c52-93bd-c22ace212c1f
     status: 200 OK
     code: 200
     duration: ""
@@ -2925,29 +2864,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: GET
   response:
-    body: '{"server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck",
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-optimistic-buck", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck"},
-      "size": 10000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -2956,6 +2895,168 @@ interactions:
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
       "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
       ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2552"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d69b457c-3348-44e2-894e-346d97ab7809
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
+      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2552"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f9d0faf5-c156-4eea-bcaf-2c055509145d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"action":"poweron"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a/action
+    method: POST
+  response:
+    body: '{"task": {"id": "8e356038-6b26-4f44-a48b-ec5c198b7d95", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/909bad38-e6e0-4255-bcda-e599238fce2a/action",
+      "href_result": "/servers/909bad38-e6e0-4255-bcda-e599238fce2a", "started_at":
+      "2022-07-15T12:54:22.131779+00:00", "terminated_at": null}}'
+    headers:
+      Content-Length:
+      - "322"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:22 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/8e356038-6b26-4f44-a48b-ec5c198b7d95
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 34542af6-67ce-46ac-9cc7-53b71e06b61e
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.874455+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
       "fr-par-1"}}'
     headers:
       Content-Length:
@@ -2965,7 +3066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:35 GMT
+      - Fri, 15 Jul 2022 12:54:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2975,7 +3076,108 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0877269e-ed7f-4cfb-888b-1499829244cb
+      - a22d1927-a699-42f1-b022-634f2d618a4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"action":"poweron"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2/action
+    method: POST
+  response:
+    body: '{"task": {"id": "dc0e4069-aa7c-4884-96da-920cec863a72", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2/action",
+      "href_result": "/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "started_at":
+      "2022-07-15T12:54:22.943732+00:00", "terminated_at": null}}'
+    headers:
+      Content-Length:
+      - "322"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:22 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/dc0e4069-aa7c-4884-96da-920cec863a72
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d67267b3-792f-4ee7-a4be-90622178bc85
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:22.308443+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2574"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73219538-f225-4c54-93da-75424f5a38b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2986,7 +3188,257 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "ipv6": null, "extra_networks": [],
+      "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": "10.71.86.97",
+      "creation_date": "2022-07-15T12:54:21.153699+00:00", "modification_date": "2022-07-15T12:54:21.874455+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9f636097-7211-48e4-b58f-b6c824bb6a4e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "ipv6": null, "extra_networks": [],
+      "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": "10.73.104.15",
+      "creation_date": "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:22.308443+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2682"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2601b42e-50c2-4854-ae29-ead69de42bd5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:29.004883+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2703"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b89fdf0b-2f02-49ce-81a9-d50c89b7d644
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:21.153699+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:29.004883+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2703"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b40fff3f-f42a-4fb7-b66a-f8c8918e9b9a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -2998,7 +3450,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:35 GMT
+      - Fri, 15 Jul 2022 12:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3008,7 +3460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e493b9df-58c3-4975-9382-4793a937f03c
+      - 9972e6e5-79df-4705-ae38-d7d7a50a8bb8
     status: 200 OK
     code: 200
     duration: ""
@@ -3019,7 +3471,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -3031,7 +3483,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:35 GMT
+      - Fri, 15 Jul 2022 12:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3041,73 +3493,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a6be28e-8fdd-4666-b49c-199607033511
+      - 3dbe26b3-d027-45df-aabe-dd4d3069c7b0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
-    method: GET
-  response:
-    body: '{"server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-optimistic-buck", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
-      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
-      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
-      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
-      "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck"},
-      "size": 10000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2564"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:16:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42209dc5-af9c-47e5-a0f6-1af026a691c4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-snap-infallible-sammet","volume_id":"42fd29c2-5b57-40dc-91a0-1755050aa4dc","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
+    body: '{"name":"tf-snap-fervent-stallman","volume_id":"59780ee3-5165-40a5-86d8-fa8f4c9f99e2","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
     form: {}
     headers:
       Content-Type:
@@ -3118,24 +3509,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:35.701043+00:00",
-      "modification_date": "2022-07-07T12:16:35.701043+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:33.448600+00:00",
+      "modification_date": "2022-07-15T12:54:33.448600+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 15000000000, "state":
-      "available", "base_volume": {"id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "da6bd37c-bbfb-4931-82b6-7470e3a595e2", "description":
-      "nop", "status": "pending", "href_from": "/snapshots", "href_result": "snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c",
-      "started_at": "2022-07-07T12:16:35.961561+00:00", "terminated_at": null}}'
+      "snapshotting", "base_volume": {"id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "74fd9288-f07f-452e-9621-8084a8a3e665", "description":
+      "volume_hot_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b", "started_at": "2022-07-15T12:54:33.694504+00:00",
+      "terminated_at": null}}'
     headers:
       Content-Length:
-      - "808"
+      - "810"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3145,7 +3537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1840932f-81f5-4835-a08e-00d4b0c39609
+      - 87a9f9ee-62b5-499a-83a6-ca6652640867
     status: 201 Created
     code: 201
     duration: ""
@@ -3156,47 +3548,49 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: GET
   response:
-    body: '{"server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck",
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-optimistic-buck", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck"},
-      "size": 10000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:29.859453+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2564"
+      - "2713"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3206,7 +3600,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89c76239-e4ee-4f7b-9fed-c92b84f864c0
+      - ef804816-3089-47bd-bb41-7855563f4260
     status: 200 OK
     code: 200
     duration: ""
@@ -3217,25 +3611,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: GET
   response:
-    body: '{"snapshot": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:35.701043+00:00",
-      "modification_date": "2022-07-07T12:16:35.701043+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:33.448600+00:00",
+      "modification_date": "2022-07-15T12:54:33.448600+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 15000000000, "state":
-      "available", "base_volume": {"id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "snapshotting", "base_volume": {"id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "544"
+      - "530"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3245,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e95e9d8-3054-40d5-aafe-710dc6153d45
+      - 20079313-33bd-4615-b423-8d64d6514a03
     status: 200 OK
     code: 200
     duration: ""
@@ -3256,7 +3650,70 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:21.423930+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:29.859453+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2713"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c6b176c-4a8a-4560-b154-8439df77fb39
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -3268,7 +3725,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +3735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 620bfe54-b5de-452a-b6f1-edcc5ad18c7b
+      - f895013c-378c-4181-b5d5-8c39d48aeae8
     status: 200 OK
     code: 200
     duration: ""
@@ -3289,46 +3746,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:35.701043+00:00",
-      "modification_date": "2022-07-07T12:16:35.701043+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 15000000000, "state":
-      "available", "base_volume": {"id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
-    headers:
-      Content-Length:
-      - "544"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 93977156-284f-4124-bb68-168085ec53c2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -3340,7 +3758,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3350,12 +3768,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ed5f2ef-6152-4b8f-b430-781c164b3679
+      - 93a8c34d-ec29-48ea-be1e-7b46495da37e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-elated-jepsen","volume_id":"778e7d73-fb3a-4d62-ad9c-bad29dda031f","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
+    body: '{"name":"tf-snap-awesome-shockley","volume_id":"e02510df-65fb-4b3a-8fb6-0fd40306e77e","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
     form: {}
     headers:
       Content-Type:
@@ -3366,24 +3784,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:36.295510+00:00",
-      "modification_date": "2022-07-07T12:16:36.295510+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:34.380876+00:00",
+      "modification_date": "2022-07-15T12:54:34.380876+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "e2a8a9d5-9b67-4df9-a627-559a71dc370b", "description":
-      "nop", "status": "pending", "href_from": "/snapshots", "href_result": "snapshots/028f9777-57ea-4cad-8c82-2c558eccf895",
-      "started_at": "2022-07-07T12:16:36.557072+00:00", "terminated_at": null}}'
+      "snapshotting", "base_volume": {"id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "6e7fcd0f-1bd3-4ee4-8274-84955934bcee", "description":
+      "volume_hot_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/2b540927-ee24-4388-a588-109e6a1d1b88", "started_at": "2022-07-15T12:54:34.674592+00:00",
+      "terminated_at": null}}'
     headers:
       Content-Length:
-      - "804"
+      - "814"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3393,7 +3812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c87e4480-6804-4a7c-9c5d-876d6475d8c0
+      - 46dc97cb-11e2-4fe3-9361-d28bc4210de8
     status: 201 Created
     code: 201
     duration: ""
@@ -3404,25 +3823,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
     method: GET
   response:
-    body: '{"snapshot": {"id": "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:36.295510+00:00",
-      "modification_date": "2022-07-07T12:16:36.295510+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:34.380876+00:00",
+      "modification_date": "2022-07-15T12:54:34.380876+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "snapshotting", "base_volume": {"id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
-      - "540"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3432,7 +3851,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0af600aa-95f4-4854-81b0-f4bb6c7bac6b
+      - 1a6c0fff-fff8-41a5-a558-ea04a9cb9e6b
     status: 200 OK
     code: 200
     duration: ""
@@ -3443,25 +3862,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: GET
   response:
-    body: '{"snapshot": {"id": "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:36.295510+00:00",
-      "modification_date": "2022-07-07T12:16:36.295510+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"snapshot": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:33.448600+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 15000000000, "state":
+      "available", "base_volume": {"id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2", "name":
+      "tf-vol-sad-beaver"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "540"
+      - "527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3471,7 +3889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fa7e82e-bd62-402b-bd34-b086a6c71872
+      - 4fce14d9-78b1-4107-b773-1787d2a73b42
     status: 200 OK
     code: 200
     duration: ""
@@ -3482,25 +3900,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: GET
   response:
-    body: '{"snapshot": {"id": "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:36.295510+00:00",
-      "modification_date": "2022-07-07T12:16:36.295510+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"snapshot": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:33.448600+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 15000000000, "state":
+      "available", "base_volume": {"id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2", "name":
+      "tf-vol-sad-beaver"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "540"
+      - "527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:36 GMT
+      - Fri, 15 Jul 2022 12:54:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3510,12 +3927,126 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c7d64cb-8c54-43ac-bf70-c51ec8b95771
+      - ff6bffb0-d8db-4aa0-b78f-3702c9cb4fa3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-image-clever-haibt","root_volume":"c40673d4-dc28-4b4a-a192-91ba16cb786c","arch":"x86_64","extra_volumes":{"1":{"id":"028f9777-57ea-4cad-8c82-2c558eccf895","name":"ubuntu_20.04_focal_fossa:volume-0","size":10000000000,"volume_type":"l_ssd"}},"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:34.380876+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e", "name":
+      "tf-vol-dreamy-poitras"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+    headers:
+      Content-Length:
+      - "531"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0ececac2-6d11-4384-b1d3-8b96584ab74c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:34.380876+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e", "name":
+      "tf-vol-dreamy-poitras"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+    headers:
+      Content-Length:
+      - "531"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 05d8204c-834d-4abc-befb-91a5159b8f41
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:34.380876+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e", "name":
+      "tf-vol-dreamy-poitras"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+    headers:
+      Content-Length:
+      - "531"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44f70972-6ca6-4099-9a24-4603c750380c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-image-flamboyant-brahmagupta","root_volume":"6df07ff3-4de3-4652-92ab-0d76b90b079b","arch":"x86_64","extra_volumes":{"1":{"id":"2b540927-ee24-4388-a588-109e6a1d1b88","name":"tf-vol-dreamy-poitras","size":10000000000,"volume_type":"l_ssd"}},"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
     form: {}
     headers:
       Content-Type:
@@ -3526,26 +4057,26 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
     method: POST
   response:
-    body: '{"image": {"id": "fd7dcfa0-ad5a-4360-8079-67841c993e05", "name": "tf-image-clever-haibt",
+    body: '{"image": {"id": "13423339-dbc8-401c-9252-ead00a50f715", "name": "tf-image-flamboyant-brahmagupta",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
+      "root_volume": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
       "volume_type": "l_ssd", "size": 15000000000}, "extra_volumes": {"1": {"id":
-      "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen", "volume_type":
-      "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:16:36.962440+00:00", "modification_date": "2022-07-07T12:16:36.962440+00:00",
+      "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64",
+      "creation_date": "2022-07-15T12:54:40.342036+00:00", "modification_date": "2022-07-15T12:54:40.342036+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "740"
+      - "752"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:37 GMT
+      - Fri, 15 Jul 2022 12:54:40 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3555,7 +4086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5387e56-d2fd-410b-bcb0-203671dded6c
+      - af252a12-e454-4ec4-868d-8bb4e5f293df
     status: 201 Created
     code: 201
     duration: ""
@@ -3566,27 +4097,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
     method: GET
   response:
-    body: '{"image": {"id": "fd7dcfa0-ad5a-4360-8079-67841c993e05", "name": "tf-image-clever-haibt",
+    body: '{"image": {"id": "13423339-dbc8-401c-9252-ead00a50f715", "name": "tf-image-flamboyant-brahmagupta",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
+      "root_volume": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
       "volume_type": "l_ssd", "size": 15000000000}, "extra_volumes": {"1": {"id":
-      "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen", "volume_type":
-      "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:16:36.962440+00:00", "modification_date": "2022-07-07T12:16:36.962440+00:00",
+      "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64",
+      "creation_date": "2022-07-15T12:54:40.342036+00:00", "modification_date": "2022-07-15T12:54:40.342036+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "740"
+      - "752"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:37 GMT
+      - Fri, 15 Jul 2022 12:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3596,7 +4127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7a3c8e0-32c9-430b-93c1-6571dc4e453a
+      - b5a85248-2d00-452b-abef-cebec16f28fd
     status: 200 OK
     code: 200
     duration: ""
@@ -3607,27 +4138,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
     method: GET
   response:
-    body: '{"image": {"id": "fd7dcfa0-ad5a-4360-8079-67841c993e05", "name": "tf-image-clever-haibt",
+    body: '{"image": {"id": "13423339-dbc8-401c-9252-ead00a50f715", "name": "tf-image-flamboyant-brahmagupta",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
+      "root_volume": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
       "volume_type": "l_ssd", "size": 15000000000}, "extra_volumes": {"1": {"id":
-      "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen", "volume_type":
-      "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:16:36.962440+00:00", "modification_date": "2022-07-07T12:16:36.962440+00:00",
+      "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64",
+      "creation_date": "2022-07-15T12:54:40.342036+00:00", "modification_date": "2022-07-15T12:54:40.342036+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "740"
+      - "752"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:37 GMT
+      - Fri, 15 Jul 2022 12:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3637,7 +4168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec836d1f-c566-409a-8f9b-f9b9bba3a148
+      - 60b419da-0277-4b8c-a0dd-4bcbdb2cb7d2
     status: 200 OK
     code: 200
     duration: ""
@@ -3648,47 +4179,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: GET
   response:
-    body: '{"server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton",
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-practical-newton", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton"},
-      "size": 15000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "bootscript": {"id":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:29.004883+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:37 GMT
+      - Fri, 15 Jul 2022 12:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3698,7 +4230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a407873-a26b-40ba-afb4-7ca552558269
+      - 0af6d5fe-0637-4207-bcc7-7bf82c50c24d
     status: 200 OK
     code: 200
     duration: ""
@@ -3709,47 +4241,49 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: GET
   response:
-    body: '{"server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck",
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-optimistic-buck", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck"},
-      "size": 10000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:29.859453+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2564"
+      - "2713"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:37 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3759,7 +4293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3387033-0bf5-46e3-bef4-f8b2404ab99c
+      - 8934f22a-7256-4f0f-8ca8-ee212f1e4a9a
     status: 200 OK
     code: 200
     duration: ""
@@ -3770,25 +4304,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: GET
   response:
-    body: '{"snapshot": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:35.701043+00:00",
-      "modification_date": "2022-07-07T12:16:35.701043+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:33.448600+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 15000000000, "state":
-      "available", "base_volume": {"id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2", "name":
+      "tf-vol-sad-beaver"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "544"
+      - "527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:37 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3798,7 +4331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aee5c18b-f332-4bfe-a6e6-339770922be8
+      - d4927893-602e-49cb-94cb-aba01f792587
     status: 200 OK
     code: 200
     duration: ""
@@ -3809,25 +4342,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
     method: GET
   response:
-    body: '{"snapshot": {"id": "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:36.295510+00:00",
-      "modification_date": "2022-07-07T12:16:36.295510+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:34.380876+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e", "name":
+      "tf-vol-dreamy-poitras"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "540"
+      - "531"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:38 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +4369,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0aedc75d-578b-4505-8801-b6322faafef2
+      - dd18966d-9591-497f-a08a-e31cae7c9fc2
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,27 +4380,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
     method: GET
   response:
-    body: '{"image": {"id": "fd7dcfa0-ad5a-4360-8079-67841c993e05", "name": "tf-image-clever-haibt",
+    body: '{"image": {"id": "13423339-dbc8-401c-9252-ead00a50f715", "name": "tf-image-flamboyant-brahmagupta",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
+      "root_volume": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
       "volume_type": "l_ssd", "size": 15000000000}, "extra_volumes": {"1": {"id":
-      "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen", "volume_type":
-      "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:16:36.962440+00:00", "modification_date": "2022-07-07T12:16:36.962440+00:00",
+      "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64",
+      "creation_date": "2022-07-15T12:54:40.342036+00:00", "modification_date": "2022-07-15T12:54:40.342036+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "740"
+      - "752"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:38 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3878,7 +4410,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c81363b-e70e-4e18-a428-0a5136c9f92f
+      - fa68dd52-085c-4c09-a5f5-2e60a9de0886
     status: 200 OK
     code: 200
     duration: ""
@@ -3889,47 +4421,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: GET
   response:
-    body: '{"server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton",
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-practical-newton", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton"},
-      "size": 15000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "bootscript": {"id":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:29.004883+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:38 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3939,7 +4472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b06e4c64-ea66-4a1b-b121-3819366a6d6c
+      - c50eab1c-5898-466c-9381-db0eefb6c41a
     status: 200 OK
     code: 200
     duration: ""
@@ -3950,47 +4483,49 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: GET
   response:
-    body: '{"server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck",
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-optimistic-buck", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck"},
-      "size": 10000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:29.859453+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2564"
+      - "2713"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:38 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4000,7 +4535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6b6f82b-fc32-4404-9f34-70795e25ce0a
+      - c4c7ce7f-bcc9-4454-9f51-e1834bf22fc9
     status: 200 OK
     code: 200
     duration: ""
@@ -4011,7 +4546,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -4023,7 +4558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:38 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4033,7 +4568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2631490-89a8-4b79-9c68-e4987a4109bc
+      - 9a207a06-5489-460c-ab33-d97ec811ce92
     status: 200 OK
     code: 200
     duration: ""
@@ -4044,7 +4579,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -4056,7 +4591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4066,7 +4601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12541efe-2249-4e3f-9b00-12f844500fc5
+      - 2a73110b-0e7b-402b-b110-604fec75bd57
     status: 200 OK
     code: 200
     duration: ""
@@ -4077,7 +4612,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -4089,7 +4624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4099,7 +4634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5be869f-2afb-4cfb-a5f3-781ab1915a6d
+      - d660962b-7795-49fc-9fae-6c862fee5ef4
     status: 200 OK
     code: 200
     duration: ""
@@ -4110,7 +4645,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -4122,7 +4657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4132,7 +4667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcfe32d3-b946-4fc7-8edd-9ac2ce18608a
+      - 290b341a-94a9-40ea-bfb3-5ddc31ad3054
     status: 200 OK
     code: 200
     duration: ""
@@ -4143,64 +4678,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: GET
   response:
-    body: '{"snapshot": {"id": "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:36.295510+00:00",
-      "modification_date": "2022-07-07T12:16:36.295510+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
-    headers:
-      Content-Length:
-      - "540"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ceace3b6-b610-4bc6-bfb6-3d91aa6da960
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:35.701043+00:00",
-      "modification_date": "2022-07-07T12:16:35.701043+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:33.448600+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 15000000000, "state":
-      "available", "base_volume": {"id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2", "name":
+      "tf-vol-sad-beaver"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "544"
+      - "527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4210,7 +4705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68766150-e61b-475d-a9af-48c601e08a98
+      - 39336ba2-ca0c-46ad-b7c8-03a23602e576
     status: 200 OK
     code: 200
     duration: ""
@@ -4221,27 +4716,65 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
     method: GET
   response:
-    body: '{"image": {"id": "fd7dcfa0-ad5a-4360-8079-67841c993e05", "name": "tf-image-clever-haibt",
+    body: '{"snapshot": {"id": "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:34.380876+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e", "name":
+      "tf-vol-dreamy-poitras"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
+    headers:
+      Content-Length:
+      - "531"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aceafa7a-1ca6-44ad-a1e7-edb277c87553
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
+    method: GET
+  response:
+    body: '{"image": {"id": "13423339-dbc8-401c-9252-ead00a50f715", "name": "tf-image-flamboyant-brahmagupta",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
+      "root_volume": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
       "volume_type": "l_ssd", "size": 15000000000}, "extra_volumes": {"1": {"id":
-      "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen", "volume_type":
-      "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:16:36.962440+00:00", "modification_date": "2022-07-07T12:16:36.962440+00:00",
+      "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64",
+      "creation_date": "2022-07-15T12:54:40.342036+00:00", "modification_date": "2022-07-15T12:54:40.342036+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "740"
+      - "752"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4251,7 +4784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 620838af-8a14-42ad-b1ae-df50a0db4cf1
+      - 7d1c4cdb-1808-47c9-badf-4563a73e45ae
     status: 200 OK
     code: 200
     duration: ""
@@ -4262,27 +4795,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
     method: GET
   response:
-    body: '{"image": {"id": "fd7dcfa0-ad5a-4360-8079-67841c993e05", "name": "tf-image-clever-haibt",
+    body: '{"image": {"id": "13423339-dbc8-401c-9252-ead00a50f715", "name": "tf-image-flamboyant-brahmagupta",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
+      "root_volume": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
       "volume_type": "l_ssd", "size": 15000000000}, "extra_volumes": {"1": {"id":
-      "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen", "volume_type":
-      "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date":
-      "2022-07-07T12:16:36.962440+00:00", "modification_date": "2022-07-07T12:16:36.962440+00:00",
+      "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "size": 10000000000}}, "public": false, "arch": "x86_64",
+      "creation_date": "2022-07-15T12:54:40.342036+00:00", "modification_date": "2022-07-15T12:54:40.342036+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
       [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "740"
+      - "752"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4292,7 +4825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0941d15-8cb2-4afd-a634-446b5a1fd998
+      - 8c68d3f5-1142-463f-8fd1-70a692cf7b84
     status: 200 OK
     code: 200
     duration: ""
@@ -4303,7 +4836,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
     method: DELETE
   response:
     body: ""
@@ -4311,7 +4844,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4321,7 +4854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ec75ce4-2ef6-436d-bd8a-95e7aacd31e4
+      - edd2111e-ed74-42b9-8761-49789631b40f
     status: 204 No Content
     code: 204
     duration: ""
@@ -4332,10 +4865,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"fd7dcfa0-ad5a-4360-8079-67841c993e05\"
+    body: '{"type": "unknown_resource", "message": "\"13423339-dbc8-401c-9252-ead00a50f715\"
       not found"}'
     headers:
       Content-Length:
@@ -4345,7 +4878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4355,7 +4888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d5a843c-2d51-49b7-ad9b-2165c6a49417
+      - 397571d1-dce0-469c-84fe-63be26d15a5a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4366,25 +4899,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
     method: GET
   response:
-    body: '{"snapshot": {"id": "028f9777-57ea-4cad-8c82-2c558eccf895", "name": "tf-snap-elated-jepsen",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:36.295510+00:00",
-      "modification_date": "2022-07-07T12:16:36.295510+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "2b540927-ee24-4388-a588-109e6a1d1b88", "name": "tf-snap-awesome-shockley",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:34.380876+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e", "name":
+      "tf-vol-dreamy-poitras"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "540"
+      - "531"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4394,7 +4926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99e6d4c4-3ed5-4d4c-8ad8-ad7d8b8db646
+      - a50402c5-a197-4d5f-b28b-926597ded58d
     status: 200 OK
     code: 200
     duration: ""
@@ -4405,25 +4937,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: GET
   response:
-    body: '{"snapshot": {"id": "c40673d4-dc28-4b4a-a192-91ba16cb786c", "name": "tf-snap-infallible-sammet",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:16:35.701043+00:00",
-      "modification_date": "2022-07-07T12:16:35.701043+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "6df07ff3-4de3-4652-92ab-0d76b90b079b", "name": "tf-snap-fervent-stallman",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:54:33.448600+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 15000000000, "state":
-      "available", "base_volume": {"id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "available", "base_volume": {"id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2", "name":
+      "tf-vol-sad-beaver"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
     headers:
       Content-Length:
-      - "544"
+      - "527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:39 GMT
+      - Fri, 15 Jul 2022 12:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4433,7 +4964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63fde259-891d-4704-92c1-a74cc3d2ffeb
+      - dfdbd9ea-4390-4b49-9e73-bf8fbae5d04f
     status: 200 OK
     code: 200
     duration: ""
@@ -4444,7 +4975,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: DELETE
   response:
     body: ""
@@ -4452,7 +4983,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4462,7 +4993,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18a5997d-caa2-491f-8297-87ac73b45aef
+      - ebd74f6c-1ece-4127-a284-66cc18ceae43
     status: 204 No Content
     code: 204
     duration: ""
@@ -4473,7 +5004,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
     method: DELETE
   response:
     body: ""
@@ -4481,7 +5012,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4491,7 +5022,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e4b27f1-e826-4924-8c52-0baf5023a8d2
+      - af184f07-53a9-45f2-9b77-aa4466032a1d
     status: 204 No Content
     code: 204
     duration: ""
@@ -4502,10 +5033,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"028f9777-57ea-4cad-8c82-2c558eccf895\"
+    body: '{"type": "unknown_resource", "message": "\"2b540927-ee24-4388-a588-109e6a1d1b88\"
       not found"}'
     headers:
       Content-Length:
@@ -4515,7 +5046,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4525,7 +5056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41750ee3-d42c-427e-be23-99f2ec205acb
+      - 730f9f03-13fa-47fa-b0a0-256e06509233
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4536,10 +5067,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"c40673d4-dc28-4b4a-a192-91ba16cb786c\"
+    body: '{"type": "unknown_resource", "message": "\"6df07ff3-4de3-4652-92ab-0d76b90b079b\"
       not found"}'
     headers:
       Content-Length:
@@ -4549,7 +5080,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4559,7 +5090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 395ab1f3-a1c7-41b2-a416-32f938651625
+      - 8427bb80-bfb7-47f9-a69f-875e4ab12747
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4570,29 +5101,1109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: GET
   response:
-    body: '{"server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck",
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-optimistic-buck", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck"},
-      "size": 10000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:29.004883+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2703"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ed8e55e-5b7c-437b-842a-51034d568699
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:29.859453+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2713"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df894bc7-86e7-468d-be30-6ed555feb363
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"action":"poweroff"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2/action
+    method: POST
+  response:
+    body: '{"task": {"id": "47d243ec-9f32-4766-8960-19e39e5bc652", "description":
+      "server_poweroff", "status": "pending", "href_from": "/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2/action",
+      "href_result": "/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "started_at":
+      "2022-07-15T12:54:43.778557+00:00", "terminated_at": null}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:43 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/47d243ec-9f32-4766-8960-19e39e5bc652
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ef3e134-00a3-47ac-81aa-27874f48a580
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: '{"action":"poweroff"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a/action
+    method: POST
+  response:
+    body: '{"task": {"id": "85ba0a24-2d4a-4288-9ec2-fecbf755e5f3", "description":
+      "server_poweroff", "status": "pending", "href_from": "/servers/909bad38-e6e0-4255-bcda-e599238fce2a/action",
+      "href_result": "/servers/909bad38-e6e0-4255-bcda-e599238fce2a", "started_at":
+      "2022-07-15T12:54:43.840616+00:00", "terminated_at": null}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:43 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/85ba0a24-2d4a-4288-9ec2-fecbf755e5f3
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae894cfe-00a6-4670-a817-5b7b02420e62
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:43.422045+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57afd294-8619-4729-b0d3-6a4cfb86cb80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:43.407206+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44a68d00-e4ef-4d74-a510-4270d608214f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:43.407206+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f0261be3-81c6-401b-8bb0-f7fdd21da4d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:43.422045+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f3a8aa3d-0dd7-41bc-9cf2-104338da8d59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:43.422045+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8bbfaa06-16ff-404c-9a18-d76b3f552c72
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:43.407206+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aecfac06-559e-4a4f-889d-3a7fdefb5708
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:43.422045+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3db243f3-8798-49ac-9921-3a3e8a81708f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:43.407206+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:54:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f1a2c71b-baaa-4b42-849e-4644119dc844
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:43.422045+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a8a05af-8dd0-413f-a9a3-574b50d2ae87
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:43.407206+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 254f4501-6a64-427e-80d9-a832e8c8fd66
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:43.422045+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 434712e7-efdc-4d11-b129-7d08f97c3e0c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:43.407206+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06b67f87-e33c-4222-8f44-b5ba0eb35ae7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.71.86.97", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:43.422045+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "43", "hypervisor_id": "304", "node_id": "49"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3ed9724-595f-418b-ac3d-fdb796570751
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
+    method: GET
+  response:
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.73.104.15", "creation_date":
+      "2022-07-15T12:54:21.423930+00:00", "modification_date": "2022-07-15T12:54:43.407206+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "34", "hypervisor_id": "701", "node_id": "8"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f7938473-5bec-46dd-985a-594764159100
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
+    method: GET
+  response:
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:55:16.599330+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -4604,13 +6215,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2564"
+      - "2542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4620,7 +6231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89dd4b0d-d325-47aa-b815-6a216fa913ef
+      - 07835b9f-d74a-4aba-be2e-077d117d7f87
     status: 200 OK
     code: 200
     duration: ""
@@ -4631,29 +6242,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: GET
   response:
-    body: '{"server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton",
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-practical-newton", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton"},
-      "size": 15000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:55:16.836120+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -4665,13 +6276,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2552"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4681,7 +6292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fae08efd-2123-4020-8d5b-a9f448659c38
+      - 304df218-af86-4ed2-ae79-cd23be1d1dd3
     status: 200 OK
     code: 200
     duration: ""
@@ -4692,29 +6303,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: GET
   response:
-    body: '{"server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck",
+    body: '{"server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-optimistic-buck", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-thirsty-jones", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "778e7d73-fb3a-4d62-ad9c-bad29dda031f",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "fc646c06-83a3-4088-ba6a-de62f26ec2ab", "name": "tf-srv-optimistic-buck"},
-      "size": 10000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "59780ee3-5165-40a5-86d8-fa8f4c9f99e2",
+      "name": "tf-vol-sad-beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "909bad38-e6e0-4255-bcda-e599238fce2a", "name": "tf-srv-thirsty-jones"},
+      "size": 15000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:54:35.420531+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.638825+00:00",
-      "modification_date": "2022-07-07T12:16:34.638825+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.153699+00:00",
+      "modification_date": "2022-07-15T12:55:16.599330+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -4726,13 +6337,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2564"
+      - "2542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4742,7 +6353,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bc43477-1672-4ed3-95f7-dfb968d40c64
+      - b99b2a3b-4119-458e-93b3-dfe35929b36b
     status: 200 OK
     code: 200
     duration: ""
@@ -4753,29 +6364,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: GET
   response:
-    body: '{"server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton",
+    body: '{"server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-practical-newton", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-cranky-thompson", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "42fd29c2-5b57-40dc-91a0-1755050aa4dc",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "1a49de44-1e1d-4e16-a233-ddc1605fbadf", "name": "tf-srv-practical-newton"},
-      "size": 15000000000, "state": "available", "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "tags": [], "zone":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "e02510df-65fb-4b3a-8fb6-0fd40306e77e",
+      "name": "tf-vol-dreamy-poitras", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "d9dea1d7-7dc6-414f-adec-1a4d40f724d2", "name": "tf-srv-cranky-thompson"},
+      "size": 10000000000, "state": "available", "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:54:36.767201+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:16:34.283981+00:00",
-      "modification_date": "2022-07-07T12:16:34.283981+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:54:21.423930+00:00",
+      "modification_date": "2022-07-15T12:55:16.836120+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -4787,13 +6398,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2552"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4803,7 +6414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93402070-039a-48cf-ad92-99af93550910
+      - 8dad9963-e21a-465c-b0e3-36507a5762f6
     status: 200 OK
     code: 200
     duration: ""
@@ -4814,7 +6425,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: DELETE
   response:
     body: ""
@@ -4822,7 +6433,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4832,7 +6443,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85a2c5f7-b4be-4dcd-9bbb-c34b3f4eab78
+      - ceaf25e8-8681-4c0b-a183-e18a5ed9e36b
     status: 204 No Content
     code: 204
     duration: ""
@@ -4843,7 +6454,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: DELETE
   response:
     body: ""
@@ -4851,7 +6462,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4861,7 +6472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acfdc630-6046-4057-9fbc-b7a7e04ac839
+      - eb41b165-f8de-464f-8085-d0e8053d8ec8
     status: 204 No Content
     code: 204
     duration: ""
@@ -4872,10 +6483,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"fc646c06-83a3-4088-ba6a-de62f26ec2ab\"
+    body: '{"type": "unknown_resource", "message": "\"d9dea1d7-7dc6-414f-adec-1a4d40f724d2\"
       not found"}'
     headers:
       Content-Length:
@@ -4885,7 +6496,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:40 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4895,7 +6506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07b39d68-cbcc-4e52-9a96-04817da2cfc0
+      - 256f471d-91dc-4cf1-b8d5-0df99cfb53b7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4906,10 +6517,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"1a49de44-1e1d-4e16-a233-ddc1605fbadf\"
+    body: '{"type": "unknown_resource", "message": "\"909bad38-e6e0-4255-bcda-e599238fce2a\"
       not found"}'
     headers:
       Content-Length:
@@ -4919,7 +6530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:41 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4929,7 +6540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8336f57f-4b73-40d0-80ce-ce70e9dfae2d
+      - 6b2eb51d-8669-4a07-996e-ff5ec4adeeb4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4940,7 +6551,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/778e7d73-fb3a-4d62-ad9c-bad29dda031f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e02510df-65fb-4b3a-8fb6-0fd40306e77e
     method: DELETE
   response:
     body: ""
@@ -4948,7 +6559,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:16:41 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4958,7 +6569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0e3ce8d-046e-48ea-bef4-8b33e0f67e03
+      - 97177938-06dd-45c1-9f64-03aebea55180
     status: 204 No Content
     code: 204
     duration: ""
@@ -4969,7 +6580,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/42fd29c2-5b57-40dc-91a0-1755050aa4dc
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/59780ee3-5165-40a5-86d8-fa8f4c9f99e2
     method: DELETE
   response:
     body: ""
@@ -4977,7 +6588,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:16:41 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4987,7 +6598,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 229f8246-5666-4d89-81ad-24da40ed0036
+      - 7343a3e0-693c-4b25-ab5b-1ab4f0426a02
     status: 204 No Content
     code: 204
     duration: ""
@@ -4998,10 +6609,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/fd7dcfa0-ad5a-4360-8079-67841c993e05
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/13423339-dbc8-401c-9252-ead00a50f715
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"fd7dcfa0-ad5a-4360-8079-67841c993e05\"
+    body: '{"type": "unknown_resource", "message": "\"13423339-dbc8-401c-9252-ead00a50f715\"
       not found"}'
     headers:
       Content-Length:
@@ -5011,7 +6622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:41 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5021,7 +6632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccc6b0fc-45f5-4845-8839-387dd32ac16b
+      - 4a8bdff1-59a2-4693-a3c9-c4a3977232af
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5032,10 +6643,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c40673d4-dc28-4b4a-a192-91ba16cb786c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6df07ff3-4de3-4652-92ab-0d76b90b079b
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"c40673d4-dc28-4b4a-a192-91ba16cb786c\"
+    body: '{"type": "unknown_resource", "message": "\"6df07ff3-4de3-4652-92ab-0d76b90b079b\"
       not found"}'
     headers:
       Content-Length:
@@ -5045,7 +6656,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:41 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5055,7 +6666,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fbf588d-6e0a-4aea-a98b-d05bebb88011
+      - 61ac5f2f-d05f-4e4d-99f7-877408da2dc8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5066,10 +6677,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/028f9777-57ea-4cad-8c82-2c558eccf895
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b540927-ee24-4388-a588-109e6a1d1b88
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"028f9777-57ea-4cad-8c82-2c558eccf895\"
+    body: '{"type": "unknown_resource", "message": "\"2b540927-ee24-4388-a588-109e6a1d1b88\"
       not found"}'
     headers:
       Content-Length:
@@ -5079,7 +6690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:41 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5089,7 +6700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa21880a-35d9-4d4a-8a75-8ab83b8f912f
+      - 6c8ed012-c595-4b9c-8bf4-98287e8dd4ba
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5100,10 +6711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1a49de44-1e1d-4e16-a233-ddc1605fbadf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/909bad38-e6e0-4255-bcda-e599238fce2a
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"1a49de44-1e1d-4e16-a233-ddc1605fbadf\"
+    body: '{"type": "unknown_resource", "message": "\"909bad38-e6e0-4255-bcda-e599238fce2a\"
       not found"}'
     headers:
       Content-Length:
@@ -5113,7 +6724,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:41 GMT
+      - Fri, 15 Jul 2022 12:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5123,7 +6734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8793975-5cc0-442e-9db4-d75810c17626
+      - 9ad7e5cc-5faa-4f58-bbbc-b59423ed9b46
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5134,10 +6745,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fc646c06-83a3-4088-ba6a-de62f26ec2ab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9dea1d7-7dc6-414f-adec-1a4d40f724d2
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"fc646c06-83a3-4088-ba6a-de62f26ec2ab\"
+    body: '{"type": "unknown_resource", "message": "\"d9dea1d7-7dc6-414f-adec-1a4d40f724d2\"
       not found"}'
     headers:
       Content-Length:
@@ -5147,7 +6758,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:16:41 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5157,7 +6768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fcfa948-0d20-47a5-b299-496ab121fc67
+      - b32c9e25-0bf4-4032-b214-f2976aed8f60
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-image-server.cassette.yaml
+++ b/scaleway/testdata/instance-image-server.cassette.yaml
@@ -713,46 +713,46 @@ interactions:
       "Rocky Linux 8", "label": "rockylinux_8", "logo": "https://marketplace-logos.s3.nl-ams.scw.cloud/rockylinux.png",
       "description": "Rocky Linux is a community-driven effort to bring you enterprise-grade,
       production-ready Linux.", "organization": {"id": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "name": "Instances User Resources Build System"}, "versions": [{"id": "8c94a517-442e-448c-80e1-57c3c9a9a92f",
-      "name": "2022-06-15T14:40:42.854386+00:00", "local_images": [{"id": "47b9dce8-fb9b-48a1-a416-5d5847086952",
-      "zone": "pl-waw-1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "9194c6b5-9062-4e95-809e-74c3c40baca3",
+      "name": "Instances User Resources Build System"}, "versions": [{"id": "8ad85252-b11b-404e-bfe3-a0652722d3c0",
+      "name": "2022-07-11T08:48:40.108217+00:00", "local_images": [{"id": "ad2f008b-a159-402a-9677-8c0a16b25fc4",
       "zone": "fr-par-3", "arch": "x86_64", "compatible_commercial_types": ["GP1-L",
       "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M", "START1-S", "START1-XS",
       "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S",
       "ENT1-M", "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S",
-      "PRO2-M", "PRO2-L", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "97e3f42f-9d81-4702-ad49-35946748fd86",
-      "zone": "ams1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
-      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "fab3df2d-1631-45fc-aecc-2c1ce23310c9",
+      "PRO2-M", "PRO2-L", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "af0e5949-58a2-45f3-bda9-5919ef45c309",
       "zone": "nl-ams-2", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
       "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
       "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
       "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
       "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "8adde02e-eec5-4f62-9db9-aa9bdcaace9b",
-      "zone": "par1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
-      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
-      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
-      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
-      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
-      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "a660dcf6-12fe-4562-ac5c-26ae3e7b146f",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "40927774-00c4-421b-ade6-e608796f4321",
       "zone": "fr-par-2", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
       "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
       "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
       "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
       "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO"]}], "creation_date": "2022-06-15T14:40:42.919695+00:00",
-      "modification_date": "2022-06-15T14:40:42.919695+00:00"}], "categories": ["distribution"],
-      "current_public_version": "8c94a517-442e-448c-80e1-57c3c9a9a92f", "creation_date":
-      "2021-06-25T10:16:16.254240+00:00", "modification_date": "2022-06-20T08:54:15.619535+00:00",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "454429e7-d794-4cb8-9831-85e60a1825c0",
+      "zone": "pl-waw-1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "PLAY2-MICRO",
+      "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "34d14210-007a-43c0-9e56-d1548998ae80",
+      "zone": "ams1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}, {"id": "bbb2da3b-5de5-48a2-b6be-0df60a28d84a",
+      "zone": "par1", "arch": "x86_64", "compatible_commercial_types": ["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO"]}], "creation_date": "2022-07-11T08:48:40.175715+00:00",
+      "modification_date": "2022-07-11T08:48:40.175715+00:00"}], "categories": ["distribution"],
+      "current_public_version": "8ad85252-b11b-404e-bfe3-a0652722d3c0", "creation_date":
+      "2021-06-25T10:16:16.254240+00:00", "modification_date": "2022-07-12T09:03:50.736296+00:00",
       "valid_until": null}, {"id": "3f1b9623-71ba-4fe3-b994-27fcdaa850ba", "name":
       "Ubuntu 20.04 Focal Fossa", "label": "ubuntu_focal", "logo": "https://marketplace-logos.s3.nl-ams.scw.cloud/ubuntu.png",
       "description": "Ubuntu is the ideal distribution for scale-out computing, Ubuntu
@@ -929,7 +929,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:45 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Link:
       - </images?page=1&per_page=50&>; rel="last"
       Server:
@@ -941,7 +941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1594f528-c3f7-40ae-be3d-65cf53ec9b5f
+      - 68b5bacb-a1ed-4a44-806d-1a5ea32d2de3
       X-Total-Count:
       - "23"
     status: 200 OK
@@ -1285,7 +1285,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:46 GMT
+      - Fri, 15 Jul 2022 12:55:22 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="last"
       Server:
@@ -1297,14 +1297,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02252aac-c21b-4fed-956b-27a7d5bace59
+      - 69d803d3-c43a-4ee0-b42e-ad0c2e91c660
       X-Total-Count:
       - "36"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-laughing-hermann","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"881d7a33-4cfa-4046-b5cf-c33cb9c62fb6","volumes":{"0":{"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    body: '{"name":"tf-srv-great-cerf","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"881d7a33-4cfa-4046-b5cf-c33cb9c62fb6","volumes":{"0":{"name":"tf-vol-compassionate-grothendieck","size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
     form: {}
     headers:
       Content-Type:
@@ -1315,26 +1315,26 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -1346,15 +1346,15 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:46 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1364,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9afbb67-aeed-400e-bc81-8aeebb2df1f6
+      - 184683c4-4b91-43ba-8efa-2179705f64eb
     status: 201 Created
     code: 201
     duration: ""
@@ -1375,29 +1375,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -1409,13 +1409,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:47 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88b76639-be59-4e64-959b-f30d1a9b390c
+      - a1c3b040-2afd-4797-b0f3-73118e77b241
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,29 +1436,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -1470,13 +1470,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:47 GMT
+      - Fri, 15 Jul 2022 12:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1486,9 +1486,49 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 203c9d40-26a1-4709-a5dd-788b8c0638dd
+      - 0a7df121-fa0a-4cf7-80e6-cba4c1d7f843
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: '{"action":"poweron"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/action
+    method: POST
+  response:
+    body: '{"task": {"id": "2d0b2a55-049f-4a6d-a5f8-78191b5353e4", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/action",
+      "href_result": "/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414", "started_at":
+      "2022-07-15T12:55:24.338380+00:00", "terminated_at": null}}'
+    headers:
+      Content-Length:
+      - "322"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:24 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/2d0b2a55-049f-4a6d-a5f8-78191b5353e4
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9922f5e9-5ac8-4fc3-bb78-6321a19dd44d
+    status: 202 Accepted
+    code: 202
     duration: ""
 - request:
     body: ""
@@ -1497,29 +1537,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:24.056955+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -1527,17 +1567,17 @@ interactions:
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
       "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2571"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:47 GMT
+      - Fri, 15 Jul 2022 12:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1547,7 +1587,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 069a667a-c134-42ac-bae7-4e2d648e0d9f
+      - 73aed717-d0f4-4cf2-8bf6-b2cbaaaaae6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1558,7 +1598,255 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:24.056955+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2571"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5492d89c-afc4-4c5c-9bfa-642b79aee3a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "ipv6": null, "extra_networks": [],
+      "dynamic_ip_required": false, "enable_ipv6": false, "private_ip": "10.64.74.41",
+      "creation_date": "2022-07-15T12:55:23.097467+00:00", "modification_date": "2022-07-15T12:55:24.056955+00:00",
+      "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true,
+      "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64", "organization":
+      "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
+      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd165a3b-d833-45e8-b92f-00b7a21652db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:37.066270+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2711"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db929472-6e6d-435e-89ba-3a1f9752d831
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:23.097467+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:37.066270+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2711"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9c350c01-ad90-4160-8975-1688e88b3335
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -1570,7 +1858,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:47 GMT
+      - Fri, 15 Jul 2022 12:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1580,7 +1868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77a50694-8fad-4c35-8f20-e5aa94ecd74a
+      - 7d2762de-8fad-45d2-8ca4-af12c101e190
     status: 200 OK
     code: 200
     duration: ""
@@ -1591,7 +1879,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -1603,7 +1891,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:48 GMT
+      - Fri, 15 Jul 2022 12:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1613,12 +1901,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3b8b98d-3b13-4230-af59-45ed68a94647
+      - 2e4fea4c-c229-4ba5-bcc6-0a346350702f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-brave-chaplygin","volume_id":"05f044fb-f30c-4207-adfc-ebf0691f3d5a","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
+    body: '{"name":"tf-snap-jovial-elbakyan","volume_id":"9f56d4d3-ca2e-4ba0-b759-3c1a98fce605","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","volume_type":"unknown_volume_type"}'
     form: {}
     headers:
       Content-Type:
@@ -1629,24 +1917,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:40.759361+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "5fa145e5-03bc-42f0-af78-bcb2df525449", "description":
-      "nop", "status": "pending", "href_from": "/snapshots", "href_result": "snapshots/f400865d-f88d-4160-ad49-d98816af3b87",
-      "started_at": "2022-07-07T12:01:48.477422+00:00", "terminated_at": null}}'
+      "snapshotting", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1",
+      "error_details": null}, "task": {"id": "71ac8725-e8c1-49d9-8af9-055007325f03",
+      "description": "volume_hot_snapshot", "status": "pending", "href_from": "/snapshots",
+      "href_result": "snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0", "started_at":
+      "2022-07-15T12:55:41.031215+00:00", "terminated_at": null}}'
     headers:
       Content-Length:
-      - "806"
+      - "825"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:48 GMT
+      - Fri, 15 Jul 2022 12:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1945,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a565925-ace7-4ccc-b053-5109ce01b7cf
+      - 04209fc0-0eaa-4c49-954b-06f2303b1dcc
     status: 201 Created
     code: 201
     duration: ""
@@ -1667,25 +1956,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:40.759361+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
+      "snapshotting", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1",
+      "error_details": null}}'
     headers:
       Content-Length:
-      - "542"
+      - "545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:48 GMT
+      - Fri, 15 Jul 2022 12:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1695,7 +1984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20c578de-5729-43ea-bf73-71c41c82bbd4
+      - c9e1ba39-22f8-4ff0-9e91-76ec8401417d
     status: 200 OK
     code: 200
     duration: ""
@@ -1706,15 +1995,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605", "name":
+      "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
@@ -1724,7 +2013,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:48 GMT
+      - Fri, 15 Jul 2022 12:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1734,12 +2023,51 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07d6761c-55cb-4590-a38b-cc7a6d01dd98
+      - e51a25d4-57e0-4763-b9ac-23fa9fb4987f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-image-compassionate-lovelace","root_volume":"f400865d-f88d-4160-ad49-d98816af3b87","arch":"x86_64","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":["test_remove_tags"]}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605", "name":
+      "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    headers:
+      Content-Length:
+      - "542"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59274b93-2a28-4bb9-809a-51459065bc52
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-image-cranky-mendel","root_volume":"c41eeedf-56e7-485a-9231-d5862ceab9c0","arch":"x86_64","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":["test_remove_tags"]}'
     form: {}
     headers:
       Content-Type:
@@ -1750,25 +2078,25 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
     method: POST
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:48.823940+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:46.555540+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["test_remove_tags"],
       "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "637"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:48 GMT
+      - Fri, 15 Jul 2022 12:55:46 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1778,7 +2106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7af29c23-ca14-49b6-b6be-1a73f2d09af5
+      - feaecf99-7646-4834-9623-4e418b05d8b9
     status: 201 Created
     code: 201
     duration: ""
@@ -1789,26 +2117,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:48.823940+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:46.555540+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["test_remove_tags"],
       "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "637"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:49 GMT
+      - Fri, 15 Jul 2022 12:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1818,7 +2146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abdaebd4-b3e9-4575-84ff-37119b97d59a
+      - 79821dad-3b1d-42c6-8056-c1afd849e7eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1829,26 +2157,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:48.823940+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:46.555540+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["test_remove_tags"],
       "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "637"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:49 GMT
+      - Fri, 15 Jul 2022 12:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1858,7 +2186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8913c570-6f00-4e70-9b75-566bb8a303f3
+      - 2187f8b1-a214-4071-b020-2420f73d2b93
     status: 200 OK
     code: 200
     duration: ""
@@ -1869,47 +2197,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:37.066270+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:49 GMT
+      - Fri, 15 Jul 2022 12:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1919,7 +2248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a7f6440-82f4-42b3-be08-a0e6fe65f170
+      - 47f3ac4c-e965-4caa-89e9-274faca52d0a
     status: 200 OK
     code: 200
     duration: ""
@@ -1930,15 +2259,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605", "name":
+      "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
@@ -1948,7 +2277,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:49 GMT
+      - Fri, 15 Jul 2022 12:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1958,7 +2287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c47726e7-3cb8-4c7f-8404-790b3d4c94b4
+      - d581cf40-7006-4581-abe5-7b9fffd0c9c1
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,26 +2298,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:48.823940+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:46.555540+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["test_remove_tags"],
       "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "637"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:49 GMT
+      - Fri, 15 Jul 2022 12:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1998,7 +2327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1633f97c-7d2e-4662-91ee-2ea1473c7ae8
+      - 144d3f45-4528-4c09-88cc-8d544cfb28f3
     status: 200 OK
     code: 200
     duration: ""
@@ -2009,47 +2338,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:37.066270+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:49 GMT
+      - Fri, 15 Jul 2022 12:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2059,7 +2389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6eb42cc9-4079-4e3e-ad79-e0da0a662afc
+      - dd230a01-30cc-45f9-9cb1-5d806789a451
     status: 200 OK
     code: 200
     duration: ""
@@ -2070,7 +2400,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -2082,7 +2412,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:50 GMT
+      - Fri, 15 Jul 2022 12:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2092,7 +2422,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 735af312-4669-49d0-acad-9f5944b47459
+      - ed3da70c-519a-4169-87e8-36e55c2cb2c4
     status: 200 OK
     code: 200
     duration: ""
@@ -2103,7 +2433,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -2115,7 +2445,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:50 GMT
+      - Fri, 15 Jul 2022 12:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2125,7 +2455,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdaf8225-343d-421d-98bd-79e6025f270d
+      - 3f5e7e9a-39e0-44be-a539-7122731998b2
     status: 200 OK
     code: 200
     duration: ""
@@ -2136,15 +2466,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605", "name":
+      "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
@@ -2154,7 +2484,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:50 GMT
+      - Fri, 15 Jul 2022 12:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2164,7 +2494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77e13352-c78a-41a0-b4f2-adc87b8e4fc6
+      - cdf7436c-32ce-48df-b67d-427abaaefec2
     status: 200 OK
     code: 200
     duration: ""
@@ -2175,26 +2505,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:48.823940+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:46.555540+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["test_remove_tags"],
       "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "637"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:50 GMT
+      - Fri, 15 Jul 2022 12:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2204,7 +2534,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7c41b88-5dbd-4389-a499-0c25ef90b4de
+      - 5c55177b-f763-4aff-90d9-aac36dea963b
     status: 200 OK
     code: 200
     duration: ""
@@ -2215,47 +2545,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:37.066270+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:50 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2265,7 +2596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa11cd1a-2c8b-46ef-a105-334b1a25f81e
+      - ae49442b-9de4-4b30-8997-0117b02176a3
     status: 200 OK
     code: 200
     duration: ""
@@ -2276,7 +2607,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -2288,7 +2619,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:50 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2298,7 +2629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1ad30cd-f973-4c22-980c-f50c77f8f11d
+      - 2a467c59-bfb7-4909-838f-cf8b3d0a1bc8
     status: 200 OK
     code: 200
     duration: ""
@@ -2309,7 +2640,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -2321,7 +2652,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:50 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2331,7 +2662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00249a85-33f2-485a-a828-8340809e3a12
+      - ceaf5ac4-61aa-49c5-9ecd-4ad99b14b275
     status: 200 OK
     code: 200
     duration: ""
@@ -2342,15 +2673,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605", "name":
+      "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
@@ -2360,7 +2691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:51 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2370,7 +2701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b33e96a-d949-4147-95d7-f888c5c51349
+      - 91e2eaa4-4eb5-49ab-8a68-130902f7a46e
     status: 200 OK
     code: 200
     duration: ""
@@ -2381,26 +2712,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:48.823940+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:46.555540+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["test_remove_tags"],
       "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "637"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:51 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2410,7 +2741,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be0be30d-d87f-4561-8fe1-ef5509099c0a
+      - 9402629f-52ac-44f4-89fc-95d7fe9ea117
     status: 200 OK
     code: 200
     duration: ""
@@ -2421,26 +2752,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:48.823940+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:46.555540+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["test_remove_tags"],
       "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "637"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:51 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2450,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3e91d9a-04ba-4663-8871-cef43edb1cc2
+      - 2d358fc9-f92e-4482-80f3-ff2cea11c0a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2461,26 +2792,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:48.823940+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:46.555540+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": ["test_remove_tags"],
       "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "637"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:51 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2490,12 +2821,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d787a8b0-0b9b-4f43-b3fe-cc58aa4a22dd
+      - 001d17ab-2cc3-4df6-aef6-b798eedacca7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"zone":"fr-par-1","id":"b08f24a3-fe8e-4da1-8d34-211a2fe7255c","name":"tf-image-compassionate-lovelace","arch":"x86_64","creation_date":"2022-07-07T12:01:48.82394Z","modification_date":"2022-07-07T12:01:48.82394Z","extra_volumes":{},"organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","public":false,"root_volume":{"id":"f400865d-f88d-4160-ad49-d98816af3b87","name":"tf-snap-brave-chaplygin","size":20000000000,"volume_type":"l_ssd"},"state":"available","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[]}'
+    body: '{"zone":"fr-par-1","id":"8b8f1730-d794-4a60-bbf7-ecba904720bc","name":"tf-image-cranky-mendel","arch":"x86_64","creation_date":"2022-07-15T12:55:46.55554Z","modification_date":"2022-07-15T12:55:46.55554Z","extra_volumes":{},"organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","public":false,"root_volume":{"id":"c41eeedf-56e7-485a-9231-d5862ceab9c0","name":"tf-snap-jovial-elbakyan","size":20000000000,"volume_type":"l_ssd"},"state":"available","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[]}'
     form: {}
     headers:
       Content-Type:
@@ -2503,25 +2834,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: PUT
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:51.526757+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:48.827404+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "619"
+      - "610"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:51 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2531,7 +2862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd4f0e93-0b91-468d-a3d2-6dfaa431f8d8
+      - 482030ce-a91a-4bc0-812e-ae623c62c3ad
     status: 200 OK
     code: 200
     duration: ""
@@ -2542,25 +2873,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:51.526757+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:48.827404+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "619"
+      - "610"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:51 GMT
+      - Fri, 15 Jul 2022 12:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2570,7 +2901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bea1bdad-078f-4d3f-a9df-c8d39cb62a89
+      - fcbbcb65-1820-4441-a06b-027889b65d79
     status: 200 OK
     code: 200
     duration: ""
@@ -2581,25 +2912,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:51.526757+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:48.827404+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "619"
+      - "610"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:51 GMT
+      - Fri, 15 Jul 2022 12:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2609,7 +2940,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0dd7925-167d-49f7-bb22-10b547421add
+      - 239cc397-a44c-4736-9485-1a5b5b2c4b2d
     status: 200 OK
     code: 200
     duration: ""
@@ -2620,47 +2951,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:37.066270+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:51 GMT
+      - Fri, 15 Jul 2022 12:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2670,7 +3002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5edb3715-581c-4bef-a4eb-e750473ef23c
+      - d681d2c5-671e-4fd0-af73-afe3faa50246
     status: 200 OK
     code: 200
     duration: ""
@@ -2681,15 +3013,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605", "name":
+      "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
@@ -2699,7 +3031,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:52 GMT
+      - Fri, 15 Jul 2022 12:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2709,7 +3041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04445011-4a26-4829-9e34-2704b156842a
+      - e21559b1-beae-4fda-8c79-ef6de7353019
     status: 200 OK
     code: 200
     duration: ""
@@ -2720,25 +3052,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:51.526757+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:48.827404+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "619"
+      - "610"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:52 GMT
+      - Fri, 15 Jul 2022 12:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +3080,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70a18230-09d6-453c-aa8c-69378bb27961
+      - d04e34df-9836-49a4-818b-eadf5808c88a
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,47 +3091,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:37.066270+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
       "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
       "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
       true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:52 GMT
+      - Fri, 15 Jul 2022 12:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2809,7 +3142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 434f676f-661a-4e83-9cbf-079c4cc19c56
+      - 29707beb-4607-438e-9c0b-8c6b61e8a85b
     status: 200 OK
     code: 200
     duration: ""
@@ -2820,7 +3153,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/user_data
     method: GET
   response:
     body: '{"user_data": []}'
@@ -2832,7 +3165,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:52 GMT
+      - Fri, 15 Jul 2022 12:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2842,7 +3175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22d94384-5f1e-4bca-92b7-9c525c350b84
+      - 4a6e16be-faed-4c7c-bd10-9e3c81878832
     status: 200 OK
     code: 200
     duration: ""
@@ -2853,7 +3186,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/private_nics
     method: GET
   response:
     body: '{"private_nics": []}'
@@ -2865,7 +3198,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:52 GMT
+      - Fri, 15 Jul 2022 12:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2875,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1266c0ae-344c-4057-8d66-51853f310e2a
+      - a052eba3-31ea-4f1c-9ac3-101c86769e8a
     status: 200 OK
     code: 200
     duration: ""
@@ -2886,15 +3219,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605", "name":
+      "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
@@ -2904,7 +3237,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:52 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2914,7 +3247,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0f062ad-2413-40f7-8494-cd353de1df8a
+      - c2842bd6-dcc2-40d2-a3b3-60d0133c7f40
     status: 200 OK
     code: 200
     duration: ""
@@ -2925,25 +3258,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:51.526757+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:48.827404+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "619"
+      - "610"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:53 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2953,7 +3286,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f10124c-db38-4a74-90be-47154a48657f
+      - 456ca356-2565-454a-ade5-445f81a92376
     status: 200 OK
     code: 200
     duration: ""
@@ -2964,25 +3297,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"image": {"id": "b08f24a3-fe8e-4da1-8d34-211a2fe7255c", "name": "tf-image-compassionate-lovelace",
+    body: '{"image": {"id": "8b8f1730-d794-4a60-bbf7-ecba904720bc", "name": "tf-image-cranky-mendel",
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "root_volume": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
+      "root_volume": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
       "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2022-07-07T12:01:48.823940+00:00",
-      "modification_date": "2022-07-07T12:01:51.526757+00:00", "default_bootscript":
+      false, "arch": "x86_64", "creation_date": "2022-07-15T12:55:46.555540+00:00",
+      "modification_date": "2022-07-15T12:55:48.827404+00:00", "default_bootscript":
       null, "from_server": null, "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "619"
+      - "610"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:53 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2992,7 +3325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42526b0c-a9c9-4e32-888f-2d5e0749f647
+      - c7a0678a-52be-4202-9952-78e96999296d
     status: 200 OK
     code: 200
     duration: ""
@@ -3003,7 +3336,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: DELETE
   response:
     body: ""
@@ -3011,7 +3344,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:01:53 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3021,7 +3354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64135af2-5a8c-437d-b9c3-670f39b1e304
+      - 8b62e885-079f-4e0b-a624-35824f2b2897
     status: 204 No Content
     code: 204
     duration: ""
@@ -3032,10 +3365,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"b08f24a3-fe8e-4da1-8d34-211a2fe7255c\"
+    body: '{"type": "unknown_resource", "message": "\"8b8f1730-d794-4a60-bbf7-ecba904720bc\"
       not found"}'
     headers:
       Content-Length:
@@ -3045,7 +3378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:53 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3055,7 +3388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a9aee59-b4b5-475f-b400-1fee51f7cc4e
+      - 1505bfad-c395-45a2-b106-2c146b40770a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3066,15 +3399,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"snapshot": {"id": "f400865d-f88d-4160-ad49-d98816af3b87", "name": "tf-snap-brave-chaplygin",
-      "volume_type": "l_ssd", "creation_date": "2022-07-07T12:01:48.191661+00:00",
-      "modification_date": "2022-07-07T12:01:48.191661+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "c41eeedf-56e7-485a-9231-d5862ceab9c0", "name": "tf-snap-jovial-elbakyan",
+      "volume_type": "l_ssd", "creation_date": "2022-07-15T12:55:40.759361+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a", "name":
-      "ubuntu_20.04_focal_fossa:volume-0"}, "tags": [], "zone": "fr-par-1", "error_details":
+      "available", "base_volume": {"id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605", "name":
+      "tf-vol-compassionate-grothendieck"}, "tags": [], "zone": "fr-par-1", "error_details":
       null}}'
     headers:
       Content-Length:
@@ -3084,7 +3417,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:53 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3094,7 +3427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75ee13db-0f84-44d2-9b43-b783b375b82e
+      - cefe935e-0d75-4f79-a7f2-d9eff58c1dd4
     status: 200 OK
     code: 200
     duration: ""
@@ -3105,7 +3438,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: DELETE
   response:
     body: ""
@@ -3113,7 +3446,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:01:53 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3123,7 +3456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69db60a2-cae3-4a0e-b781-8d144ef87c3f
+      - b1dced7c-8983-40f7-ae42-f9886ba52c8b
     status: 204 No Content
     code: 204
     duration: ""
@@ -3134,10 +3467,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"f400865d-f88d-4160-ad49-d98816af3b87\"
+    body: '{"type": "unknown_resource", "message": "\"c41eeedf-56e7-485a-9231-d5862ceab9c0\"
       not found"}'
     headers:
       Content-Length:
@@ -3147,7 +3480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:54 GMT
+      - Fri, 15 Jul 2022 12:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3157,7 +3490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0f09fe3-ed05-485e-ac5d-8006f6b0361b
+      - c4e57063-4947-4caa-8b71-067250d2f9d3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3168,29 +3501,565 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:37.066270+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2711"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e38df243-f037-4760-90ff-6c668a038497
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"action":"poweroff"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/action
+    method: POST
+  response:
+    body: '{"task": {"id": "3fe22de9-aff2-46ab-a2a7-8f02fc66ab68", "description":
+      "server_poweroff", "status": "pending", "href_from": "/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414/action",
+      "href_result": "/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414", "started_at":
+      "2022-07-15T12:55:51.357895+00:00", "terminated_at": null}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:51 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3fe22de9-aff2-46ab-a2a7-8f02fc66ab68
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8970e183-51d5-4a6b-a684-c1ac577d3d73
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:51.120536+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b443e7c-3e14-450f-ab9c-ba9d51098038
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:51.120536+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:55:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7246262f-b30d-482b-b3fa-0e207654c0b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:51.120536+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99e882f6-9a47-4e8b-904b-1d40fbf02a5b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:51.120536+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1e762e62-4ac2-481a-b111-aab663436da1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:51.120536+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 366eae8d-a9d3-415f-b9dd-fd15ced6286a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:51.120536+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ecde80a9-65fc-41d3-bd97-a4bd6f3513c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "stopping", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": "10.64.74.41", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:51.120536+00:00", "bootscript": {"id":
+      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
+      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
+      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
+      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
+      true, "zone": "fr-par-1"}, "security_group": {"id": "75cc2e54-0eb5-4d98-af0c-72c24c6b3173",
+      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
+      "14", "cluster_id": "15", "hypervisor_id": "1902", "node_id": "21"}, "maintenances":
+      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
+      "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2671"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Jul 2022 12:56:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8442088b-9f5f-4140-82a5-d51b7165568c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
+    method: GET
+  response:
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
+      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
+      10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
+      "default_bootscript": null, "from_server": null, "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:56:24.559569+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -3202,13 +4071,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:54 GMT
+      - Fri, 15 Jul 2022 12:56:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3218,7 +4087,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f16a31c-95a8-496a-b268-845e8461c635
+      - c3d9dc88-b332-4410-b38b-ef9c241b8cc5
     status: 200 OK
     code: 200
     duration: ""
@@ -3229,29 +4098,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann",
+    body: '{"server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "hostname": "tf-srv-laughing-hermann", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
+      "hostname": "tf-srv-great-cerf", "image": {"id": "881d7a33-4cfa-4046-b5cf-c33cb9c62fb6",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "deb50fd4-209d-4fe2-9e39-1d2c85912133",
       "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "unified", "size":
       10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
       "2022-01-21T08:38:33.552838+00:00", "modification_date": "2022-01-21T08:38:33.552838+00:00",
       "default_bootscript": null, "from_server": null, "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "05f044fb-f30c-4207-adfc-ebf0691f3d5a",
-      "name": "ubuntu_20.04_focal_fossa:volume-0", "volume_type": "l_ssd", "export_uri":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "9f56d4d3-ca2e-4ba0-b759-3c1a98fce605",
+      "name": "tf-vol-compassionate-grothendieck", "volume_type": "l_ssd", "export_uri":
       null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "server": {"id": "dce11725-68c0-43e2-a574-b91e5701e982", "name": "tf-srv-laughing-hermann"},
-      "size": 20000000000, "state": "available", "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "tags": [], "zone":
+      "server": {"id": "bf570ae3-e9f1-4606-9470-f2be82bb3414", "name": "tf-srv-great-cerf"},
+      "size": 20000000000, "state": "available", "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:55:42.865104+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
       "", "public_ip": null, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-07T12:01:46.671115+00:00",
-      "modification_date": "2022-07-07T12:01:46.671115+00:00", "bootscript": {"id":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2022-07-15T12:55:23.097467+00:00",
+      "modification_date": "2022-07-15T12:56:24.559569+00:00", "bootscript": {"id":
       "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
       4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
       "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
@@ -3263,13 +4132,13 @@ interactions:
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2567"
+      - "2549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:54 GMT
+      - Fri, 15 Jul 2022 12:56:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3279,7 +4148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9abfc462-bf4a-4faf-92cc-0b4d82225fcc
+      - df055d62-6177-4f0d-89e1-3c0e3090ab05
     status: 200 OK
     code: 200
     duration: ""
@@ -3290,7 +4159,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: DELETE
   response:
     body: ""
@@ -3298,7 +4167,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:01:54 GMT
+      - Fri, 15 Jul 2022 12:56:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3308,7 +4177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9735135c-e2be-4426-bb63-2a1ccb840db0
+      - 748bf377-72a5-4e5d-8674-9f0b74def9e9
     status: 204 No Content
     code: 204
     duration: ""
@@ -3319,10 +4188,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"dce11725-68c0-43e2-a574-b91e5701e982\"
+    body: '{"type": "unknown_resource", "message": "\"bf570ae3-e9f1-4606-9470-f2be82bb3414\"
       not found"}'
     headers:
       Content-Length:
@@ -3332,7 +4201,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:54 GMT
+      - Fri, 15 Jul 2022 12:56:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +4211,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06d2e0cd-8452-45a4-93d8-084fc5156d39
+      - 0783c3ef-f50f-4847-898b-e52891b772f1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3353,7 +4222,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/05f044fb-f30c-4207-adfc-ebf0691f3d5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/9f56d4d3-ca2e-4ba0-b759-3c1a98fce605
     method: DELETE
   response:
     body: ""
@@ -3361,7 +4230,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 07 Jul 2022 12:01:54 GMT
+      - Fri, 15 Jul 2022 12:56:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3371,7 +4240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68251792-3a41-41f1-981c-16bf2c803468
+      - cd87f96b-915f-4716-afe6-e1ef51201be5
     status: 204 No Content
     code: 204
     duration: ""
@@ -3382,10 +4251,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b08f24a3-fe8e-4da1-8d34-211a2fe7255c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/8b8f1730-d794-4a60-bbf7-ecba904720bc
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"b08f24a3-fe8e-4da1-8d34-211a2fe7255c\"
+    body: '{"type": "unknown_resource", "message": "\"8b8f1730-d794-4a60-bbf7-ecba904720bc\"
       not found"}'
     headers:
       Content-Length:
@@ -3395,7 +4264,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:55 GMT
+      - Fri, 15 Jul 2022 12:56:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3405,7 +4274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b68e4f74-ce23-4d90-8c95-f53baa81b99c
+      - fd96a651-cc47-459b-b940-08c31a0a635c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3416,10 +4285,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f400865d-f88d-4160-ad49-d98816af3b87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c41eeedf-56e7-485a-9231-d5862ceab9c0
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"f400865d-f88d-4160-ad49-d98816af3b87\"
+    body: '{"type": "unknown_resource", "message": "\"c41eeedf-56e7-485a-9231-d5862ceab9c0\"
       not found"}'
     headers:
       Content-Length:
@@ -3429,7 +4298,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:55 GMT
+      - Fri, 15 Jul 2022 12:56:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3439,7 +4308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 383b274d-6827-43e5-8aa4-481d137832e5
+      - f0a6982c-a57c-4913-aa54-76a31da7910a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3450,10 +4319,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.3; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dce11725-68c0-43e2-a574-b91e5701e982
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf570ae3-e9f1-4606-9470-f2be82bb3414
     method: GET
   response:
-    body: '{"type": "unknown_resource", "message": "\"dce11725-68c0-43e2-a574-b91e5701e982\"
+    body: '{"type": "unknown_resource", "message": "\"bf570ae3-e9f1-4606-9470-f2be82bb3414\"
       not found"}'
     headers:
       Content-Length:
@@ -3463,7 +4332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jul 2022 12:01:55 GMT
+      - Fri, 15 Jul 2022 12:56:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3473,7 +4342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 448622fd-c534-4399-8a3b-f1cf115fe963
+      - efe187e9-e2b2-4e9c-b19d-77926740ca4c
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
To fix the error "cannot snapshot volume ***: cannot create a ro disk from an empty disk" in the nightly tests, I removed state "stopped" in tests involving servers.