### PR TITLE
fix(docs): s3 storage as terraform backend

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -247,11 +247,10 @@ Be careful as no locking mechanism are yet supported.
 Using scaleway object storage as terraform backend is not suitable if you work in a team with a risk of simultaneous access to the same plan.
 
 Note: For security reason it's not recommended to store secrets in terraform files.
-If you want to configure the backend with environment var, you need to use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` [source](https://www.terraform.io/docs/backends/types/s3.html#access_key).
+If you don't want to hardcode this elements in terraform files, you can run `terraform init` like so:
 
 ```bash
-export AWS_ACCESS_KEY_ID=$SCW_ACCESS_KEY
-export AWS_SECRET_ACCESS_KEY=$SCW_SECRET_KEY
+terraform init -backend-config="access_key=$SCW_ACCESS_KEY" -backend-config="secret_key=$SCW_SECRET_KEY"
 ```
 
 ## Debugging a deployment


### PR DESCRIPTION
Provided solution can't work as `terraform init` doesn't read env var. One should use `-backend-config`.