### PR TITLE
fix(vpcgw_dhcp): set dns search and servers_override fields to computed

### DIFF
--- a/scaleway/resource_vpc_public_gateway_dhcp.go
+++ b/scaleway/resource_vpc_public_gateway_dhcp.go
@@ -210,14 +210,6 @@ func resourceScalewayVPCPublicGatewayDHCPRead(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 
-	if len(dhcp.DNSSearch) > 0 {
-		_ = d.Set("dns_search", flattenSliceString(dhcp.DNSSearch))
-	}
-
-	if len(dhcp.DNSServersOverride) > 0 {
-		_ = d.Set("dns_servers_override", flattenSliceString(dhcp.DNSServersOverride))
-	}
-
 	_ = d.Set("address", dhcp.Address.String())
 	_ = d.Set("created_at", dhcp.CreatedAt.Format(time.RFC3339))
 	_ = d.Set("dns_local_name", dhcp.DNSLocalName)
@@ -228,6 +220,8 @@ func resourceScalewayVPCPublicGatewayDHCPRead(ctx context.Context, d *schema.Res
 	_ = d.Set("project_id", dhcp.ProjectID)
 	_ = d.Set("push_default_route", dhcp.PushDefaultRoute)
 	_ = d.Set("push_dns_server", dhcp.PushDNSServer)
+	_ = d.Set("dns_search", flattenSliceString(dhcp.DNSSearch))
+	_ = d.Set("dns_servers_override", flattenSliceString(dhcp.DNSServersOverride))
 	_ = d.Set("rebind_timer", dhcp.RebindTimer.Seconds)
 	_ = d.Set("renew_timer", dhcp.RenewTimer.Seconds)
 	_ = d.Set("subnet", dhcp.Subnet.String())

--- a/scaleway/resource_vpc_public_gateway_dhcp.go
+++ b/scaleway/resource_vpc_public_gateway_dhcp.go
@@ -90,6 +90,7 @@ func resourceScalewayVPCPublicGatewayDHCP() *schema.Resource {
 			"dns_servers_override": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -98,6 +99,7 @@ func resourceScalewayVPCPublicGatewayDHCP() *schema.Resource {
 			"dns_search": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
Errors reported on scaleway community slack
```
    The following problems may be the cause of any confusing errors from downstream operations:
      - .dns_servers_override: planned value cty.ListValEmpty(cty.String) for a non-computed attribute
      - .dns_search: planned value cty.ListValEmpty(cty.String) for a non-computed attribut
```