### PR TITLE
docs: add lifecycle in lb_certificate example

### DIFF
--- a/docs/resources/lb_frontend.md
+++ b/docs/resources/lb_frontend.md
@@ -45,6 +45,10 @@ resource scaleway_lb_certificate cert01 {
     letsencrypt {
         common_name = "${replace(scaleway_lb_ip.ip01.ip_address,".", "-")}.lb.${scaleway_lb.lb01.region}.scw.cloud"
     }
+    # Make sure the new certificate is created before the old one can be replaced
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource scaleway_lb_frontend frt01 {


### PR DESCRIPTION
Hello,

I believe an important piece of information is missing from the documentation about certificates attached to load balancers.

If the `create_before_destroy` lifecycle rule is not set on a certificate attached to a load balancer, the user will get the error message: "operation was rejected because the certificate is used on a frontend" when trying to change the certificate (add a domain for instance).

![2022-10-25-001226_870x58_scrot](https://user-images.githubusercontent.com/3043706/197889939-7332459a-5d40-4211-8e10-3f18933b6d44.png)

Having this rule fixes the issue. I had the idea to set it because it is the same with DigitalOcean, but they have this on their doc:
![2022-10-26-000029_675x167_scrot](https://user-images.githubusercontent.com/3043706/197890406-d05b77ed-4561-416d-93d6-0936ff17536d.png) ([source](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/loadbalancer))


I added the setting in load balancer code examples, but it might also be useful to add it on `lb_certificate` page, or a note about it.

Best,
~Nico
