### PR TITLE
fix(object): fix region retrieval for object bucket website endpoint

### DIFF
--- a/scaleway/helpers_object.go
+++ b/scaleway/helpers_object.go
@@ -14,10 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -466,22 +464,6 @@ func SecondJSONUnlessEquivalent(old, newP string) (string, error) {
 	}
 
 	return newP, nil
-}
-
-func resourceBucketWebsiteConfigurationWebsiteEndpoint(ctx context.Context, conn *s3.S3, bucket string, region scw.Region) (*S3Website, error) {
-	// Using s3manager.GetBucketRegionWithClient to avoid path style calls
-	// Lookup https://github.com/aws/aws-sdk-go/issues/3115
-	// https://github.com/hashicorp/terraform-provider-aws/pull/14221/files
-	bucketRegion, err := s3manager.GetBucketRegionWithClient(ctx, conn, bucket, func(r *request.Request) {
-		r.Config.S3ForcePathStyle = aws.Bool(false)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error getting Object Bucket (%s) Location: %w", bucket, err)
-	}
-
-	region = scw.Region(bucketRegion)
-
-	return WebsiteEndpoint(bucket, region), nil
 }
 
 type S3Website struct {

--- a/scaleway/resource_object_bucket_website_configuration.go
+++ b/scaleway/resource_object_bucket_website_configuration.go
@@ -168,11 +168,7 @@ func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.Resou
 		return diag.FromErr(fmt.Errorf("error setting error_document: %w", err))
 	}
 
-	// Add website_endpoint and website_domain as attributes
-	websiteEndpoint, err := resourceBucketWebsiteConfigurationWebsiteEndpoint(ctx, conn, bucket, region)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	websiteEndpoint := WebsiteEndpoint(bucket, region)
 
 	if websiteEndpoint != nil {
 		_ = d.Set("website_endpoint", websiteEndpoint.Endpoint)


### PR DESCRIPTION
Using `s3manager.GetBucketRegionWithClient` was always returning "us-east-1" as a region