### PR TITLE
feat(k8s) - breaking - make "delete_additional_resources" required

### DIFF
--- a/docs/resources/k8s_cluster.md
+++ b/docs/resources/k8s_cluster.md
@@ -17,6 +17,7 @@ resource "scaleway_k8s_cluster" "jack" {
   name    = "jack"
   version = "1.24.3"
   cni     = "cilium"
+  delete_additional_resources = false
 }
 
 resource "scaleway_k8s_pool" "john" {
@@ -35,6 +36,7 @@ resource "scaleway_k8s_cluster" "henry" {
   type = "multicloud"
   version = "1.24.3"
   cni     = "kilo"
+  delete_additional_resources = false
 }
 
 resource "scaleway_k8s_pool" "friend_from_outer_space" {
@@ -54,7 +56,8 @@ resource "scaleway_k8s_cluster" "john" {
   description      = "my awesome cluster"
   version          = "1.24.3"
   cni              = "calico"
-  tags             = ["i'm an awsome tag", "yay"]
+  tags             = ["i'm an awesome tag", "yay"]
+  delete_additional_resources = false
 
   autoscaler_config {
     disable_scale_down              = false
@@ -86,6 +89,7 @@ resource "scaleway_k8s_cluster" "joy" {
   name    = "joy"
   version = "1.24.3"
   cni     = "flannel"
+  delete_additional_resources = false
 }
 
 resource "scaleway_k8s_pool" "john" {
@@ -125,6 +129,7 @@ resource "scaleway_k8s_cluster" "joy" {
   name    = "joy"
   version = "1.24.3"
   cni     = "flannel"
+  delete_additional_resources = false
 }
 
 resource "scaleway_k8s_pool" "john" {
@@ -215,6 +220,10 @@ The following arguments are supported:
 - `cni` - (Required) The Container Network Interface (CNI) for the Kubernetes cluster.
 ~> **Important:** Updates to this field will recreate a new resource.
 
+- `delete_additional_resources` - (Required) Delete additional resources like block volumes, IPs and loadbalancers that were created in Kubernetes on cluster deletion.
+~> **Important:** Setting this field to `true` means that you will lose all your cluster data and network configuration when you delete your cluster.
+If you prefer keeping it, you should instead set it as `false`.
+
 - `tags` - (Optional) The tags associated with the Kubernetes cluster.
 
 - `autoscaler_config` - (Optional) The configuration options for the [Kubernetes cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
@@ -269,8 +278,6 @@ The following arguments are supported:
     - `groups_prefix` - (Optional) Prefix prepended to group claims
 
     - `required_claim` - (Optional) Multiple key=value pairs that describes a required claim in the ID Token
-
-- `delete_additional_resources` - (Defaults to `false`) Delete additional resources like block volumes and loadbalancers that were created in Kubernetes on cluster deletion.
 
 - `default_pool` - (Deprecated) See below.
 

--- a/scaleway/data_source_k8s_cluster_test.go
+++ b/scaleway/data_source_k8s_cluster_test.go
@@ -24,6 +24,7 @@ func TestAccScalewayDataSourceK8SCluster_Basic(t *testing.T) {
 						version = "%s"
 						cni     = "cilium"
 					  	tags    = [ "terraform-test", "data_scaleway_k8s_cluster", "basic" ]
+						delete_additional_resources = true
 					}
 
 					resource "scaleway_k8s_pool" "default" {

--- a/scaleway/data_source_k8s_pool_test.go
+++ b/scaleway/data_source_k8s_pool_test.go
@@ -25,6 +25,7 @@ func TestAccScalewayDataSourceK8SPool_Basic(t *testing.T) {
 						version = "%s"
 						cni     = "cilium"
 					  	tags    = [ "terraform-test", "data_scaleway_k8s_pool", "basic" ]
+						delete_additional_resources = true
 					}
 					
 					resource "scaleway_k8s_pool" "default" {
@@ -42,6 +43,7 @@ func TestAccScalewayDataSourceK8SPool_Basic(t *testing.T) {
 						version = "%s"
 						cni     = "cilium"
 					  	tags    = [ "terraform-test", "data_scaleway_k8s_cluster", "basic" ]
+						delete_additional_resources = true
 					}
 
 					resource "scaleway_k8s_pool" "default" {

--- a/scaleway/resource_k8s_cluster.go
+++ b/scaleway/resource_k8s_cluster.go
@@ -154,8 +154,7 @@ func resourceScalewayK8SCluster() *schema.Resource {
 			},
 			"delete_additional_resources": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
+				Required:    true,
 				Description: "Delete additional resources like block volumes and loadbalancers on cluster deletion",
 			},
 			"region":          regionSchema(),

--- a/scaleway/resource_k8s_cluster_test.go
+++ b/scaleway/resource_k8s_cluster_test.go
@@ -470,6 +470,7 @@ resource "scaleway_k8s_cluster" "minimal" {
 	version = "%s"
 	name = "ClusterConfigMinimal"
 	tags = [ "terraform-test", "scaleway_k8s_cluster", "minimal" ]
+	delete_additional_resources = true
 }`, version)
 }
 
@@ -493,6 +494,7 @@ resource "scaleway_k8s_cluster" "autoscaler" {
 		max_graceful_termination_sec = 1337
 	}
 	tags = [ "terraform-test", "scaleway_k8s_cluster", "autoscaler-config" ]
+	delete_additional_resources = true
 }`, version)
 }
 
@@ -514,6 +516,7 @@ resource "scaleway_k8s_cluster" "autoscaler" {
 		max_graceful_termination_sec = 2664
 	}
 	tags = [ "terraform-test", "scaleway_k8s_cluster", "autoscaler-config" ]
+	delete_additional_resources = true
 }`, version)
 }
 
@@ -531,6 +534,7 @@ resource "scaleway_k8s_cluster" "oidc" {
 		groups_prefix = "pouf"
 	}
 	tags = [ "terraform-test", "scaleway_k8s_cluster", "oidc-config" ]
+	delete_additional_resources = true
 }
 `, version)
 }
@@ -549,6 +553,7 @@ resource "scaleway_k8s_cluster" "oidc" {
 		username_prefix = "boo"
 	}
 	tags = [ "terraform-test", "scaleway_k8s_cluster", "oidc-config" ]
+	delete_additional_resources = true
 }
 `, version)
 }
@@ -565,6 +570,7 @@ resource "scaleway_k8s_cluster" "auto_upgrade" {
 		maintenance_window_day = "%s"
 	}
 	tags = [ "terraform-test", "scaleway_k8s_cluster", "auto_upgrade" ]
+	delete_additional_resources = true
 }`, version, enable, hour, day)
 }
 
@@ -575,6 +581,7 @@ resource "scaleway_k8s_cluster" "multicloud" {
 	version = "%s"
 	cni = "kilo"
 	type = "multicloud"
+	delete_additional_resources = true
 }
 
 resource "scaleway_k8s_pool" "multicloud" {

--- a/scaleway/testdata/data-source-k8s-cluster-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-cluster-basic.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:32 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7087343-a29d-4c74-9a34-a6d34a9464f0
+      - dd53ba58-083c-49be-a819-6a671cea9f9f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"tf-cluster","description":"","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"version":"1.24.5","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster","description":"","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"version":"1.24.7","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355125Z","updated_at":"2022-10-25T09:15:33.520559583Z","type":"kapsule","name":"tf-cluster","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262342611Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:54:52.274001299Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:33 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 895ed851-0954-4130-8f94-e278bb8cc936
+      - abc9a57b-7704-4ea0-a3b4-cc88291ae4ec
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:15:33.520560Z","type":"kapsule","name":"tf-cluster","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:54:52.274001Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1322"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:33 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f0587df-c83a-4dd6-98b6-ac1676c08893
+      - 44a72fb0-a76b-4937-9715-8b4075f82260
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:15:35.281943Z","type":"kapsule","name":"tf-cluster","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.932301Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be1f84d6-32d2-401d-abaf-ac802da1cc66
+      - d74caf17-a23e-40f9-abe2-9e2b4286dee6
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:15:35.281943Z","type":"kapsule","name":"tf-cluster","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.932301Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44e65fe1-3f35-4923-af5e-6f156b3ca526
+      - cfd50222-196c-42d0-8373-f8e9496566c1
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2572"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42e1031f-e3f5-4f55-81ed-efe85c0cf485
+      - 3f58bda7-a8a6-4889-953c-a3ff203fd6f0
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.932301Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1327"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:54:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4ad1641-dbf5-4569-92db-570bdaf69aab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"clusters":[{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:15:35.281943Z","type":"kapsule","name":"tf-cluster","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}]}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.932301Z","upgrade_available":false,"version":"1.24.7"}],"total_count":1}'
     headers:
       Content-Length:
       - "1358"
@@ -223,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - faebf564-0492-4012-b8b4-1d53f153c44c
+      - 39a2ef1c-0a13-4853-84da-2e55694fbf3e
     status: 200 OK
     code: 200
     duration: ""
@@ -242,12 +276,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:15:35.281943Z","type":"kapsule","name":"tf-cluster","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.932301Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -256,7 +290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -266,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb338bf3-a5cf-4e30-be04-5a3b9f839b66
+      - 07818612-629d-49cd-bc5c-7d77ff8a3ebd
     status: 200 OK
     code: 200
     duration: ""
@@ -275,12 +309,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:15:35.281943Z","type":"kapsule","name":"tf-cluster","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.932301Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -289,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -299,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 016c8c12-0c32-437e-9e02-5737cf82ccdd
+      - b7085364-3e72-44b1-86d5-799df4ab49d4
     status: 200 OK
     code: 200
     duration: ""
@@ -308,45 +342,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:15:35.281943Z","type":"kapsule","name":"tf-cluster","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1327"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 47a33aae-98e6-47da-8325-b3e93d1406fb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
-    method: GET
-  response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2572"
@@ -355,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -365,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 848615f6-a8a7-473d-8c41-7249549140a6
+      - 84b02335-d05a-45c0-8214-f09fdd6f293b
     status: 200 OK
     code: 200
     duration: ""
@@ -374,12 +375,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2572"
@@ -388,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:39 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -398,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e77a9051-de1d-46df-9d63-a4ab8b8403c0
+      - b946092c-ba2d-4580-b79d-47509ffb8029
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +410,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848295Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819419559Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "570"
@@ -423,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:40 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80055b7f-d218-4363-8e62-41ded5c489e7
+      - a9ea1ae6-eac9-4269-976b-1996221f2bde
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -456,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:40 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7333741c-3cc8-4d9e-9695-02a0986d15a2
+      - 67290c39-02c9-46fc-af09-484c48b65da8
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -489,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:46 GMT
+      - Mon, 02 Jan 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f19df3e-ad6c-484e-bc0c-272ddd399d6d
+      - c612a81f-afbe-46f8-b08e-6b5fda6a32fb
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -522,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:51 GMT
+      - Mon, 02 Jan 2023 13:55:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71530a04-9714-41d0-9099-70439aed580d
+      - ea86931a-3a9e-435c-b638-54a9eb2f40bf
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -555,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:15:57 GMT
+      - Mon, 02 Jan 2023 13:55:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83e7ab8b-7042-412d-85bc-2cc9a9f1390c
+      - b1d66b3a-eeb4-4742-abcf-e1e0cbd70a0c
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -588,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:02 GMT
+      - Mon, 02 Jan 2023 13:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb72a066-d429-44bd-a693-59b394487d6e
+      - 7d03fad0-8c24-4d5c-8210-7225288b1265
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -621,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:07 GMT
+      - Mon, 02 Jan 2023 13:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f2fe85b-e5dc-470f-b30a-a4b67f4812dc
+      - 9e4b188a-4e84-4fc7-a925-461693829fad
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -654,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:13 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20f56e9b-6f48-4ee1-86a6-db9c8e279de6
+      - 0ebcb8e8-78c8-407b-839b-08441a430522
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -687,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:18 GMT
+      - Mon, 02 Jan 2023 13:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 314dbe50-932f-47d6-bf9b-dc369e4a4308
+      - 2f87b73c-2945-4ecd-8b10-03a67faa6688
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -720,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:23 GMT
+      - Mon, 02 Jan 2023 13:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4904914-b7e7-41e6-911e-a613ff2b058a
+      - fa4a62a4-8f9f-4228-bc52-e8429a8ed746
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -753,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:29 GMT
+      - Mon, 02 Jan 2023 13:55:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a9d4463-7717-4155-a3d9-2615d7433514
+      - 127a3450-891e-4b46-a52f-38624297ea91
     status: 200 OK
     code: 200
     duration: ""
@@ -772,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -786,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:34 GMT
+      - Mon, 02 Jan 2023 13:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49098732-fd59-4115-a26e-f1b809342679
+      - 99ef3a7b-8ac4-4a5a-bbee-b83de1da617b
     status: 200 OK
     code: 200
     duration: ""
@@ -805,12 +806,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -819,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:40 GMT
+      - Mon, 02 Jan 2023 13:55:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3cd33f3-7b1f-485d-84d6-65ea2ec2ed18
+      - a2a7d72e-e587-461f-bf0c-431dec2ff241
     status: 200 OK
     code: 200
     duration: ""
@@ -838,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -852,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:45 GMT
+      - Mon, 02 Jan 2023 13:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2558971a-e0d7-4684-8faf-eaf936646e35
+      - 7334745b-9d1f-4cbd-b298-1e4f686145af
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -885,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:51 GMT
+      - Mon, 02 Jan 2023 13:56:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74e2b742-0df7-4126-8967-4d8f7ba6c6b2
+      - ed08ad1a-b39f-48bf-9882-a3cbd686e16a
     status: 200 OK
     code: 200
     duration: ""
@@ -904,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -918,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:16:56 GMT
+      - Mon, 02 Jan 2023 13:56:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0334b54f-4527-4762-be79-80639230b575
+      - 1b657fcf-03e5-4a57-b4cc-7c31f743db3f
     status: 200 OK
     code: 200
     duration: ""
@@ -937,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -951,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:01 GMT
+      - Mon, 02 Jan 2023 13:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 182f5e27-0e52-4bbc-8d98-484da878fa8f
+      - 905b921b-5587-4cc9-b2e3-6011a64635d5
     status: 200 OK
     code: 200
     duration: ""
@@ -970,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -984,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:06 GMT
+      - Mon, 02 Jan 2023 13:56:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1e0c944-d163-4cbd-b828-365fd49af311
+      - 1bfd73d7-1d2c-4759-813d-0d0cffbafb60
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1017,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:11 GMT
+      - Mon, 02 Jan 2023 13:56:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3aa0059f-e365-4a2c-a7d7-a28c98715829
+      - 84da42cc-5e6f-4a52-b785-5ed86993c202
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1050,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:17 GMT
+      - Mon, 02 Jan 2023 13:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3efe776e-1b01-4819-b250-5c47f23fa665
+      - 060c54f8-ce62-48ac-946d-b1da3e7a671f
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1083,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:22 GMT
+      - Mon, 02 Jan 2023 13:56:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1416395-b1cf-46ec-9ae1-e8658cae8042
+      - 4c26801f-c56a-48c8-90b8-8b51f32e5169
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1116,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:27 GMT
+      - Mon, 02 Jan 2023 13:56:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eca3ba4c-253e-4bcf-b35e-f88847639b86
+      - 8318820e-f549-4b6b-893f-6d7cb2d09050
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1149,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:32 GMT
+      - Mon, 02 Jan 2023 13:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12337d4e-4747-4b56-969b-bd70f81fda5d
+      - d7368c0f-fbde-4664-a161-4cef88d94e3c
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1182,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:38 GMT
+      - Mon, 02 Jan 2023 13:56:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1a68d27-72c8-45fa-80f9-fb7d6d121aef
+      - ae44f093-3b45-49db-9971-f02e758e62d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1202,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1215,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:43 GMT
+      - Mon, 02 Jan 2023 13:56:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 430dcb72-2702-4331-8f95-0002c9161c90
+      - 3b25a78e-75dc-405d-8f25-4d9dba711cdf
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1235,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1248,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:49 GMT
+      - Mon, 02 Jan 2023 13:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06dd2103-f39e-4155-9e33-2b9aacd4874f
+      - 41c35810-e643-4cdb-96ad-ecf71092f62e
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1268,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1281,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:54 GMT
+      - Mon, 02 Jan 2023 13:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 449056a6-d5ac-49b1-9e8d-c0c7c70d0306
+      - 91980bc1-bcca-4cc3-9f41-3c937538b309
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1301,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1314,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:17:59 GMT
+      - Mon, 02 Jan 2023 13:57:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9b2d38d-3842-4cc5-964f-ddedcf617d92
+      - 9e3bc207-6144-495c-90b1-388006c9db29
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1347,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:05 GMT
+      - Mon, 02 Jan 2023 13:57:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c92307c-78be-46b7-9ed1-2259f9c9734b
+      - b0982065-476a-47ca-b3a5-5029386cca34
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1380,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:10 GMT
+      - Mon, 02 Jan 2023 13:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9791f2b-93d1-4be8-951a-37a32e87b910
+      - 9537fcee-d022-4f77-8c8d-76f6e3622bde
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1413,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:15 GMT
+      - Mon, 02 Jan 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2dc18498-0d3a-4238-bf3b-e0c6a97b891f
+      - 1af48a0b-d2ef-4767-ae72-18991a927cf2
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1446,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:20 GMT
+      - Mon, 02 Jan 2023 13:57:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a72f154-4314-49a5-8d31-4d38042788af
+      - 94cc2776-eae0-4ff3-8086-3fb56859d005
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,12 +1466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1479,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:26 GMT
+      - Mon, 02 Jan 2023 13:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e4462c3-3d26-486b-b9ca-8cb01ec8013b
+      - 37accc26-ed57-4d06-935a-b968a80baafb
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,12 +1499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1512,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:31 GMT
+      - Mon, 02 Jan 2023 13:57:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8060270-e3f9-408b-aaca-c151dbe59f04
+      - 65506e81-df00-4ef0-b6b8-89ce49f04749
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,12 +1532,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1545,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:36 GMT
+      - Mon, 02 Jan 2023 13:57:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17dbc139-5a7f-46e1-91d7-09851f58b322
+      - 388b0193-a45b-491a-a9c9-09b98b22b01e
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,12 +1565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1578,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:42 GMT
+      - Mon, 02 Jan 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d696b3da-4963-47d9-92d3-a4542e2487a4
+      - 3940c203-d7b5-4146-9447-ea03015a8d26
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,12 +1598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1611,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:47 GMT
+      - Mon, 02 Jan 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3b2b26e-fa21-49cb-a59b-b77509d46a2e
+      - c499a0f6-242c-4a93-a8da-59efb744e05d
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,12 +1631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1644,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:52 GMT
+      - Mon, 02 Jan 2023 13:58:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a60a30d3-ec92-40b5-aab6-944d8a57b240
+      - 08788b72-a579-42f6-99d8-34b7460f5c39
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,12 +1664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1677,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:18:58 GMT
+      - Mon, 02 Jan 2023 13:58:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 973cedcd-ee02-47c9-ae35-7fa3ed57cb94
+      - ea8437ff-4f1b-4d0b-be7d-185bcc7098cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,12 +1697,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1710,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:04 GMT
+      - Mon, 02 Jan 2023 13:58:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 735e15f9-4c1f-4232-ba00-278abea3dec3
+      - 5d4e9236-4124-4f4a-9817-bbe0b54c82a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1730,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1743,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:09 GMT
+      - Mon, 02 Jan 2023 13:58:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c448598-029f-42ae-817a-3c400709a1d5
+      - c5ddbb66-b61a-4a14-b216-81c2c9499ff2
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,12 +1763,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1776,7 +1777,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:14 GMT
+      - Mon, 02 Jan 2023 13:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb9cf3eb-7269-45a6-b2a5-745e3b3195a6
+      - d6a623ea-cc4e-4f90-a3b1-a090141abe09
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,12 +1796,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1809,7 +1810,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:20 GMT
+      - Mon, 02 Jan 2023 13:58:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36911be4-36ea-4398-a43c-b83937aa0487
+      - 99ef31f1-4ff5-49b0-9b80-682f4595261e
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,12 +1829,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1842,7 +1843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:25 GMT
+      - Mon, 02 Jan 2023 13:58:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2be40b4f-a04c-4c17-be07-93e75428fee9
+      - afd37753-a4ff-47d6-8d60-66bb97d8df1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,12 +1862,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1875,7 +1876,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:30 GMT
+      - Mon, 02 Jan 2023 13:58:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14618c51-e4a5-4875-b88c-0b54d82199d4
+      - bcdf301c-009c-4fbb-8640-cd3c1c267b1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,12 +1895,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1908,7 +1909,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:35 GMT
+      - Mon, 02 Jan 2023 13:58:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bd1861f-41ec-40f4-be9e-8dd223c6b92e
+      - 41a29b71-4773-443f-b928-632aaddc2ce0
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,12 +1928,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1941,7 +1942,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:40 GMT
+      - Mon, 02 Jan 2023 13:58:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1951,7 +1952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a96b4af-7ec9-4864-9587-cb4f675ca9cd
+      - 59cd515a-2160-42ac-b4e9-07c8ef2d3c61
     status: 200 OK
     code: 200
     duration: ""
@@ -1960,12 +1961,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -1974,7 +1975,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:46 GMT
+      - Mon, 02 Jan 2023 13:58:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1984,7 +1985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebe228df-e97d-4a77-848a-60c64b0e67b8
+      - 31f67151-73f2-4343-9460-acb485d1b3fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1993,12 +1994,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -2007,7 +2008,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:51 GMT
+      - Mon, 02 Jan 2023 13:58:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2017,7 +2018,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18cb8781-3625-4a67-aa76-0b326603855d
+      - 83b6b90d-9f7c-4957-b35c-63a13b329daf
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,12 +2027,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -2040,7 +2041,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:19:57 GMT
+      - Mon, 02 Jan 2023 13:59:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2050,7 +2051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f1c9013-deed-455c-b826-3c3fbbb8f55c
+      - 79dde279-36e3-4e09-a0d7-86b8342ffc0d
     status: 200 OK
     code: 200
     duration: ""
@@ -2059,12 +2060,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:54:57.819420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -2073,7 +2074,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:02 GMT
+      - Mon, 02 Jan 2023 13:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2083,7 +2084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38c18052-06d4-4f96-8436-a2fb1010cbc7
+      - 1da34704-6a21-4a22-886e-0205924ea3b9
     status: 200 OK
     code: 200
     duration: ""
@@ -2092,210 +2093,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "567"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0346d372-2b00-42e8-9e23-1b6b08472908
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "567"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b9587c48-be61-48d0-a940-d2e6b37791e2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "567"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 530f70fa-e908-4faf-97dd-3d4496758907
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "567"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 153cae07-9e7b-4c52-ab94-59659aefe677
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "567"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 74c69bd0-3964-4306-a69e-22d583aa77b6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:15:39.602848Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "567"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6db9a0a1-d37d-4ec8-bfeb-5b2cde1e25f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:20:35.200398Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T13:59:12.708074Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "565"
@@ -2304,7 +2107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:40 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3676379b-5202-4ec4-8740-0a215836c139
+      - aa345ab2-a2e6-4da6-8025-ce00fb5f423e
     status: 200 OK
     code: 200
     duration: ""
@@ -2323,12 +2126,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1319"
@@ -2337,7 +2140,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:40 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed61179e-0d72-46d6-9eac-dc577bfad8fb
+      - 39ddf5d5-fd2d-4653-9c55-2a6a5c6f62f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2356,12 +2159,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:20:35.200398Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T13:59:12.708074Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "565"
@@ -2370,7 +2173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:40 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2380,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a73b5ca3-94d0-4cf5-bd8c-20ce1d74f941
+      - 48b7bed0-c4d2-4b26-85a6-5db44b4ed72e
     status: 200 OK
     code: 200
     duration: ""
@@ -2389,21 +2192,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/nodes?order_by=created_at_asc&page=1&pool_id=cab78ec8-97de-4945-b558-0307016ad3b0&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/nodes?order_by=created_at_asc&page=1&pool_id=bf5f069f-6efa-41a3-a166-1261df1c3367&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8d05a33b-182e-498d-9d37-8b4d7d5e96cc","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:17:42.913111Z","updated_at":"2022-10-25T09:20:35.167868Z","pool_id":"cab78ec8-97de-4945-b558-0307016ad3b0","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-default-8d05a33b182e498d9d378b4","public_ip_v4":"51.15.249.180","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/f9afaf05-7457-4270-8700-89bb4a9c4d3f","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T13:56:33.260223Z","error_message":null,"id":"a83f1487-14bf-421a-9321-ac54fbf1021a","name":"scw-tf-cluster-default-a83f148714bf421a9321ac5","pool_id":"bf5f069f-6efa-41a3-a166-1261df1c3367","provider_id":"scaleway://instance/fr-par-1/9fc4d116-e6c9-4c96-a66d-9f14e25f8d98","public_ip_v4":"163.172.190.255","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T13:59:12.690833Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:41 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2413,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 687e7e01-206d-4d7d-b6e7-55fe86954cbf
+      - c82296a5-6220-495e-934d-e721bb763803
     status: 200 OK
     code: 200
     duration: ""
@@ -2422,45 +2225,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1319"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 38aff835-3caf-4f1c-8999-d060d33cab02
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1319"
@@ -2469,7 +2239,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:42 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2479,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 193e43d4-0906-4870-8218-bb5d02dc7b32
+      - f5ba1649-6dc0-484f-b7e8-f15f91b944cc
     status: 200 OK
     code: 200
     duration: ""
@@ -2488,12 +2258,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1319"
@@ -2502,7 +2272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:42 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2512,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 660c5ba2-6554-4a71-9627-176267213b36
+      - c2fa6902-834e-4d90-812a-3a84aee10e9b
     status: 200 OK
     code: 200
     duration: ""
@@ -2521,12 +2291,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1319"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a54707e2-9405-463f-bca4-0411d305e2d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"clusters":[{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}]}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}],"total_count":1}'
     headers:
       Content-Length:
       - "1350"
@@ -2535,7 +2338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:42 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2545,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47511449-ea2c-44d9-9f11-ed720e3c4532
+      - d49e5329-1593-46e5-9af3-1b9efc32707f
     status: 200 OK
     code: 200
     duration: ""
@@ -2554,12 +2357,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1319"
@@ -2568,7 +2371,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:42 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2578,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11aef984-e91e-46cf-b0fe-0be265612c86
+      - 454d0059-74a2-411b-916b-33291f985459
     status: 200 OK
     code: 200
     duration: ""
@@ -2587,12 +2390,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2572"
@@ -2601,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:42 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2611,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca3868dd-fbaa-433b-ab2a-1908ed6e8e13
+      - 3d29c182-0500-42ef-96cb-247c6b4133ae
     status: 200 OK
     code: 200
     duration: ""
@@ -2620,12 +2423,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2572"
@@ -2634,7 +2437,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:42 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2644,7 +2447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c1fdc36-77e2-4363-96ef-f7cffd3677b3
+      - f04b27cd-f76d-48a3-be2a-42c17bd77c8a
     status: 200 OK
     code: 200
     duration: ""
@@ -2653,12 +2456,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1319"
@@ -2667,7 +2470,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:43 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2677,7 +2480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5efc0a6-6a46-4a20-9b58-92e666574e53
+      - 4d0c98be-3224-4fe7-8fbf-e53deab4257c
     status: 200 OK
     code: 200
     duration: ""
@@ -2686,12 +2489,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2572"
@@ -2700,7 +2503,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:43 GMT
+      - Mon, 02 Jan 2023 13:59:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2710,7 +2513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 822dc0fe-94b6-4953-9f63-c51e2c4a5ed9
+      - 5d611945-4f29-467d-bd77-284cff7c5cc5
     status: 200 OK
     code: 200
     duration: ""
@@ -2719,12 +2522,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:20:35.200398Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1319"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0246d715-098d-4ae1-80d3-30b5137e0bed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T13:59:12.708074Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "565"
@@ -2733,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2743,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d957781-ac12-4c89-a1bb-5ad262299a20
+      - 7e0802e0-edfa-4088-b5f0-ead9107c34d9
     status: 200 OK
     code: 200
     duration: ""
@@ -2752,12 +2588,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"clusters":[{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}]}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}],"total_count":1}'
     headers:
       Content-Length:
       - "1350"
@@ -2766,7 +2602,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2776,7 +2612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18225335-d936-4a34-a9aa-4405f3af984f
+      - f1425f31-561d-4fa3-917a-ede100607004
     status: 200 OK
     code: 200
     duration: ""
@@ -2785,12 +2621,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1319"
@@ -2799,7 +2635,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:43 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2809,7 +2645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d829f68-ad3a-4000-be50-866838b0ed8f
+      - 31c825fc-c4bd-4b1a-80a0-1c2baa52e1d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2818,12 +2654,111 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/nodes?order_by=created_at_asc&page=1&pool_id=bf5f069f-6efa-41a3-a166-1261df1c3367&status=unknown
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"nodes":[{"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T13:56:33.260223Z","error_message":null,"id":"a83f1487-14bf-421a-9321-ac54fbf1021a","name":"scw-tf-cluster-default-a83f148714bf421a9321ac5","pool_id":"bf5f069f-6efa-41a3-a166-1261df1c3367","provider_id":"scaleway://instance/fr-par-1/9fc4d116-e6c9-4c96-a66d-9f14e25f8d98","public_ip_v4":"163.172.190.255","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T13:59:12.690833Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 89658a8e-c149-45bc-9e62-db14b80a5ef3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2572"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab8615d3-5164-4cbe-b639-78704939dc55
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2572"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e79cf823-8708-4303-bb1e-dad2bcfd905a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1319"
@@ -2832,7 +2767,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2842,7 +2777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 497b0a97-8db8-4e01-b966-4e1653cb1759
+      - 04bee2b1-2e9f-4a6c-996b-a2da8ac54df7
     status: 200 OK
     code: 200
     duration: ""
@@ -2851,111 +2786,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
-    method: GET
-  response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
-    headers:
-      Content-Length:
-      - "2572"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9d5ec77d-2a8e-470e-91cf-0ea8c712f5d3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
-    method: GET
-  response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
-    headers:
-      Content-Length:
-      - "2572"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7c4a3767-8b9f-407a-bf03-72cef7999fcd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/nodes?order_by=created_at_asc&page=1&pool_id=cab78ec8-97de-4945-b558-0307016ad3b0&status=unknown
-    method: GET
-  response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8d05a33b-182e-498d-9d37-8b4d7d5e96cc","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:17:42.913111Z","updated_at":"2022-10-25T09:20:35.167868Z","pool_id":"cab78ec8-97de-4945-b558-0307016ad3b0","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-default-8d05a33b182e498d9d378b4","public_ip_v4":"51.15.249.180","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/f9afaf05-7457-4270-8700-89bb4a9c4d3f","error_message":null}]}'
-    headers:
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ef5745f-df23-44ac-8542-0e47b8a13a22
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"clusters":[{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}]}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}],"total_count":1}'
     headers:
       Content-Length:
       - "1350"
@@ -2964,7 +2800,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2974,7 +2810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c97facd5-0f0c-43d2-a4e5-f01b126c8f7c
+      - 37dc74ab-0c81-4c25-b1db-b48a2c71d3d3
     status: 200 OK
     code: 200
     duration: ""
@@ -2983,12 +2819,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:56:18.791615Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1319"
@@ -2997,7 +2833,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3007,7 +2843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30be90b4-663d-49b8-b893-2dfb88ba27c7
+      - 239722bc-a3bf-4438-bd0b-5754717bbacd
     status: 200 OK
     code: 200
     duration: ""
@@ -3016,45 +2852,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:16:52.236376Z","type":"kapsule","name":"tf-cluster","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1319"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b633b93-17cd-417a-bb82-833462c21969
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
-    method: GET
-  response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2572"
@@ -3063,7 +2866,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:44 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3073,7 +2876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa9c8e47-0d62-4801-8146-268aaf6d7f15
+      - 750d5d45-185b-4f1e-93e4-8111d9f49828
     status: 200 OK
     code: 200
     duration: ""
@@ -3082,12 +2885,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTFUVlJWZWs1R2IxaEVWRTE1VFZSQmVVNUVRVFZOVkZWNlRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFdoWkNqaDNabUozZDNSemJUaFpSVEJEWXpSTlUzTkphbGhyT1N0WVUyMUtNV0pFWmxJMWJIWjZOelp1VEhoeFowSjJaV1ZxZFU1QkszVllUbWMyWkRoRWRtSUtjMlkzYldjMWVqTnJibFpSUzFsUFRtbG1UMmg2TlVsUWNIUm9UMHd6UWxsekwwUnBOamQwTmpBeE4zSkhXaXM0WTNsRU5WTnFSSFprWTNreldsUXJaZ3BWWlVKMlNWRkRaME12VW0xNWJucEVPQ3M0ZW1sbmNESjVaa1pCUmxNNUswc3dNM0F2Tm1kTWJWaHZNR1JuWjNwTVJYaHJla1pRU1U1YU5qY3JNbVZNQ21OU2RtRnBWVzF0Vm1GRmMzSk9ielJUTWt4emQxcEJhR2RsYWtoMmMxSXdhWHBSZFdNd01VWXZWVFpLUVVWcE5XZFNTVzlUYWtGemVsUkNSMFJvV0hBS1VXTmlObUkzVDFaYVJ6TXpXWFkyYTFKNFUyOVZRazFLYjBSUlowSnpMekpyYkRodmRWaGxjR0ZLTml0c1pHRkJWak5NYkdoUlJHOXZMMEpuUVhaMVpBcE5UakUwYVhwdmNtbzJTWEpNZDJoRFZXVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRTV1ZJZUVKT2VYVjJWalozUlU5cWVVUjZPRTlCSzBreFZsbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRSRWxNTWtGWVJqVXdWRTQ0T1doM1VIWkxiemR2V2xST1FTc3JWVW8yVVRKSlVHRm5TVEYwYW5oRVRFZEJUa05DV1FwaU1YRktPRzUxTVVkRUwyRlFZbUpuZWxsaGRWQXJRMDR5UVdSTFdERTJXRTQzWjNwSVJsUXZiVkpEUjJKdWRraDBlRVpXY2xGTFpIUkhObmhTVlZOS0NrNTFibTRyYVZsNllqSmFSMjlrTDNoSlVGRlRMMHRqTXpaaWJHeEZUbFZoU1VaalIwWnhXVXhsYW1oVVZuWldjMjlrWjFKNU5GSnpSbUZLYkhOWGEyNEtjV2tyWlRnM2VWVjZNazVMVW5sa2VpdGhZbmg0VmpKWk1qTnhkVXBoVmt0dVJsQlhXVXBETW5BM1ZXRTVPVTFxVkN0RlkzZERhRFJ4ZEV4emEyNXRVd3BoYVdGSWNHbFhVVXRJUkRoSk9FUTNWMlZhZEVFNGJ6Qk1TM1E1U0U1aGNYQndWUzlMT1doWFZtcGlUMk51T0VWV1pWcERXbUp1UlhSc1NrUmpTblJYQ205eWJVMXhTbTlEVUc1alNFRkxTVlJvZDNKc1NHSXlWRzU2VkVwcU1VOUpkSGh3UmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUyZDIzZjc4LTkxYjItNDBhZS04YTkyLTMzYjk5MWMxNDdhYS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrbG94NWxnNG9sd25LZEZxcWhiN1AzQmxpTGJpQ0ZHb2Z1VExRQ1FRa3k5bXFmdlZIS3c4cGFRVg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVU1R2IxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd0dkNuYzRiWFZ5YTJKUGMzUXlVVFY2YzBaSVVFMUtNbGMxT0hwV1owSndWa2xHUmsxaVJVMHdWV1pHSzNKWmFTOUZhMHBMUm5acGJVRkxhR3hrYmpCMWJtZ0taVU4wTjJGVGVsaHNTM1pLVm01b2JuVlBaR0Z5V0hGaU9GZG9ObWRCYUhKWmMyTXJRVUl5WWpoc1NERmlPRXRxWVZvelVuSnJiVVZKVEN0b1RVZElWd3BHU0ZORldUbEhSMll5YnpsdVQxSjZaMGh2TjFBM1VucDBOSGxVTUVaTGNHTTNUMnhHTlRGb2EycHFLMHBTSzNWU1owRTVPVGx2TmpnNFIwVjZZVTlHQ21GcVkyOHpXblEyU1VsblNuQkhVSFp1WVVneVNWcHhTMHAwUVZsTE1UQTRWbTlhVmxkalFXNVlNREowWnpBdmFqaEZOeXMyTUhKUlExcFVRMGsyUkdZS1NXUm5NV3RHY1c5bllrUm1PSHBUUTNaQldreEJXa3AzY0VKV09UTnRaVXhqZERreVMxSjVNVWdyU25ZMWJEaERlblZqSzBKbGNYSmlXVTFJVmlzMWNRcHZaRzVQTjNRelRFMDFSMkYxTUhGcFkzRXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhia2N5YzIxUlQwSnJNMDhyY0RSUVRXODNXbTlNVnpKS2R6aE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTWEJ4T0c1SWJFb3pXSHBOWTJWbU5WUlFlRlE1ZFdSalRsSnVaMDUzVldkM1RTdEpSRVZITjNsNlNURkhWa1UwWVFvMEwyNXRTWFF5SzA1clJuZFlhR042VlVjNE9FZE9WMnN2TDJsRU5YVnJhelV3Y0RKR1ZVdFlSMjl5VXpGb1VtOW5aVzFZVWxFMmVYUllhMkpxYWpkaENqSlBRbEJPYW1sRWJXaEJWSFZSVVZOb1pqVkxUVVZFYlhkSlQwZHdkalJrTUV3M1RXaFZkMWN4TTJ4Uk5XNVBUR2RaVW1sT2R6QnJSVWh1ZFdsbFN6Z0tMMFowYVdFeFdWSllWbWt5Y0N0clF6RjRiVUp0V25GR1dXMXhhRVpLU1hsUmNrYzFLMHN3Tm1rMmFqRktjREYwVXpOMlVuUjRSMVo1VmxneU1XNHZaZ3BVTUc1TFZYZDVTMGRFVG01U2JGVTJTbVpRVkdZdmNtSXhkVXBRUXl0WlRtcFJSRUoyUTNWdGQxQjZXRGMyVEZOSmExTlhaa2d4VVhsSFVHbHhVekl2Q2tWMWEwaDRjamhqZG1abU5rMVljRXMyZVdkcVVuTkJjR0ZhVUROSFJ6SlVlRVp3WXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RmNTliMTMwLTJlMTEtNDNlYS1hMjYwLTM3ZmQ1MWYyNTFkMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGMlUyRUE5QXoyeUJ6bGtDMFhhc0Nqbk1QYkV6bmlDYjQzRTFlWExiS1oxamtJUEFncnpMdmNQbQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2572"
@@ -3096,7 +2899,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:45 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3106,7 +2909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a425ccd5-3178-4a10-a8b4-b80c8d088b49
+      - 59841406-187a-41ab-9ef9-101a438b8145
     status: 200 OK
     code: 200
     duration: ""
@@ -3115,12 +2918,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cab78ec8-97de-4945-b558-0307016ad3b0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf5f069f-6efa-41a3-a166-1261df1c3367
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"cab78ec8-97de-4945-b558-0307016ad3b0","cluster_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","created_at":"2022-10-25T09:15:39.591273Z","updated_at":"2022-10-25T09:20:45.850354958Z","name":"default","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"df59b130-2e11-43ea-a260-37fd51f251d3","container_runtime":"containerd","created_at":"2023-01-02T13:54:57.792245Z","id":"bf5f069f-6efa-41a3-a166-1261df1c3367","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-01-02T13:59:14.490428410Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "571"
@@ -3129,7 +2932,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:45 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3139,7 +2942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a53c4e0c-e10b-4b28-88cb-06e816758a7e
+      - e8d5dcaa-c8ce-4602-b149-34a04793ccd8
     status: 200 OK
     code: 200
     duration: ""
@@ -3148,12 +2951,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:20:46.119021085Z","type":"kapsule","name":"tf-cluster","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:59:14.544409285Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1325"
@@ -3162,7 +2965,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:46 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3172,7 +2975,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26110bdc-95e5-42fa-b410-839dedcd7ec9
+      - 23b482f4-712d-4af7-a97b-601db71c200c
     status: 200 OK
     code: 200
     duration: ""
@@ -3181,12 +2984,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:20:46.119021Z","type":"kapsule","name":"tf-cluster","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:59:14.544409Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1322"
@@ -3195,7 +2998,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:46 GMT
+      - Mon, 02 Jan 2023 13:59:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3205,7 +3008,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3a1e2fc-5f10-4c01-8bea-e7d9210c2246
+      - 63bea585-d018-4dea-a473-2bf629bc7c0d
     status: 200 OK
     code: 200
     duration: ""
@@ -3214,12 +3017,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:20:46.119021Z","type":"kapsule","name":"tf-cluster","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:59:14.544409Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1322"
@@ -3228,7 +3031,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:51 GMT
+      - Mon, 02 Jan 2023 13:59:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3238,7 +3041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dec4346-9e2e-417f-958c-6f96d04f5b19
+      - 3eabffcd-82c3-4bd3-aa91-f6a767775660
     status: 200 OK
     code: 200
     duration: ""
@@ -3247,12 +3050,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"52d23f78-91b2-40ae-8a92-33b991c147aa","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:15:33.507355Z","updated_at":"2022-10-25T09:20:46.119021Z","type":"kapsule","name":"tf-cluster","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://52d23f78-91b2-40ae-8a92-33b991c147aa.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.52d23f78-91b2-40ae-8a92-33b991c147aa.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:59:14.544409Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1322"
@@ -3261,7 +3064,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:20:56 GMT
+      - Mon, 02 Jan 2023 13:59:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3271,7 +3074,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d83f6301-bdfd-4641-a325-b2280486a662
+      - 0546ce71-b082-4281-a39c-d348d057b228
     status: 200 OK
     code: 200
     duration: ""
@@ -3280,21 +3083,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:59:14.544409Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
-      - "128"
+      - "1322"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:21:02 GMT
+      - Mon, 02 Jan 2023 13:59:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3304,7 +3107,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52f16cbe-0dfb-4d11-8503-649730bf8695
+      - 0667312c-6229-44c5-84e3-fd2974805630
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://df59b130-2e11-43ea-a260-37fd51f251d3.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.262343Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.df59b130-2e11-43ea-a260-37fd51f251d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"df59b130-2e11-43ea-a260-37fd51f251d3","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T13:59:14.544409Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1322"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 152b2ea7-73b6-494e-82db-15b913d67a3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"df59b130-2e11-43ea-a260-37fd51f251d3","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - de4a7173-45c8-4447-8c6e-11325069ae90
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3313,12 +3182,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"df59b130-2e11-43ea-a260-37fd51f251d3","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3327,7 +3196,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:21:02 GMT
+      - Mon, 02 Jan 2023 13:59:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3337,7 +3206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d6b3309-a37c-4b38-b2c4-ddaef49a90fe
+      - 06a3713b-7587-454b-9a8c-6b69fbb7225b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3346,12 +3215,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"df59b130-2e11-43ea-a260-37fd51f251d3","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3360,7 +3229,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:21:02 GMT
+      - Mon, 02 Jan 2023 13:59:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3370,7 +3239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47da4b6a-696e-4fc7-9257-a8254ae0139d
+      - b901a5d1-78d9-4f58-b033-8b57020e695b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3379,12 +3248,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/52d23f78-91b2-40ae-8a92-33b991c147aa
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/df59b130-2e11-43ea-a260-37fd51f251d3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"52d23f78-91b2-40ae-8a92-33b991c147aa","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"df59b130-2e11-43ea-a260-37fd51f251d3","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3393,7 +3262,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:21:02 GMT
+      - Mon, 02 Jan 2023 13:59:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3403,7 +3272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1669141-d897-4aca-8a68-80f0719a855c
+      - 6297b33e-0a05-4249-91c3-36a64019e2de
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:26:51 GMT
+      - Mon, 02 Jan 2023 15:49:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91df3e7b-be56-4884-bda3-8c2ddd76448e
+      - b6970920-dd54-49a7-b407-25b5607d51d7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.24.5","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.24.7","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706156678Z","updated_at":"2022-10-25T09:26:52.719803792Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637956936Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:11.652745126Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:26:52 GMT
+      - Mon, 02 Jan 2023 15:49:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be2d6c30-308c-42f9-8feb-25f33d681dba
+      - 800bd4a7-009c-407f-887d-a7c31628124a
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:26:52.719804Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:11.652745Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1324"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:26:52 GMT
+      - Mon, 02 Jan 2023 15:49:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04885d4f-8a61-4113-9cee-5859923bfc4f
+      - 06252e65-ccc9-4b09-acd0-0356d51458e1
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:26:54.425501Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:13.173709Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:26:58 GMT
+      - Mon, 02 Jan 2023 15:49:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4771c23-15ff-49c4-b967-d58941bdb225
+      - 14dd383c-3169-4eaf-883b-164f6def5c83
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:26:54.425501Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:13.173709Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:26:58 GMT
+      - Mon, 02 Jan 2023 15:49:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12c5f95d-26b1-499b-ac86-5239abf8503f
+      - adc02072-1bef-4bbb-9db8-a5366e0a772e
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMVRXcFpNVTB4YjFoRVZFMTVUVlJCZVU1RVFUVk5hbGt4VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGR2Q2t0NFZsSTJkMVZqUjJsWE5sTlJkak00Ym05SlFVSndPR05hZFVoVU1FbDFjSEY2YjI5eFZ6VnFkM05GVUdReGJuZEpjWE5wTldWR1JHVjFVR2wzYjJjS2NGTldOa2xMZVRCNmJVTkxWbkJxTVdWVU9XZGlTbWxZUm10SE1EUmpZVkZ5TTBFeU5qUkdZbVF3WjJ4b05GSnZZWEUwTkd0S1ZFYzBaR0V6ZVdwSlp3cG1LMGxCUW5CWFUyNXlPRVY2VjBOQ1UxcHVRelpaWWpsSmRIRlZUV3RKSzJVeFZra3JkVFoxUzBVNEsya3JWUzlZVkc1blQzRlNNUzk2UkZKcVpHWmxDak1yVmpGa1VGQk1VbUkyWW10RVVFMXZXVmd4VkhreVVUazVTSGxLU0VNNVZUbFNOMU5NY2xObmFHUjFkRlpqZEdSSllVbFFXR3RFTkVKa1dtVXJiMjRLZVdzeldVMVZiM1ZrVFRVNE9VRXpjamxMYkhWWU0yeFJZVmxxTVc5cFoweFZabmQ1VkhKM00yRnZaVEJ0U0ZSYWF6WnFaUzlYZEZkWU9ETk1aek13VUFwVmNYSkVhbFZNWWpaWU5WWnJVRU56VjNKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVVIVjJUbXMzVkROekwwVjVlVmtyVTFOQmFUWTJRWEExTVdSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQloxQjJSbVpNZWxWSk4xUjRSVTVKYjJOc2JWSkhiVmRRVUdsTmRtOHljVVpaZVdOMFVrcHNSREYxVERWbGVXWlVLd3BoYkVKT2JEUlRMekYzTjA1WFpWRnNUako2VXpoWE9GZzNSV0prYWxSUmFXVnllamx0YjNNeVZEbEtOVFJzYWxSaVV6QjZOVmh1SzJaRU9UVTVLM0JKQ2t0QmRtdDNTWGxTUWtoUWRuTmtZbTVFY1dsSWRsVk1lV2hZUWl0bU4zTlRVRmRIU1c5c1dXMUJiVWRJZERSdlVqRjVjMFZrZDBkU01GVjRWVk5uVFdJS1RqbEdSMGRtVm5WTmMxbGlUVzlpTW5KV09EVkVlRFJtZHl0d1dsaERaVTVVZDFCeVpFVjFkREUyVWtkaWRGSkhXU3MyYWpZeFExZEtSR1pCWVc1T1ZncDNWMVJpUVVaSFFteDZOM2RaY0RCeFEydE1aREp4ZUdGdk9VdG5XVzh4UWt0cWVFOWtSV2x4ZUV4NVVXWjJWM0JRTm5CblZrNTRkV1J4Wm5sSlQzVnVDalJqUzA1bVFtaEhha05OWW0xQ2R5dDJWR0pVZVRkQlVFZHBiWFp4YVVKVVRIaHpaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDNiMzdhMjEtYTU3ZS00YTk2LWFmMTYtYjM1OWI1Y2NiMzA5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1ZTk3djJXc2ZYZUpNY2c5SmhDdjl6dkkyc2huMGlpNkM1S3B2R1JIZVJMRDcwQ1JFdnpHMDZ3UQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:26:58 GMT
+      - Mon, 02 Jan 2023 15:49:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 306a3eb6-f82a-44c6-bb7c-2a8b47b0ae4a
+      - 2b87f7d0-c6c5-48bb-b9bc-a9c923cbc4a7
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:26:54.425501Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:49:13.173709Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -223,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:26:59 GMT
+      - Mon, 02 Jan 2023 15:49:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 703de16b-8f82-4fe3-9012-cd9dd79bc7c0
+      - 85375952-53e2-47ee-8c6a-cfdfd8238b6d
     status: 200 OK
     code: 200
     duration: ""
@@ -244,12 +245,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383103Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362256Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "620"
@@ -258,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:01 GMT
+      - Mon, 02 Jan 2023 15:49:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -268,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bff5d70-e77a-4b8d-9c78-e40dfb83680d
+      - 246fd9d1-f741-4f00-b21c-bc99ba4a0ac7
     status: 200 OK
     code: 200
     duration: ""
@@ -277,12 +278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -291,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:01 GMT
+      - Mon, 02 Jan 2023 15:49:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -301,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfae9f09-cc79-475b-8c9c-940cac49551b
+      - 40f63509-7dad-4883-8e9b-6ac18f731892
     status: 200 OK
     code: 200
     duration: ""
@@ -310,12 +311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -324,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:07 GMT
+      - Mon, 02 Jan 2023 15:49:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -334,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 909572c8-ace2-4588-8d46-de6493eabec4
+      - 1d5d0a24-6e05-4161-b08a-685ef045f4b9
     status: 200 OK
     code: 200
     duration: ""
@@ -343,12 +344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -357,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:12 GMT
+      - Mon, 02 Jan 2023 15:49:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -367,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10d223b2-46db-4fd8-9171-5743a3afbd64
+      - 9fa0f530-b187-4e03-8480-51820197de79
     status: 200 OK
     code: 200
     duration: ""
@@ -376,12 +377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -390,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:17 GMT
+      - Mon, 02 Jan 2023 15:49:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa015d66-7403-4d46-885e-62724dc94354
+      - 6d067b88-3009-421c-92ff-8f4bb9541183
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -423,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:23 GMT
+      - Mon, 02 Jan 2023 15:49:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be04491c-5be1-4084-b853-29765237b20f
+      - 77e56a93-6efc-4f5f-af9b-8dfc781ab587
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -456,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:28 GMT
+      - Mon, 02 Jan 2023 15:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35d827bc-b2d8-46cd-93a9-1fa1388fe3be
+      - 0233a2ea-923e-4ed9-812a-31d9033dc8bb
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -489,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:33 GMT
+      - Mon, 02 Jan 2023 15:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c11a7908-8007-4ae3-ac7e-3fdd67767af6
+      - b3cfc8ee-e091-4900-add8-5e1ba549d3db
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -522,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:39 GMT
+      - Mon, 02 Jan 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d951905-34a3-436f-9d97-711a23d2d55b
+      - b35a7269-6ab3-403b-8cae-9ed3c9710b45
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -555,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:44 GMT
+      - Mon, 02 Jan 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22838843-4548-4fbd-8266-aa590c0ddd38
+      - d67c76d7-919f-4da8-a981-29042069c71c
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -588,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:49 GMT
+      - Mon, 02 Jan 2023 15:50:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ce0f81c-b3bd-4f5b-9d29-c6360832fac0
+      - 35ccea63-522f-4f65-b0d3-9ff6f3a65da8
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -621,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:27:54 GMT
+      - Mon, 02 Jan 2023 15:50:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32f5b6b8-b17b-4dc9-ba99-6c0c0717bc60
+      - 8cb595b6-0254-43e5-a681-a69872694f9c
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -654,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:00 GMT
+      - Mon, 02 Jan 2023 15:50:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b87a2903-dddc-41ab-80f3-6471b32cf6bb
+      - 82e614c4-07b3-45ca-9787-ebc5236cdec2
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -687,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:05 GMT
+      - Mon, 02 Jan 2023 15:50:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7f0ac04-5516-4bd0-a6c0-3c037493a2a4
+      - ee420242-62ea-472b-b9b5-ab7009316ba5
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -720,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:10 GMT
+      - Mon, 02 Jan 2023 15:50:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e37dfec-b515-46e6-b980-171e82b0cdc0
+      - 3fd23cde-89dc-4e5f-96a5-84b9714cebe0
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -753,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:16 GMT
+      - Mon, 02 Jan 2023 15:50:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0f82493-bab4-4151-aaa1-760bf158244e
+      - 7d0cdeaf-b7c8-49fb-bb33-e676fe823ed7
     status: 200 OK
     code: 200
     duration: ""
@@ -772,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -786,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:21 GMT
+      - Mon, 02 Jan 2023 15:50:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c4bba7d-3377-4ed3-96d6-e46df1db0d3a
+      - 00679209-943b-45c6-a2ef-a80193644b97
     status: 200 OK
     code: 200
     duration: ""
@@ -805,12 +806,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -819,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:26 GMT
+      - Mon, 02 Jan 2023 15:50:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13f17ecd-2d29-459b-acdb-4266d4297b8a
+      - f55a8b4d-c02b-4776-ae1e-9a90c066c96c
     status: 200 OK
     code: 200
     duration: ""
@@ -838,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -852,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:32 GMT
+      - Mon, 02 Jan 2023 15:50:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab5fb911-4922-4bcb-a74d-06cf064402d9
+      - 6a9dbae4-7b03-4280-85de-6957328974eb
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -885,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:37 GMT
+      - Mon, 02 Jan 2023 15:50:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7a13959-1a80-4f7e-9f2c-ae6a2d5eefc4
+      - c411b0b1-2a5c-44f5-9f02-e06d043d1439
     status: 200 OK
     code: 200
     duration: ""
@@ -904,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -918,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:43 GMT
+      - Mon, 02 Jan 2023 15:50:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86416fc4-2cb2-4231-a675-a64620988c47
+      - 11dadd90-5cfb-483a-ade3-f2093569d74d
     status: 200 OK
     code: 200
     duration: ""
@@ -937,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -951,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:48 GMT
+      - Mon, 02 Jan 2023 15:50:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09cc9ce0-f439-46d9-9b1c-378f8e3f04e1
+      - ce33dde0-dfac-4810-b9dc-0d4605e9e084
     status: 200 OK
     code: 200
     duration: ""
@@ -970,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -984,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:54 GMT
+      - Mon, 02 Jan 2023 15:51:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 883ff03a-21ec-4c8b-ab68-3ccd17bd284d
+      - e6842c69-aa89-46a3-9377-19844fc209e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1017,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:28:59 GMT
+      - Mon, 02 Jan 2023 15:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15bc350a-dc45-48f9-8c21-2330c08deb11
+      - 10eb3843-0dbe-4587-bce0-66246b6d19d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1050,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:05 GMT
+      - Mon, 02 Jan 2023 15:51:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13563409-f615-479c-a598-b3883e504bb3
+      - ab61aa01-5e7f-459c-9d8f-7efa1c058842
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1083,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:10 GMT
+      - Mon, 02 Jan 2023 15:51:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59ca688c-8a63-4c75-969c-eaeb203c66a9
+      - 14348602-4ab0-4eb0-b5a8-eac1fa5f8654
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1116,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:16 GMT
+      - Mon, 02 Jan 2023 15:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a25f068b-76b9-4239-8fd7-d3ab7764f1df
+      - 3ca1f799-b304-4336-b08b-8add39f7c132
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1149,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:21 GMT
+      - Mon, 02 Jan 2023 15:51:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad362dfe-f042-4878-a26e-deb0410454d6
+      - 4d6ff016-e08d-4174-ab03-b27d79f0ca08
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1182,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:26 GMT
+      - Mon, 02 Jan 2023 15:51:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9947dc29-0a14-4769-a557-2b0af5600593
+      - 0505b0d7-7fd8-42e3-8d31-f53dec87e02f
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1202,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1215,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:31 GMT
+      - Mon, 02 Jan 2023 15:51:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7db190b-6203-4a2e-9a05-38e9ddd2dab3
+      - 8118ae32-bbd6-4b36-803a-5ece321f557e
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1235,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1248,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:36 GMT
+      - Mon, 02 Jan 2023 15:51:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 116e22ba-f5b2-4ac1-acfd-6afcf10f7ca6
+      - ff3d4f32-66d8-4486-a5a8-b58541c3e540
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1268,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1281,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:41 GMT
+      - Mon, 02 Jan 2023 15:51:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2a3c3d0-78e4-427a-bfa6-18c8607f012c
+      - c454bbbc-bd1e-4e9f-a2b6-d99bf834e490
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1301,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1314,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:47 GMT
+      - Mon, 02 Jan 2023 15:51:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf07aa19-439d-4167-882e-6f58de9663a0
+      - da0c2b6b-1b9c-4ecd-a746-ee9f8173878a
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1347,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:52 GMT
+      - Mon, 02 Jan 2023 15:51:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98f9b37f-9643-4f44-af56-ff73d554b965
+      - ee9b8be4-6ae9-4489-81ae-cba02947ac20
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1380,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:29:58 GMT
+      - Mon, 02 Jan 2023 15:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ea72630-1520-43f4-afa5-26e3764d16a3
+      - 57325235-04c0-49d2-ac7b-5835dbaaabd4
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1413,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:03 GMT
+      - Mon, 02 Jan 2023 15:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd8c3429-35a3-4359-8402-4f3dec3e9658
+      - 8299a1cf-2a64-4689-82f6-1ef842495047
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1446,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:08 GMT
+      - Mon, 02 Jan 2023 15:52:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf624f39-6f88-4e7d-abf0-c883598a446b
+      - 0fd03fa7-f3ce-4fed-97ff-3876e0cff778
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,12 +1466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1479,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:13 GMT
+      - Mon, 02 Jan 2023 15:52:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca4e2408-0aa7-48fd-b877-7825eb95a0dd
+      - f440f98b-dd92-4e1b-9928-a399009f2483
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,12 +1499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1512,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:18 GMT
+      - Mon, 02 Jan 2023 15:52:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bce9e5f-c5d1-4483-97e3-2305c5ffc006
+      - 3568e53c-bbbd-4d6f-b4c2-14e30ddad051
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,12 +1532,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1545,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:23 GMT
+      - Mon, 02 Jan 2023 15:52:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 143d4010-9825-4c91-ae64-8e720a339f75
+      - e98c43b3-4bfa-44a2-b019-23fa0ce097d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,12 +1565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1578,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:29 GMT
+      - Mon, 02 Jan 2023 15:52:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10ba938b-062f-43f4-9d58-3f6b56d1de5d
+      - 04f6f294-d3b0-4c13-8b77-c23e7809eaac
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,12 +1598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1611,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:34 GMT
+      - Mon, 02 Jan 2023 15:52:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d491987-7b93-40ce-8d88-58aca759f04b
+      - 18fdb272-0521-4eb3-825e-3212c87d28bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,12 +1631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1644,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:40 GMT
+      - Mon, 02 Jan 2023 15:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25154077-f496-4d08-943f-aa71ff4b3b2e
+      - d6e58c24-7d73-4aeb-b2fd-c59c05c80c28
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,12 +1664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1677,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:45 GMT
+      - Mon, 02 Jan 2023 15:52:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b30101a-142e-45bf-a098-692448a004d9
+      - 5ad5fb3d-7f61-46c3-bd18-0df2ec768ebc
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,12 +1697,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1710,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:51 GMT
+      - Mon, 02 Jan 2023 15:52:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94c9bd1a-644b-40b9-95a0-17d99550f380
+      - 4d855d9b-70f9-493a-993e-2a1b2b8f1711
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1730,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1743,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:30:56 GMT
+      - Mon, 02 Jan 2023 15:53:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6668d9f-1a82-4737-ba4e-0454b8d58a14
+      - 7c69db0f-7564-4460-9fc1-60d2310aaa43
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,12 +1763,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1776,7 +1777,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:31:02 GMT
+      - Mon, 02 Jan 2023 15:53:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9987c50-77b7-4642-b02a-660653764ef9
+      - 1ef87e5a-7bba-44d3-8216-f89e01f95672
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,12 +1796,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1809,7 +1810,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:31:07 GMT
+      - Mon, 02 Jan 2023 15:53:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 989fc3cf-68e4-43ac-a520-e5d4741942d4
+      - 1807b07c-c069-470c-8d33-aa6356c4079d
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,12 +1829,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:49:17.124362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1842,7 +1843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:31:12 GMT
+      - Mon, 02 Jan 2023 15:53:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c38843f0-58cf-496e-875e-c257ab7493c7
+      - 4b59fe6f-2eda-49e5-8b45-4e1821db2da5
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,870 +1862,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f69c82cf-20b4-435d-b5db-f68c5474719d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1ecf20f7-7012-4899-9c64-8198d25a9cda
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d8f89ec-79c8-44af-9f1a-c63ea8873578
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f2ff2c73-8f94-4555-975b-4199ef7c6945
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - beeeb9e9-04b1-4c5e-bb3e-f92ed4a92824
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4a5ac59-0e01-4f00-8f4d-179e9cca1991
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7430dcb9-ff7d-4a2c-90fb-5a8916b39f3c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fe77ca03-7625-47f8-8c0f-47764f6680a2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:31:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9fe07866-dd68-4f02-a244-ea67f3ae4ae8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b9e9db7-105f-49d6-8926-0ee00b8e4684
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bbe874d4-c43f-4014-8d4e-62a170565c42
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eace7a36-b1c8-4136-b811-1082bb4c95b6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d2959385-8999-4b5e-8592-c4ee547a44a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7d23579e-8ae7-49ba-a0b4-a6656a371134
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bf364a93-85d0-4447-b905-195c47f30f46
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 49dbc5fd-e9c2-4f91-8252-54293aa753ae
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 141c9ba1-ff8e-4e56-b2ec-30223e499274
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1cd0568-c537-4a7f-a941-252035e4f16f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e42a144e-dd5f-42e6-a74d-a3122fcf24c0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:32:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 12021bbc-23a3-4d71-985c-9696f30b86b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:33:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff0fce4c-60f4-490c-8247-86182f97ccb9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:33:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 38826fe4-236e-468f-8701-db877e4bdfdb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:33:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f295712-f2af-491f-96d5-35bf1a464025
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:33:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 48f99b0f-7051-4b86-a015-c1193081b7f2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:33:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b218a435-1a9a-4d45-a70c-a7981aa14b82
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:27:00.102383Z","name":"tf-pool","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:33:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a428ed6e-9f2d-4fc0-b474-a219040c5f76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -2733,7 +1876,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:32 GMT
+      - Mon, 02 Jan 2023 15:53:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2743,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f90ff9e0-f265-44bb-ad57-c38268b262f7
+      - 66961d05-3fe7-4017-a5ca-8f82d030995c
     status: 200 OK
     code: 200
     duration: ""
@@ -2752,12 +1895,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:27:56.148496Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:50:07.843757Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1321"
@@ -2766,7 +1909,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:33 GMT
+      - Mon, 02 Jan 2023 15:53:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2776,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eefc6fa-b061-4844-9b3a-058bdea61c74
+      - 2f223904-3ede-4e70-b771-1f3078c25e18
     status: 200 OK
     code: 200
     duration: ""
@@ -2785,12 +1928,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -2799,7 +1942,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:33 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2809,7 +1952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fbcfd5c-e55d-4561-b1e4-1881cb2860f3
+      - 6027b482-d265-4c25-8dfa-9b4bc3c8d87d
     status: 200 OK
     code: 200
     duration: ""
@@ -2818,12 +1961,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:33:30.704323Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -2832,7 +1975,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:33 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2842,7 +1985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b406969e-5393-4686-963f-2ce4a01b54ce
+      - 2e0db11b-0571-4d4e-85b2-6c1869fb852c
     status: 200 OK
     code: 200
     duration: ""
@@ -2851,12 +1994,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:27:56.148496Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:50:07.843757Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1321"
@@ -2865,7 +2008,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:35 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2875,7 +2018,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0f79511-dc8c-41df-856e-9ef4f9b149b0
+      - 147d24e3-04f9-4d36-bd97-d4646fd64690
     status: 200 OK
     code: 200
     duration: ""
@@ -2884,12 +2027,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMVRXcFpNVTB4YjFoRVZFMTVUVlJCZVU1RVFUVk5hbGt4VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGR2Q2t0NFZsSTJkMVZqUjJsWE5sTlJkak00Ym05SlFVSndPR05hZFVoVU1FbDFjSEY2YjI5eFZ6VnFkM05GVUdReGJuZEpjWE5wTldWR1JHVjFVR2wzYjJjS2NGTldOa2xMZVRCNmJVTkxWbkJxTVdWVU9XZGlTbWxZUm10SE1EUmpZVkZ5TTBFeU5qUkdZbVF3WjJ4b05GSnZZWEUwTkd0S1ZFYzBaR0V6ZVdwSlp3cG1LMGxCUW5CWFUyNXlPRVY2VjBOQ1UxcHVRelpaWWpsSmRIRlZUV3RKSzJVeFZra3JkVFoxUzBVNEsya3JWUzlZVkc1blQzRlNNUzk2UkZKcVpHWmxDak1yVmpGa1VGQk1VbUkyWW10RVVFMXZXVmd4VkhreVVUazVTSGxLU0VNNVZUbFNOMU5NY2xObmFHUjFkRlpqZEdSSllVbFFXR3RFTkVKa1dtVXJiMjRLZVdzeldVMVZiM1ZrVFRVNE9VRXpjamxMYkhWWU0yeFJZVmxxTVc5cFoweFZabmQ1VkhKM00yRnZaVEJ0U0ZSYWF6WnFaUzlYZEZkWU9ETk1aek13VUFwVmNYSkVhbFZNWWpaWU5WWnJVRU56VjNKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVVIVjJUbXMzVkROekwwVjVlVmtyVTFOQmFUWTJRWEExTVdSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQloxQjJSbVpNZWxWSk4xUjRSVTVKYjJOc2JWSkhiVmRRVUdsTmRtOHljVVpaZVdOMFVrcHNSREYxVERWbGVXWlVLd3BoYkVKT2JEUlRMekYzTjA1WFpWRnNUako2VXpoWE9GZzNSV0prYWxSUmFXVnllamx0YjNNeVZEbEtOVFJzYWxSaVV6QjZOVmh1SzJaRU9UVTVLM0JKQ2t0QmRtdDNTWGxTUWtoUWRuTmtZbTVFY1dsSWRsVk1lV2hZUWl0bU4zTlRVRmRIU1c5c1dXMUJiVWRJZERSdlVqRjVjMFZrZDBkU01GVjRWVk5uVFdJS1RqbEdSMGRtVm5WTmMxbGlUVzlpTW5KV09EVkVlRFJtZHl0d1dsaERaVTVVZDFCeVpFVjFkREUyVWtkaWRGSkhXU3MyYWpZeFExZEtSR1pCWVc1T1ZncDNWMVJpUVVaSFFteDZOM2RaY0RCeFEydE1aREp4ZUdGdk9VdG5XVzh4UWt0cWVFOWtSV2x4ZUV4NVVXWjJWM0JRTm5CblZrNTRkV1J4Wm5sSlQzVnVDalJqUzA1bVFtaEhha05OWW0xQ2R5dDJWR0pVZVRkQlVFZHBiWFp4YVVKVVRIaHpaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDNiMzdhMjEtYTU3ZS00YTk2LWFmMTYtYjM1OWI1Y2NiMzA5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1ZTk3djJXc2ZYZUpNY2c5SmhDdjl6dkkyc2huMGlpNkM1S3B2R1JIZVJMRDcwQ1JFdnpHMDZ3UQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2898,7 +2041,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:35 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2908,7 +2051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 914b8a6e-d0da-42a0-a24f-9e0bd4c2f781
+      - a56a412f-a4ed-41ad-8687-c05a29389699
     status: 200 OK
     code: 200
     duration: ""
@@ -2917,12 +2060,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -2931,7 +2074,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:35 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2941,7 +2084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8154364-86c4-4689-a5f1-6bf79424d091
+      - 5c38660d-5e17-47f9-bafc-eb28338ac372
     status: 200 OK
     code: 200
     duration: ""
@@ -2950,12 +2093,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:33:30.704323Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -2964,7 +2107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:35 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2974,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8c4bd61-2428-4965-922e-68d0e56f5923
+      - 97471330-c59c-49ac-b91f-e149302b3c95
     status: 200 OK
     code: 200
     duration: ""
@@ -2983,12 +2126,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:27:56.148496Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-01-02T15:50:07.843757Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1321"
@@ -2997,7 +2140,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:36 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3007,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47b100c1-3d1f-433f-ab7d-e963b3931b65
+      - 1257813e-52d4-4341-9a74-83e3c4f7d8d5
     status: 200 OK
     code: 200
     duration: ""
@@ -3016,12 +2159,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMVRXcFpNVTB4YjFoRVZFMTVUVlJCZVU1RVFUVk5hbGt4VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGR2Q2t0NFZsSTJkMVZqUjJsWE5sTlJkak00Ym05SlFVSndPR05hZFVoVU1FbDFjSEY2YjI5eFZ6VnFkM05GVUdReGJuZEpjWE5wTldWR1JHVjFVR2wzYjJjS2NGTldOa2xMZVRCNmJVTkxWbkJxTVdWVU9XZGlTbWxZUm10SE1EUmpZVkZ5TTBFeU5qUkdZbVF3WjJ4b05GSnZZWEUwTkd0S1ZFYzBaR0V6ZVdwSlp3cG1LMGxCUW5CWFUyNXlPRVY2VjBOQ1UxcHVRelpaWWpsSmRIRlZUV3RKSzJVeFZra3JkVFoxUzBVNEsya3JWUzlZVkc1blQzRlNNUzk2UkZKcVpHWmxDak1yVmpGa1VGQk1VbUkyWW10RVVFMXZXVmd4VkhreVVUazVTSGxLU0VNNVZUbFNOMU5NY2xObmFHUjFkRlpqZEdSSllVbFFXR3RFTkVKa1dtVXJiMjRLZVdzeldVMVZiM1ZrVFRVNE9VRXpjamxMYkhWWU0yeFJZVmxxTVc5cFoweFZabmQ1VkhKM00yRnZaVEJ0U0ZSYWF6WnFaUzlYZEZkWU9ETk1aek13VUFwVmNYSkVhbFZNWWpaWU5WWnJVRU56VjNKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVVIVjJUbXMzVkROekwwVjVlVmtyVTFOQmFUWTJRWEExTVdSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQloxQjJSbVpNZWxWSk4xUjRSVTVKYjJOc2JWSkhiVmRRVUdsTmRtOHljVVpaZVdOMFVrcHNSREYxVERWbGVXWlVLd3BoYkVKT2JEUlRMekYzTjA1WFpWRnNUako2VXpoWE9GZzNSV0prYWxSUmFXVnllamx0YjNNeVZEbEtOVFJzYWxSaVV6QjZOVmh1SzJaRU9UVTVLM0JKQ2t0QmRtdDNTWGxTUWtoUWRuTmtZbTVFY1dsSWRsVk1lV2hZUWl0bU4zTlRVRmRIU1c5c1dXMUJiVWRJZERSdlVqRjVjMFZrZDBkU01GVjRWVk5uVFdJS1RqbEdSMGRtVm5WTmMxbGlUVzlpTW5KV09EVkVlRFJtZHl0d1dsaERaVTVVZDFCeVpFVjFkREUyVWtkaWRGSkhXU3MyYWpZeFExZEtSR1pCWVc1T1ZncDNWMVJpUVVaSFFteDZOM2RaY0RCeFEydE1aREp4ZUdGdk9VdG5XVzh4UWt0cWVFOWtSV2x4ZUV4NVVXWjJWM0JRTm5CblZrNTRkV1J4Wm5sSlQzVnVDalJqUzA1bVFtaEhha05OWW0xQ2R5dDJWR0pVZVRkQlVFZHBiWFp4YVVKVVRIaHpaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDNiMzdhMjEtYTU3ZS00YTk2LWFmMTYtYjM1OWI1Y2NiMzA5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1ZTk3djJXc2ZYZUpNY2c5SmhDdjl6dkkyc2huMGlpNkM1S3B2R1JIZVJMRDcwQ1JFdnpHMDZ3UQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -3030,7 +2173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:36 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3040,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aff993a5-4b24-40af-8410-59c2dab83210
+      - 3094f69e-84cc-4c66-af82-7e360ef82422
     status: 200 OK
     code: 200
     duration: ""
@@ -3049,12 +2192,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -3063,7 +2206,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:36 GMT
+      - Mon, 02 Jan 2023 15:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3073,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6330e5ee-83e4-40a3-baa5-0d5efbf57b03
+      - f2751599-622d-4ea6-a58f-3d7cef15b859
     status: 200 OK
     code: 200
     duration: ""
@@ -3082,12 +2225,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:33:30.704323Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -3096,7 +2239,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:36 GMT
+      - Mon, 02 Jan 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3106,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c925d0d7-f260-440f-815d-175f27defe14
+      - 4c1c1bf5-6644-439d-8457-ad41953f7f12
     status: 200 OK
     code: 200
     duration: ""
@@ -3115,12 +2258,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -3129,7 +2272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:37 GMT
+      - Mon, 02 Jan 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3139,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1738c6cf-14db-4c86-ae84-f5e49d3fdab2
+      - 7b5ef00e-70e2-4e3a-9ee4-a82ddc995442
     status: 200 OK
     code: 200
     duration: ""
@@ -3148,12 +2291,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:33:30.704323Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -3162,7 +2305,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:38 GMT
+      - Mon, 02 Jan 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3172,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e68d4a79-f0bf-4f8a-88f5-6f8a8e82772f
+      - 8c3b40bc-184b-49a2-ba69-dec78509b9dd
     status: 200 OK
     code: 200
     duration: ""
@@ -3181,12 +2324,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -3195,7 +2338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:38 GMT
+      - Mon, 02 Jan 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3205,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 252528a4-dee4-4deb-a752-46a58f77c83c
+      - e9f400c0-1452-456f-9d59-f8081d06a7b9
     status: 200 OK
     code: 200
     duration: ""
@@ -3214,12 +2357,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:33:30.704323Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:17.901613Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -3228,7 +2371,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:39 GMT
+      - Mon, 02 Jan 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3238,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77b2f7f0-146e-46e2-9f0b-7f25bcfda56c
+      - 2661bcb8-3039-4964-9d0a-cff2e4415055
     status: 200 OK
     code: 200
     duration: ""
@@ -3249,12 +2392,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647034523Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585435758Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -3263,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:39 GMT
+      - Mon, 02 Jan 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3273,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1cf7b97-03f1-4994-a390-1a332e8d5054
+      - ba87ea03-3828-4d29-8c03-3d949d567867
     status: 200 OK
     code: 200
     duration: ""
@@ -3282,12 +2425,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3296,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:39 GMT
+      - Mon, 02 Jan 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3306,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a75cfa0-def9-47ee-a55f-64305a758d93
+      - bd9c41f3-0dbf-4ca9-bda9-5b604d5b800c
     status: 200 OK
     code: 200
     duration: ""
@@ -3315,12 +2458,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3329,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:45 GMT
+      - Mon, 02 Jan 2023 15:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3339,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d32d9b11-b50e-4d59-8cf1-3a1f5b0367b9
+      - 00745675-fac4-43bd-a998-2ee4da065370
     status: 200 OK
     code: 200
     duration: ""
@@ -3348,12 +2491,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3362,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:50 GMT
+      - Mon, 02 Jan 2023 15:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3372,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d640a5c-d18c-41d3-886c-2dcd03bc51a0
+      - ba67562b-2a8f-4874-baa4-5cb38c494735
     status: 200 OK
     code: 200
     duration: ""
@@ -3381,12 +2524,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3395,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:33:56 GMT
+      - Mon, 02 Jan 2023 15:53:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3405,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c71192f3-1c69-4f6b-ae70-ab955452cbd7
+      - 14bc94cc-854b-4a3a-8f75-e542e812e11d
     status: 200 OK
     code: 200
     duration: ""
@@ -3414,12 +2557,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3428,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:01 GMT
+      - Mon, 02 Jan 2023 15:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3438,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2a0a389-8ff0-4af0-bf9c-113ca37a97b9
+      - 29922f9a-fdd4-4935-b054-2c1fa275bf0c
     status: 200 OK
     code: 200
     duration: ""
@@ -3447,12 +2590,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3461,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:07 GMT
+      - Mon, 02 Jan 2023 15:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3471,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7516d7d5-056b-46a8-aba3-72563623845d
+      - c82df568-1518-4af3-a1bc-1d0e3c7ce04c
     status: 200 OK
     code: 200
     duration: ""
@@ -3480,12 +2623,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3494,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:12 GMT
+      - Mon, 02 Jan 2023 15:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3504,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac2bc4c3-07a3-419c-8446-a9ffb3c72a14
+      - 7efba53f-f967-4bd2-8751-dde3bb528cf2
     status: 200 OK
     code: 200
     duration: ""
@@ -3513,12 +2656,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3527,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:18 GMT
+      - Mon, 02 Jan 2023 15:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3537,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af09ce11-7906-429f-90b4-524f2415810e
+      - a23946b8-40f4-4c11-9dfb-9f25dfc34fff
     status: 200 OK
     code: 200
     duration: ""
@@ -3546,12 +2689,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:33:39.647035Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -3560,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:23 GMT
+      - Mon, 02 Jan 2023 15:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3570,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0ce6353-6a2e-4f2e-9130-45a105536956
+      - 0997c977-5196-4c11-b005-2469b9816bce
     status: 200 OK
     code: 200
     duration: ""
@@ -3579,12 +2722,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:34:25.811455Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:53:22.585436Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1327"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 15:54:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 89fccd1f-2e5a-450a-a12d-eb542051f4b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:09.993032Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1324"
@@ -3593,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:28 GMT
+      - Mon, 02 Jan 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3603,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63a9a81c-02a9-45d8-ae78-636699e42dad
+      - de6b5a72-4980-40fb-a5e0-be51e774136c
     status: 200 OK
     code: 200
     duration: ""
@@ -3612,12 +2788,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:34:25.811455Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:09.993032Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1324"
@@ -3626,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:28 GMT
+      - Mon, 02 Jan 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3636,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf5a1cb2-1107-4d12-9150-70f9ebce53e6
+      - d23461d4-549e-4d18-8823-bfefe496ef8f
     status: 200 OK
     code: 200
     duration: ""
@@ -3645,12 +2821,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMVRXcFpNVTB4YjFoRVZFMTVUVlJCZVU1RVFUVk5hbGt4VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGR2Q2t0NFZsSTJkMVZqUjJsWE5sTlJkak00Ym05SlFVSndPR05hZFVoVU1FbDFjSEY2YjI5eFZ6VnFkM05GVUdReGJuZEpjWE5wTldWR1JHVjFVR2wzYjJjS2NGTldOa2xMZVRCNmJVTkxWbkJxTVdWVU9XZGlTbWxZUm10SE1EUmpZVkZ5TTBFeU5qUkdZbVF3WjJ4b05GSnZZWEUwTkd0S1ZFYzBaR0V6ZVdwSlp3cG1LMGxCUW5CWFUyNXlPRVY2VjBOQ1UxcHVRelpaWWpsSmRIRlZUV3RKSzJVeFZra3JkVFoxUzBVNEsya3JWUzlZVkc1blQzRlNNUzk2UkZKcVpHWmxDak1yVmpGa1VGQk1VbUkyWW10RVVFMXZXVmd4VkhreVVUazVTSGxLU0VNNVZUbFNOMU5NY2xObmFHUjFkRlpqZEdSSllVbFFXR3RFTkVKa1dtVXJiMjRLZVdzeldVMVZiM1ZrVFRVNE9VRXpjamxMYkhWWU0yeFJZVmxxTVc5cFoweFZabmQ1VkhKM00yRnZaVEJ0U0ZSYWF6WnFaUzlYZEZkWU9ETk1aek13VUFwVmNYSkVhbFZNWWpaWU5WWnJVRU56VjNKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVVIVjJUbXMzVkROekwwVjVlVmtyVTFOQmFUWTJRWEExTVdSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQloxQjJSbVpNZWxWSk4xUjRSVTVKYjJOc2JWSkhiVmRRVUdsTmRtOHljVVpaZVdOMFVrcHNSREYxVERWbGVXWlVLd3BoYkVKT2JEUlRMekYzTjA1WFpWRnNUako2VXpoWE9GZzNSV0prYWxSUmFXVnllamx0YjNNeVZEbEtOVFJzYWxSaVV6QjZOVmh1SzJaRU9UVTVLM0JKQ2t0QmRtdDNTWGxTUWtoUWRuTmtZbTVFY1dsSWRsVk1lV2hZUWl0bU4zTlRVRmRIU1c5c1dXMUJiVWRJZERSdlVqRjVjMFZrZDBkU01GVjRWVk5uVFdJS1RqbEdSMGRtVm5WTmMxbGlUVzlpTW5KV09EVkVlRFJtZHl0d1dsaERaVTVVZDFCeVpFVjFkREUyVWtkaWRGSkhXU3MyYWpZeFExZEtSR1pCWVc1T1ZncDNWMVJpUVVaSFFteDZOM2RaY0RCeFEydE1aREp4ZUdGdk9VdG5XVzh4UWt0cWVFOWtSV2x4ZUV4NVVXWjJWM0JRTm5CblZrNTRkV1J4Wm5sSlQzVnVDalJqUzA1bVFtaEhha05OWW0xQ2R5dDJWR0pVZVRkQlVFZHBiWFp4YVVKVVRIaHpaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDNiMzdhMjEtYTU3ZS00YTk2LWFmMTYtYjM1OWI1Y2NiMzA5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1ZTk3djJXc2ZYZUpNY2c5SmhDdjl6dkkyc2huMGlpNkM1S3B2R1JIZVJMRDcwQ1JFdnpHMDZ3UQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -3659,7 +2835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:28 GMT
+      - Mon, 02 Jan 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3669,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3c59eb5-1da7-43dd-82de-a9afac2c49d5
+      - 7bcfa80b-33fc-4170-9ce8-e4c69fb99e01
     status: 200 OK
     code: 200
     duration: ""
@@ -3678,12 +2854,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"pools":[{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}]}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "643"
@@ -3692,7 +2868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:28 GMT
+      - Mon, 02 Jan 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3702,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a83b48d4-f862-4975-a2ee-f17d66468f9b
+      - 2aa3f67b-f769-498f-9089-8d351a0d1ae8
     status: 200 OK
     code: 200
     duration: ""
@@ -3711,12 +2887,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -3725,7 +2901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:30 GMT
+      - Mon, 02 Jan 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3735,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67b9006e-e647-4271-a8c4-debcbeacc31a
+      - 6dc12c6b-2979-4c5e-974e-427035a463b3
     status: 200 OK
     code: 200
     duration: ""
@@ -3744,21 +2920,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:34:27.103045Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "635"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:30 GMT
+      - Mon, 02 Jan 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3768,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99fe7de3-cf33-420b-8f77-7e7c6d51216f
+      - 9464ae43-788f-489a-ad71-95c8e69e491d
     status: 200 OK
     code: 200
     duration: ""
@@ -3777,45 +2953,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:34:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5ae533d-d0fc-4a95-8c9c-67054d0fc2e8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -3824,7 +2967,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:30 GMT
+      - Mon, 02 Jan 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3834,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7b16920-2a00-4485-9813-2b36d1c1f9be
+      - c03d8db8-538b-43f6-beb8-47e788a9ac41
     status: 200 OK
     code: 200
     duration: ""
@@ -3843,12 +2986,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -3857,7 +3000,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:31 GMT
+      - Mon, 02 Jan 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3867,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f305c20b-ac81-4713-88bf-7c8a81865a8d
+      - f57f8c50-74fc-46a9-9083-71d54c1692b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3876,12 +3019,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"total_count":1,"pools":[{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}]}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "615"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 15:54:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e88c926e-c3cb-46ce-85ae-6d6d790ae430
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    method: GET
+  response:
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "643"
@@ -3890,7 +3066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:31 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3900,7 +3076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e77b9ecc-c950-4dfd-89c8-43cc767821e9
+      - 27e9ef09-03c5-4b1a-9684-14c473b0c984
     status: 200 OK
     code: 200
     duration: ""
@@ -3909,45 +3085,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:34:27.103045Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
-    headers:
-      Content-Length:
-      - "635"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:34:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b008c4c2-d3a6-4d88-b4ea-cbc1d3deefcc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -3956,7 +3099,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:31 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3966,7 +3109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8243c265-6eb9-478d-86a0-9f14317f12a3
+      - f53870e4-4f1d-425d-b8bb-d18ddb9632b5
     status: 200 OK
     code: 200
     duration: ""
@@ -3975,21 +3118,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:34:27.103045Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "635"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:31 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3999,7 +3142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f7d8629-efc2-4fc8-a1bd-4081dcfa7b0c
+      - c0241244-6fa2-4d90-aee7-f944376377c3
     status: 200 OK
     code: 200
     duration: ""
@@ -4008,12 +3151,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:34:25.811455Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "606"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 15:54:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 67366b30-faf2-473b-abef-67786a696f5a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:09.993032Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1324"
@@ -4022,7 +3198,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:31 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4032,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb5d98ca-c2c5-42aa-b82d-e2dc6179c962
+      - fd2ec3da-ced9-455a-92e9-2cf972f26826
     status: 200 OK
     code: 200
     duration: ""
@@ -4041,12 +3217,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMVRXcFpNVTB4YjFoRVZFMTVUVlJCZVU1RVFUVk5hbGt4VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGR2Q2t0NFZsSTJkMVZqUjJsWE5sTlJkak00Ym05SlFVSndPR05hZFVoVU1FbDFjSEY2YjI5eFZ6VnFkM05GVUdReGJuZEpjWE5wTldWR1JHVjFVR2wzYjJjS2NGTldOa2xMZVRCNmJVTkxWbkJxTVdWVU9XZGlTbWxZUm10SE1EUmpZVkZ5TTBFeU5qUkdZbVF3WjJ4b05GSnZZWEUwTkd0S1ZFYzBaR0V6ZVdwSlp3cG1LMGxCUW5CWFUyNXlPRVY2VjBOQ1UxcHVRelpaWWpsSmRIRlZUV3RKSzJVeFZra3JkVFoxUzBVNEsya3JWUzlZVkc1blQzRlNNUzk2UkZKcVpHWmxDak1yVmpGa1VGQk1VbUkyWW10RVVFMXZXVmd4VkhreVVUazVTSGxLU0VNNVZUbFNOMU5NY2xObmFHUjFkRlpqZEdSSllVbFFXR3RFTkVKa1dtVXJiMjRLZVdzeldVMVZiM1ZrVFRVNE9VRXpjamxMYkhWWU0yeFJZVmxxTVc5cFoweFZabmQ1VkhKM00yRnZaVEJ0U0ZSYWF6WnFaUzlYZEZkWU9ETk1aek13VUFwVmNYSkVhbFZNWWpaWU5WWnJVRU56VjNKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVVIVjJUbXMzVkROekwwVjVlVmtyVTFOQmFUWTJRWEExTVdSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQloxQjJSbVpNZWxWSk4xUjRSVTVKYjJOc2JWSkhiVmRRVUdsTmRtOHljVVpaZVdOMFVrcHNSREYxVERWbGVXWlVLd3BoYkVKT2JEUlRMekYzTjA1WFpWRnNUako2VXpoWE9GZzNSV0prYWxSUmFXVnllamx0YjNNeVZEbEtOVFJzYWxSaVV6QjZOVmh1SzJaRU9UVTVLM0JKQ2t0QmRtdDNTWGxTUWtoUWRuTmtZbTVFY1dsSWRsVk1lV2hZUWl0bU4zTlRVRmRIU1c5c1dXMUJiVWRJZERSdlVqRjVjMFZrZDBkU01GVjRWVk5uVFdJS1RqbEdSMGRtVm5WTmMxbGlUVzlpTW5KV09EVkVlRFJtZHl0d1dsaERaVTVVZDFCeVpFVjFkREUyVWtkaWRGSkhXU3MyYWpZeFExZEtSR1pCWVc1T1ZncDNWMVJpUVVaSFFteDZOM2RaY0RCeFEydE1aREp4ZUdGdk9VdG5XVzh4UWt0cWVFOWtSV2x4ZUV4NVVXWjJWM0JRTm5CblZrNTRkV1J4Wm5sSlQzVnVDalJqUzA1bVFtaEhha05OWW0xQ2R5dDJWR0pVZVRkQlVFZHBiWFp4YVVKVVRIaHpaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDNiMzdhMjEtYTU3ZS00YTk2LWFmMTYtYjM1OWI1Y2NiMzA5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1ZTk3djJXc2ZYZUpNY2c5SmhDdjl6dkkyc2huMGlpNkM1S3B2R1JIZVJMRDcwQ1JFdnpHMDZ3UQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVeFRrUnJlRTFzYjFoRVZFMTZUVVJGZDAxVVJURk9SR3Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTekV6Q25kMk4yaDRabkZoUW5WTVJtcHZSME0yTjA5TldIWmpiQ3N4UjFaNlVqbEhjbkZMZUZoV2MydHlVRU52YkdaUVR6ZzVXVkJUTTI1MlJYRjVhREozWVZJS1JWYzNkVlI1U0N0bWVXMDJSVVZyUVRaQmNEWjZNa2cwUWsxREszbENjM3BpVWtSVmNGVlBhblpoVTFGVVprMTRiek5aZEU1Tk1USkVMekJrVXpWa1NncE9kR3BRUWpSR2MwUkVUbVU0YjJFd2VVbG1VRzlYYkhwbGVITlFWSEV6YmxJemEzZ3pRbFpVWmtKTlNISlViakoyTUU5MldIbE5RM1ZQYjFreFRFSklDa3N2ZG05S2VFeEpWbkJKUVRWd1RFdEliak5pYkhSbWQyNTRhRk5tUkVGd2NrcHdjVEZDZDNKcGNIQXdiREpLVnpCS1JqRklRbWhsZFRkWE9XeFdUMmdLUlRsb1dsSk1ZVFo1ZWxOV2VFdHRjMDFuWkZoUVJWQjNZMWhhYTJVNWNuRlpXbEZ4YTFWSVQzZzRiRFEzV0c5ck56WkNVMWRyT1dGdk9HMVhhRlpLT0FwVGVYRXJVMmREU1VRMVlsRlJNMFJ0Vm1RNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTksydExhVFptUVdKUlZUWXlXbkJYYkVGTVdXZzRla2swUzFwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdGWlhhVXBPWkRobWNtTlRhbEptZFZCMGNreGFXR3d5YVZCbGExbzVSVlpsWXpWemRIWlJjMmRLVkhCMWJDdElTUXBTTDFKUlJrZEZaakZUYUVGTWNIWnZZVkYxTlhKM00wTk5Ua1l6VUhSeU5ISldabkJuVHl0eVdXeDZaWEpHUWxadUwwbFBMemREYWxkelNISjJUa2huQ2xSMldFSlZaMFZsZUhsb1NqaHJjVUY0UldwSmIzYzNNRUV5WVZsR1FrRlNSemhYYTJ4SVRrVjZNVlZTZEhoYVYybEJVbVpCWVZCRFlqTnZVVXBFTlVnS2JFUmxaMGQzZEZsbU9WTjBXbWR3TlRWYWRtNTFURGhxVUdoVmFtMTVRMWh0YjNCWE5VeHNiRWhuVTFWblRsaDZSWGd3TlRJd0t6Z3pjelJXYmxCa1VBcEliRlpvYjJwa1lUbFZOQzl4V1RGMGMzbFJXbFptS3pOWVFWRjBXSHB1VDI5cGVWVk9ZbFp3SzNGUGMwTmxTVXRKUmtGbE4wUmpObTFZUWtKeFJHeDRDak5VZHk5VlZERTBVVVV4S3l0bVZIQXljVGt3UlZsMlowZG5VRXhoVFRGSFRIQnRWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjEyMDYwNTItNjIxYS00NDM0LWEyZjAtMjQyOWE1N2U3MWI3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5ZWk5bzZoWFNydmgwT0JsQTJxZ29PTE4yTWtYUGxwYkRCRWp5SHJyOUtYZlJ0U3JYYlhJYVhBeA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -4055,7 +3231,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4065,7 +3241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a900407-be8a-4526-a876-d75d19b0468b
+      - 240876eb-bb78-469b-b98c-2af607238f79
     status: 200 OK
     code: 200
     duration: ""
@@ -4074,12 +3250,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -4088,7 +3264,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4098,7 +3274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04b78692-dbbe-4a69-804e-a388cf8e3868
+      - 077873d7-a04a-4257-b9e7-d739b8ef1a29
     status: 200 OK
     code: 200
     duration: ""
@@ -4107,21 +3283,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:34:27.103045Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "635"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4131,7 +3307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55b563bc-4156-4e1b-b9b1-a400c3f79292
+      - bea62d76-e737-4f1d-9894-7ac8c0892c44
     status: 200 OK
     code: 200
     duration: ""
@@ -4140,12 +3316,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -4154,7 +3330,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4164,7 +3340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aec98f1f-542c-409a-9d3e-a5dca493533c
+      - 210609bc-6794-451d-b826-2b7700c0d74b
     status: 200 OK
     code: 200
     duration: ""
@@ -4173,12 +3349,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"pools":[{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}]}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "643"
@@ -4187,7 +3363,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4197,7 +3373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34e5adeb-996e-4792-9f21-d4ef18be9bd3
+      - 902c5a18-f673-4b37-a58f-326dff1dab15
     status: 200 OK
     code: 200
     duration: ""
@@ -4206,12 +3382,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "606"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 15:54:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d7cd9711-4807-4a28-8808-4c6597df2d1d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -4220,7 +3429,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4230,7 +3439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e3247c9-1745-4901-8291-6cab38d58ba2
+      - b2da491b-690a-4242-825d-4a4aa0133eaa
     status: 200 OK
     code: 200
     duration: ""
@@ -4239,21 +3448,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:34:27.103045Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "635"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4263,7 +3472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41ff2a5a-de10-4666-bb8e-ba0bd58a1424
+      - 01ec6cf7-2974-438e-9faf-178bc19df415
     status: 200 OK
     code: 200
     duration: ""
@@ -4272,45 +3481,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:34:27.103045Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
-    headers:
-      Content-Length:
-      - "635"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e49c95fe-9144-4a45-9bf4-b84ed42d10d5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -4319,7 +3495,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4329,7 +3505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62a389e7-305b-44e2-95db-6ecae26c8501
+      - cc05965f-eb63-46b1-a1e3-c45a0194f2c4
     status: 200 OK
     code: 200
     duration: ""
@@ -4338,12 +3514,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"pools":[{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}]}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "643"
@@ -4352,7 +3528,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4362,7 +3538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e41955a9-3f04-402f-8f68-40f4682fef5d
+      - 3283cf0d-0535-45f2-9b54-9d4fc486c2c0
     status: 200 OK
     code: 200
     duration: ""
@@ -4371,12 +3547,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:33:30.718300Z","name":"tf-pool","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "606"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 15:54:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a414b73-e6eb-4859-a2a8-3afca24362b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:53:17.912774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -4385,7 +3594,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4395,7 +3604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e24ced9-ca56-483c-b3f8-f0b865f6a984
+      - e5f44d78-87f7-448f-a20f-24fee31ce1f5
     status: 200 OK
     code: 200
     duration: ""
@@ -4404,21 +3613,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7/nodes?order_by=created_at_asc&page=1&pool_id=627e80be-e33c-4264-82c6-948647957e4d&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:34:27.103045Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T15:50:20.852557Z","error_message":null,"id":"23a9eceb-4490-4ca6-80f6-119c2215e48f","name":"scw-tf-cluster-pool-tf-pool-23a9eceb44904ca680","pool_id":"627e80be-e33c-4264-82c6-948647957e4d","provider_id":"scaleway://instance/fr-par-1/744e4874-c621-4f4b-95e8-18ade5fc7db2","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T15:53:35.937628Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "635"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
+      - Mon, 02 Jan 2023 15:54:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4428,7 +3637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c1c36eb-8785-43f2-9565-a8ec2059b58f
+      - ce75f877-54f6-4b90-b86d-e6eca26f31e3
     status: 200 OK
     code: 200
     duration: ""
@@ -4437,45 +3646,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309/nodes?order_by=created_at_asc&page=1&pool_id=144a6468-dc41-4381-ade9-b43baeb35ee2&status=unknown
-    method: GET
-  response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"5890c6be-d09d-4566-b721-722a9a5316f7","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:29:44.903126Z","updated_at":"2022-10-25T09:34:27.103045Z","pool_id":"144a6468-dc41-4381-ade9-b43baeb35ee2","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"name":"scw-tf-cluster-pool-tf-pool-5890c6bed09d4566b7","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/50f06380-4a47-4759-a613-4a3b24c0fea1","error_message":null}]}'
-    headers:
-      Content-Length:
-      - "635"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 09:34:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19916904-aead-451c-a2f4-94654641dc07
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/144a6468-dc41-4381-ade9-b43baeb35ee2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/627e80be-e33c-4264-82c6-948647957e4d
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"144a6468-dc41-4381-ade9-b43baeb35ee2","cluster_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","created_at":"2022-10-25T09:27:00.092109Z","updated_at":"2022-10-25T09:34:33.401138785Z","name":"tf-pool","status":"deleting","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":["terraform-test","data_scaleway_k8s_pool","basic"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"61206052-621a-4434-a2f0-2429a57e71b7","container_runtime":"containerd","created_at":"2023-01-02T15:49:17.117513Z","id":"627e80be-e33c-4264-82c6-948647957e4d","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-01-02T15:54:15.059116293Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -4484,7 +3660,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:33 GMT
+      - Mon, 02 Jan 2023 15:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4494,7 +3670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15b31623-6483-4962-a91c-ec906895b1d7
+      - ef1d143e-c132-4553-9a9f-6b3378feba08
     status: 200 OK
     code: 200
     duration: ""
@@ -4503,12 +3679,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:34:33.721886895Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146354947Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -4517,7 +3693,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:33 GMT
+      - Mon, 02 Jan 2023 15:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4527,7 +3703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1584b226-c635-48f9-97fb-acd4e1bf1e63
+      - aec0af3d-6902-4f23-8d3a-395d061ca436
     status: 200 OK
     code: 200
     duration: ""
@@ -4536,12 +3712,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:34:33.721887Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146355Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -4550,7 +3726,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:34 GMT
+      - Mon, 02 Jan 2023 15:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4560,7 +3736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e5ce937-7177-40a6-ac06-368b36f529ac
+      - 0fd17f93-4bb0-4aa3-86aa-c237cf10dbf9
     status: 200 OK
     code: 200
     duration: ""
@@ -4569,12 +3745,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:34:33.721887Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146355Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -4583,7 +3759,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:39 GMT
+      - Mon, 02 Jan 2023 15:54:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4593,7 +3769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2239ec0-ba26-4f08-8288-267761e160c0
+      - 747f76d5-b065-4912-a74a-64cbe213e21a
     status: 200 OK
     code: 200
     duration: ""
@@ -4602,12 +3778,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:34:33.721887Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146355Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -4616,7 +3792,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:44 GMT
+      - Mon, 02 Jan 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4626,7 +3802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8751532f-b066-4b8e-83f0-346273786f27
+      - 4780d2df-fb3f-4a8e-8203-bd6188aa06b5
     status: 200 OK
     code: 200
     duration: ""
@@ -4635,12 +3811,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T09:26:52.706157Z","updated_at":"2022-10-25T09:34:33.721887Z","type":"kapsule","name":"tf-cluster-pool","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"cluster_url":"https://d3b37a21-a57e-4a96-af16-b359b5ccb309.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.d3b37a21-a57e-4a96-af16-b359b5ccb309.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://61206052-621a-4434-a2f0-2429a57e71b7.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T15:49:11.637957Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.61206052-621a-4434-a2f0-2429a57e71b7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"61206052-621a-4434-a2f0-2429a57e71b7","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-01-02T15:54:15.146355Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1327"
@@ -4649,7 +3825,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:49 GMT
+      - Mon, 02 Jan 2023 15:54:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4659,7 +3835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48b467fe-47d1-42ff-849a-45ab4ece490d
+      - b68461ea-d4a6-47a6-8d53-ef734aa94798
     status: 200 OK
     code: 200
     duration: ""
@@ -4668,12 +3844,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"61206052-621a-4434-a2f0-2429a57e71b7","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4682,7 +3858,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:55 GMT
+      - Mon, 02 Jan 2023 15:54:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4692,7 +3868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a87f585f-e4c1-4e95-a826-0afa7033d9d7
+      - 303af0f0-1f91-4d12-8206-ab2b36ec0f97
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4701,12 +3877,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3b37a21-a57e-4a96-af16-b359b5ccb309
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/61206052-621a-4434-a2f0-2429a57e71b7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d3b37a21-a57e-4a96-af16-b359b5ccb309","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"61206052-621a-4434-a2f0-2429a57e71b7","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4715,7 +3891,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 09:34:55 GMT
+      - Mon, 02 Jan 2023 15:54:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4725,7 +3901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3da61d4c-a745-4a2d-80c3-3b7a7e9ae5db
+      - 076ef259-8554-4af8-ba03-7955ce363291
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-auto-upgrade.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-auto-upgrade.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:22 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 351f73d8-f3ef-4fb3-8ba4-df991f9c72cf
+      - 8dfe9e89-f41b-479c-ad5a-bffee8d617b8
     status: 200 OK
     code: 200
     duration: ""
@@ -42,15 +43,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -59,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:22 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5def5cbb-bc00-4251-af5b-95fefc18086c
+      - 93579b3d-29c0-4695-ba2d-25a91f61542c
     status: 200 OK
     code: 200
     duration: ""
@@ -78,15 +80,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -95,7 +98,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:23 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -105,7 +108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d650ee12-972d-4985-a9ff-acd2faa74391
+      - 54736d34-6483-4257-a267-c64442087b66
     status: 200 OK
     code: 200
     duration: ""
@@ -114,15 +117,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -131,7 +135,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:23 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -141,23 +145,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d608007-263b-4021-86fd-4f0487f9478d
+      - a2132da8-9075-4b86-9b8d-74544ef19701
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"default-pool","description":"","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"version":"1.23.11","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":false,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"default-pool","description":"","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"version":"1.23.13","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":false,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713049Z","updated_at":"2022-10-25T08:39:25.496402262Z","type":"kapsule","name":"default-pool","description":"","status":"creating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324291Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:17.438919375Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1332"
@@ -166,7 +170,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -176,7 +180,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66115366-d3d5-494b-bcef-9de5c7fc640f
+      - 359a7990-3abe-43c7-9da7-639359f56d9d
     status: 200 OK
     code: 200
     duration: ""
@@ -185,12 +189,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:25.496402Z","type":"kapsule","name":"default-pool","description":"","status":"creating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:17.438919Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1326"
@@ -199,7 +203,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -209,7 +213,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4f986fa-6647-4dbe-8aed-97086eb9d481
+      - b232fc11-78d2-42e1-945d-5040c51cd098
     status: 200 OK
     code: 200
     duration: ""
@@ -218,12 +222,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:29.215249Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:19.926864Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1331"
@@ -232,7 +236,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -242,7 +246,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dd8689d-2e26-4b1c-974e-7fb7e4d9b921
+      - e7de12b9-2e08-45ed-9326-86f2595a8caf
     status: 200 OK
     code: 200
     duration: ""
@@ -251,12 +255,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:29.215249Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:19.926864Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1331"
@@ -265,7 +269,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -275,7 +279,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 575c49e7-c273-41b9-a98b-64e4506800ff
+      - 2b5ee133-23fe-4850-b7c2-930f33f39a19
     status: 200 OK
     code: 200
     duration: ""
@@ -284,12 +288,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -298,7 +302,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -308,7 +312,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4168b0c-0e8d-42a5-b966-ccacc213056e
+      - ec28df0e-0e37-49c1-854f-cba94e30e7ed
     status: 200 OK
     code: 200
     duration: ""
@@ -317,12 +321,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:29.215249Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:19.926864Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1331"
@@ -331,7 +335,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -341,7 +345,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6bdb5bb-1d44-4200-9876-30ec3a6bec7a
+      - bb35b023-5568-4b30-94fd-2008492712a1
     status: 200 OK
     code: 200
     duration: ""
@@ -350,12 +354,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:29.215249Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:19.926864Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1331"
@@ -364,7 +368,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -374,7 +378,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a62a97f4-bb77-4533-b288-fd5c20b5e7dd
+      - 6cf9d5a7-a2e1-4356-a9e3-aef476ddc2ba
     status: 200 OK
     code: 200
     duration: ""
@@ -383,12 +387,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -397,7 +401,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -407,7 +411,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8824c0ea-dc6c-45b0-bb74-9d9819f3d9af
+      - a998fe38-9289-44a6-b941-e8715d41fc70
     status: 200 OK
     code: 200
     duration: ""
@@ -416,12 +420,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:29.215249Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:19.926864Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1331"
@@ -430,7 +434,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -440,7 +444,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e77408a-942f-46a9-9858-1a9d8c4a901d
+      - d568ecfe-d1aa-4a1a-978b-b871e4e3b525
     status: 200 OK
     code: 200
     duration: ""
@@ -449,12 +453,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -463,7 +467,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +477,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edf57cb2-0a91-45b2-9b92-b60f3bda3bd0
+      - 8393af24-bfc0-4034-be2f-7cf171a1283a
     status: 200 OK
     code: 200
     duration: ""
@@ -482,15 +486,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -499,7 +504,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -509,7 +514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27e6d10c-5194-41d0-b4c8-fe4f39bbe42e
+      - 6518f60e-5ccb-452a-9455-e3c60749b7c2
     status: 200 OK
     code: 200
     duration: ""
@@ -518,12 +523,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:29.215249Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:19.926864Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1331"
@@ -532,7 +537,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -542,7 +547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 585b8ff5-7c63-42f0-bc0f-c2cda659f295
+      - 6ffeb075-e6a5-4ffa-9870-cbe5eece2a92
     status: 200 OK
     code: 200
     duration: ""
@@ -553,12 +558,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:33.876771018Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:23.809779767Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1328"
@@ -567,7 +572,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -577,7 +582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca3105d0-3200-4257-90c1-e93f3a18ae92
+      - 8e0f8811-d074-46b5-afca-a1fa0ec2b854
     status: 200 OK
     code: 200
     duration: ""
@@ -586,12 +591,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:33.876771Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:23.809780Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1325"
@@ -600,7 +605,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:34 GMT
+      - Mon, 02 Jan 2023 13:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -610,7 +615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3eaadd9-5a0e-44d7-835d-34d4a8052d8d
+      - cb84fca6-b24e-4efe-9d48-a379ba7e9ccd
     status: 200 OK
     code: 200
     duration: ""
@@ -619,12 +624,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:35.248740Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:25.117231Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1330"
@@ -633,7 +638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:39 GMT
+      - Mon, 02 Jan 2023 13:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -643,7 +648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc8739c6-38c0-4e8b-9978-d38c044c75c1
+      - acac4207-8f8b-4476-9c52-4d0990948935
     status: 200 OK
     code: 200
     duration: ""
@@ -652,12 +657,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:35.248740Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:25.117231Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1330"
@@ -666,7 +671,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:39 GMT
+      - Mon, 02 Jan 2023 13:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -676,7 +681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91bc39f4-e683-4a9d-8197-114056811bc8
+      - 6626d94b-3c18-4c57-827d-56b3b7c997d8
     status: 200 OK
     code: 200
     duration: ""
@@ -685,12 +690,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -699,7 +704,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:40 GMT
+      - Mon, 02 Jan 2023 13:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -709,7 +714,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edba584f-374c-49d4-8c24-eb1cb6d19f36
+      - 75f5fe69-2308-451d-a0c1-e120073a1027
     status: 200 OK
     code: 200
     duration: ""
@@ -718,12 +723,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:35.248740Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:25.117231Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1330"
@@ -732,7 +737,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:41 GMT
+      - Mon, 02 Jan 2023 13:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -742,7 +747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ac08719-45c8-4a3b-b775-ac23f6561913
+      - 5f60c85d-bd44-47bf-bbd1-b2581cc8820c
     status: 200 OK
     code: 200
     duration: ""
@@ -751,12 +756,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:35.248740Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:25.117231Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1330"
@@ -765,7 +770,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:41 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -775,7 +780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7ec20d5-e764-47be-908b-b16c39eaa0f1
+      - 571caf16-7757-4d6b-8081-d2581b630745
     status: 200 OK
     code: 200
     duration: ""
@@ -784,12 +789,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -798,7 +803,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:42 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -808,7 +813,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44e8fdd5-b748-4499-8a70-92cbc24f6033
+      - 4f2d51d2-cf4e-4842-a97b-87a250c61e33
     status: 200 OK
     code: 200
     duration: ""
@@ -817,12 +822,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:35.248740Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:25.117231Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1330"
@@ -831,7 +836,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:43 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -841,7 +846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30ae4051-2a68-4f91-9cef-ab126ab618a8
+      - 50a23df3-013b-45de-9bb6-55dbd1260817
     status: 200 OK
     code: 200
     duration: ""
@@ -850,12 +855,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -864,7 +869,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:44 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -874,7 +879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5f13d9f-e2fd-46f7-b8f9-e75683a6b70e
+      - 9011b46f-afa2-4aac-9b35-ab3d91f044df
     status: 200 OK
     code: 200
     duration: ""
@@ -883,15 +888,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -900,7 +906,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:46 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -910,7 +916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c18f2bd-00ea-4525-96d5-2f1f4461d036
+      - 9eefc826-b08f-4c80-8f38-65c0d09996a0
     status: 200 OK
     code: 200
     duration: ""
@@ -919,12 +925,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:35.248740Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:25.117231Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1330"
@@ -933,7 +939,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:46 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -943,7 +949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 061adf88-7b0d-4548-a916-3c920536aee7
+      - 948eeaae-747b-4023-b12a-9d2399c51842
     status: 200 OK
     code: 200
     duration: ""
@@ -954,12 +960,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:47.120059918Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:30.687617886Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1328"
@@ -968,7 +974,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:47 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -978,7 +984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f29a0c92-dfc6-41e6-a3f5-0619c9889851
+      - 4821caa6-86eb-4398-a09e-47a815dd865d
     status: 200 OK
     code: 200
     duration: ""
@@ -987,12 +993,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:47.120060Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:30.687618Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1325"
@@ -1001,7 +1007,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:48 GMT
+      - Mon, 02 Jan 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1011,7 +1017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2c65cc5-5d04-4b31-9c39-5b62dac6696a
+      - 0bb45e8a-2636-4ecf-b59f-975f50b135b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1020,12 +1026,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:50.618820Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:31.916167Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1330"
@@ -1034,7 +1040,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:53 GMT
+      - Mon, 02 Jan 2023 13:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1044,23 +1050,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d061cfc-2a06-47c0-b00e-186225c05cf5
+      - 85a49599-7fe3-4845-ae22-bcdd0c7ee2c9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"version":"1.24.5","upgrade_pools":true}'
+    body: '{"version":"1.24.7","upgrade_pools":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/upgrade
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/upgrade
     method: POST
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:54.167496470Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:35.851614140Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -1069,7 +1075,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:54 GMT
+      - Mon, 02 Jan 2023 13:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1079,7 +1085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7a5ca94-914c-41be-a15b-89ccc5617b4e
+      - 98fc3baa-3504-4b61-9c63-0570f4fea3dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1088,12 +1094,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:54.167496Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:35.851614Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1325"
@@ -1102,7 +1108,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:54 GMT
+      - Mon, 02 Jan 2023 13:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1112,7 +1118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfd05001-c019-4655-b7a9-4bba31381565
+      - 1179793e-1b49-499b-8af1-dbb7c1ad78ee
     status: 200 OK
     code: 200
     duration: ""
@@ -1121,12 +1127,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:57.020257Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:37.016996Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -1135,7 +1141,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:00 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1145,7 +1151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9845e575-0e50-4f45-a225-0bdc4cc951f0
+      - 600ea8a7-a764-4263-a19b-a98d0f40ea87
     status: 200 OK
     code: 200
     duration: ""
@@ -1154,12 +1160,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:57.020257Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:37.016996Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -1168,7 +1174,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:00 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1178,7 +1184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aabe02c8-de74-45cf-a9b6-5b145807f98c
+      - 7052f1a6-c6d0-497a-9f78-6289f5a70d3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1187,12 +1193,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -1201,7 +1207,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:00 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1211,7 +1217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eef62c1c-449e-42ec-85a1-3bb8572ceeba
+      - fdaa51b4-08ea-4050-9b6f-38ff6e3b444e
     status: 200 OK
     code: 200
     duration: ""
@@ -1220,12 +1226,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:57.020257Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:37.016996Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -1234,7 +1240,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:01 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1244,7 +1250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe9284b5-fa0d-47e7-b0f0-927f11f9f31d
+      - 0f3240e5-6bab-4b71-b0e4-66971794df62
     status: 200 OK
     code: 200
     duration: ""
@@ -1253,12 +1259,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:57.020257Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:37.016996Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -1267,7 +1273,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:02 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1277,7 +1283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbc5159e-9c52-4281-a86c-118567cfdf19
+      - 7bde752f-97a7-466f-8ecc-173d979a00d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1286,12 +1292,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -1300,7 +1306,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:02 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1310,7 +1316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 982ddae4-7071-4e2b-9dcd-5fa6813f85c7
+      - d3dff099-db5b-47a8-89f1-cf3b5a042ed2
     status: 200 OK
     code: 200
     duration: ""
@@ -1319,12 +1325,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:57.020257Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:37.016996Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -1333,7 +1339,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:03 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1343,7 +1349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d761bf0a-001a-4411-8c89-e5e699e59d47
+      - ca9a774e-270e-4b7e-82ca-9ead08e9f06e
     status: 200 OK
     code: 200
     duration: ""
@@ -1352,12 +1358,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -1366,7 +1372,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:04 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1376,7 +1382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33544ae7-29c0-41f9-bab9-267500894ea8
+      - cbf5f1b3-970a-4ac2-88a2-34955e1da21b
     status: 200 OK
     code: 200
     duration: ""
@@ -1385,12 +1391,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:39:57.020257Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:37.016996Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -1399,7 +1405,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:04 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1409,7 +1415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 420fbf56-4a12-43e1-a2e4-04b6e1a68819
+      - 9d1c15ef-2f41-4b53-b23f-8e104949d06a
     status: 200 OK
     code: 200
     duration: ""
@@ -1420,12 +1426,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:04.839531777Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:41.887830769Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -1434,7 +1440,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:04 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1444,7 +1450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12d9d0cd-13fd-4ff8-9887-75f6412dad88
+      - 2e1885a9-b1a7-478b-a23f-7a543d185141
     status: 200 OK
     code: 200
     duration: ""
@@ -1453,12 +1459,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:04.839532Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:41.887831Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -1467,7 +1473,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:05 GMT
+      - Mon, 02 Jan 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1477,7 +1483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77a0278a-2985-4614-8579-d98378685761
+      - 9a364eb9-8e87-49f4-810c-c77400649cfd
     status: 200 OK
     code: 200
     duration: ""
@@ -1486,12 +1492,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:06.238206Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:42.973878Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1331"
@@ -1500,7 +1506,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:10 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1510,7 +1516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a84a802-141f-4387-87a2-1520367e5c12
+      - 6aa3c1d6-135d-4ac1-ae94-1692c64e6c05
     status: 200 OK
     code: 200
     duration: ""
@@ -1519,12 +1525,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:06.238206Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:42.973878Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1331"
@@ -1533,7 +1539,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:10 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1543,7 +1549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57877083-92d6-4c67-9513-b60d2bc1c9db
+      - 3bf79e82-6e4e-4be1-a768-1a00d96048f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1552,12 +1558,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -1566,7 +1572,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:11 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1576,7 +1582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c835e2f-4c42-48df-bbb5-7388a8ff4ce0
+      - 7361d366-ec13-43a8-90e5-9865fcc10179
     status: 200 OK
     code: 200
     duration: ""
@@ -1585,12 +1591,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:06.238206Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:42.973878Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1331"
@@ -1599,7 +1605,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:11 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1609,7 +1615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0587adc1-b40f-4049-9715-f801c7302961
+      - d1056729-54df-4e9e-b5ce-5d07f888576e
     status: 200 OK
     code: 200
     duration: ""
@@ -1618,12 +1624,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:06.238206Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:42.973878Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1331"
@@ -1632,7 +1638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:12 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1642,7 +1648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8369fac-51e9-415c-8c2c-2eeccf2f45c3
+      - 8e3f1da6-37dd-4f4c-968f-e9b78de830bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1651,12 +1657,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -1665,7 +1671,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:12 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1675,7 +1681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d0a0e32-4c06-48c7-b1da-2d7be6120bc9
+      - 8110a853-8e5f-4ea9-916b-6c836630d9a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1684,12 +1690,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:06.238206Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:42.973878Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1331"
@@ -1698,7 +1704,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:12 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1708,7 +1714,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19140778-5a54-4142-80ad-774e802df401
+      - 3a63a11a-152f-4f70-81e8-4bc6820dbd60
     status: 200 OK
     code: 200
     duration: ""
@@ -1717,12 +1723,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -1731,7 +1737,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:12 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1741,7 +1747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df03a26a-a658-4f1c-bb9b-608759c92b0c
+      - 49025255-450e-4815-85ec-8984d17c34b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1750,15 +1756,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -1767,7 +1774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:13 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1777,7 +1784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4034e7fa-0aa0-42b1-a4c5-1f82cc08e23f
+      - 0cfb38db-ada0-4286-bbd0-09a9364847b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1786,12 +1793,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:06.238206Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:42.973878Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1331"
@@ -1800,7 +1807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:13 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1810,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8ec3ba7-cc9f-484a-82e6-c3fc2677b2be
+      - d4c72758-ffc6-4117-a982-006f06c1cec3
     status: 200 OK
     code: 200
     duration: ""
@@ -1821,12 +1828,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:13.594835881Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:47.931708892Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -1835,7 +1842,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:13 GMT
+      - Mon, 02 Jan 2023 13:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1845,7 +1852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f6d5a71-a6a1-4b2a-845b-e7c8cf80680d
+      - a08c51bc-3181-449e-b49b-0fc7af4c64fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1854,12 +1861,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:13.594836Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:47.931709Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -1868,7 +1875,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:13 GMT
+      - Mon, 02 Jan 2023 13:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1878,7 +1885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55fc9717-aeae-4517-9cb4-3231be4531a7
+      - b7e9692a-2a7e-4f74-a1d8-69d4d6d2bc98
     status: 200 OK
     code: 200
     duration: ""
@@ -1887,12 +1894,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:14.717836Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:49.107052Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -1901,7 +1908,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:18 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1911,7 +1918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3ba760d-e721-4764-b179-20e1a3e4ab01
+      - 61b26e67-4232-46fb-b322-b9c0f4b079f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1920,12 +1927,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:14.717836Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:49.107052Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -1934,7 +1941,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:18 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1944,7 +1951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51ebce75-5b1a-4c95-9f76-7cdd8fa8e190
+      - 201df400-9e7b-4369-98bc-1efcff9d8978
     status: 200 OK
     code: 200
     duration: ""
@@ -1953,12 +1960,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -1967,7 +1974,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:18 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1977,7 +1984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39fe3ea0-87e0-4b9b-a006-3bf41176baad
+      - b281cee2-8e0a-4b6d-8923-0ca428ee984a
     status: 200 OK
     code: 200
     duration: ""
@@ -1986,12 +1993,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:14.717836Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:49.107052Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -2000,7 +2007,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:19 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2010,7 +2017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b492d095-c91f-4659-b436-c540feb16b21
+      - 076a4a4f-9371-48e3-ba95-9930aedd26ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2019,12 +2026,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:14.717836Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:49.107052Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -2033,7 +2040,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:19 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2043,7 +2050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28dbf102-6b06-4a0d-8305-ebab10290e61
+      - 78a28a0e-8af2-46f5-9bea-e4c1a93ed7ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2052,12 +2059,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -2066,7 +2073,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:19 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2076,7 +2083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 631a0c01-2147-44f1-800c-819ae4f4ed0f
+      - 2ba92089-4047-482e-8342-2275a012e98b
     status: 200 OK
     code: 200
     duration: ""
@@ -2085,12 +2092,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:14.717836Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:49.107052Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -2099,7 +2106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:19 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2109,7 +2116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3255d8ad-daf0-4dab-a356-691676f2335c
+      - 06c56d67-5200-4e00-902e-b1cd90ebea9f
     status: 200 OK
     code: 200
     duration: ""
@@ -2118,12 +2125,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -2132,7 +2139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:19 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2142,7 +2149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a3010f4-4146-4bc6-96de-7a3a144ce65c
+      - e1d9c55b-b4ef-4f55-8fde-3ef898fe2394
     status: 200 OK
     code: 200
     duration: ""
@@ -2151,15 +2158,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -2168,7 +2176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:20 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2178,7 +2186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 239fbd2d-c261-49f7-a2da-3650892f6d4b
+      - 422acbe1-25c1-49b4-a2f6-693adebaadcd
     status: 200 OK
     code: 200
     duration: ""
@@ -2189,12 +2197,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:20.343267057Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:53.878143569Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -2203,7 +2211,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:20 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2213,7 +2221,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bc81a87-14b3-42df-84fa-1192da5860b7
+      - fe518724-aa9c-453e-b781-6662b09dc49e
     status: 200 OK
     code: 200
     duration: ""
@@ -2222,12 +2230,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:20.343267Z","type":"kapsule","name":"default-pool","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:53.878144Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1325"
@@ -2236,7 +2244,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:20 GMT
+      - Mon, 02 Jan 2023 13:55:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2246,7 +2254,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71505aec-e4dc-42fc-ba80-8790c6423875
+      - 3e84c34e-1dff-4b40-b9ea-a19c6cab9d30
     status: 200 OK
     code: 200
     duration: ""
@@ -2255,12 +2263,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:21.515061Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:55.030508Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -2269,7 +2277,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:25 GMT
+      - Mon, 02 Jan 2023 13:55:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2279,7 +2287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fe31abb-4954-4f2d-94ef-54fe465a693a
+      - bbc9d5fd-dc0f-44ff-8585-45caba7e2cbb
     status: 200 OK
     code: 200
     duration: ""
@@ -2288,12 +2296,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:21.515061Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:55.030508Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -2302,7 +2310,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:25 GMT
+      - Mon, 02 Jan 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2312,7 +2320,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed7698b2-ea73-47cb-a057-6631a69b9265
+      - 79e1cf02-2dd9-4a8a-80c7-e3c6539e7aa8
     status: 200 OK
     code: 200
     duration: ""
@@ -2321,12 +2329,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -2335,7 +2343,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:26 GMT
+      - Mon, 02 Jan 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2345,7 +2353,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 169d9b85-d37c-4a44-9223-736c8089e635
+      - c7e42ff6-17f4-4509-ab37-4cfa4589be6e
     status: 200 OK
     code: 200
     duration: ""
@@ -2354,12 +2362,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:21.515061Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:55.030508Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -2368,7 +2376,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:26 GMT
+      - Mon, 02 Jan 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2378,7 +2386,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d3475e0-d6aa-4a4a-b9cf-1de018a6e2be
+      - d7e6a52d-d02b-4f2f-99ec-053075f7445f
     status: 200 OK
     code: 200
     duration: ""
@@ -2387,12 +2395,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:21.515061Z","type":"kapsule","name":"default-pool","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:55.030508Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -2401,7 +2409,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:27 GMT
+      - Mon, 02 Jan 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2411,7 +2419,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c38bff8-337d-4eb4-9de2-02a7165835f3
+      - 255dd13e-e92a-4eed-a45b-ff5ef57b7ae5
     status: 200 OK
     code: 200
     duration: ""
@@ -2420,12 +2428,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTlHYjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEp3Q2pKbWNFOHliR2c1ZGtremQyOVpaakkwYVZFNVVqaDFNVlo1VEZGbWIwSkNPVTEwYkU5MWFVWlBUM05zZUdWUU9UQldXR1ZhWm1WWlMzcExiV01yZG5BS1IyMWlTSGh0YnpreU9GaFFOVUZRV2xWcmVFdEROM2xRVkU5VE5VWTBWazAyT0VwRUsyNDBjRkIxWkdsNEwxSkZkVXhPTUc5ak5UZEtSa28wYzAxdGFBcE5kVTR6V1VsVU1DczVlV1JwTld0Q2RXdGthamxCY1hCR1dUZEpNekZ3ZVRsdE1URXpZVEJNVW05RFVXdFBSVlZzVm5wR01tTlBOMmgwTmpGS1ZFOTFDazk1T0RoME5YTnhWVmxUTlZaTmEyRkJVVmw0YkZaVk5tVmhNVXBsZUVGclNESndTbE5ZWW05TFVHWmlNRmQ2TTJoaVZtbEJNbXQ0YnpWek5VeGpiV2tLYjJsdWFEUjRVR3d2V2pKdWEzaGtaV2hZV2toVldsQlZRbmN2T1RGU1RYSmFVa3RRWmtsTmMxaG5iV2xzVUhkTFJteE9UVWgzWWpsdmRrUk1jWGw0V1Fvdk5GZFZSbk5SVjFGaVQwNWtiME5wV1ROVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE5EaE5ZMUEyVVdaWVJXOW9WVlJKUzFSaGMwSTJZM1ZzVjBoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05Ya3lTVmx4WmxWS1UxbDViVGxDWTJ3dk4yZHpXREpWVFRKVE5EQXdZbEk1U3l0aVJuRkhUSGROTm1Zd2QzSXplQXBtWjJaUUwzVnNSbU42ZG5ONlpVdFhRVmxFVnpCdU1VUXlaaXN2VVZZeVRYVm9TR1JSTTBoc2RISkJOVkkwZVRSU2JESjBkV2RrZWlzdlYyYzBTbVZ4Q25kR2FuSmpiMVl6UlU4MmNDc3pOVFJoVlN0V2IzTXpjVVZQY0RaVmJURnlOVTVrZGl0RU1XRmFVVkF6UzNBclRXUnRNWEZrYkVSVlozSlhkbFo2YlhnS1MwVktOVTQ0VTFWVFZYTk5aRGhyYkVoMFQxYzNMM014WjJjNFoycDRWek40Y1hKbFoya3ZVSE12WVVkMFZHNTZja0phTDBwVFYzTXJWalZUVEdKVlZncFVRamRETlhOaVltcFRjekUyYzJkRE16SkZVSFZyYzFwTGJteHJURkZRTlRGaGNEVjZZazVqU0dSamRsRlBkMWwzTm1VeFEwaFRlRGhqVFZkVk9YQjFDbVp6TTNKU2NWUkVaVVUzV0hST05rOXRTVzFTUWt4bGF6VlFjelZpVEhsV2VYaGpRd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmMwNGM2ZjgtNTQ1OC00N2I5LWE3ODctZjQ5ZGNlNmU5MzhhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuYXN3Z3N3VlliUnBLWXNUenhCQnc0NkxoRkRjUTBhZkRsZFROM0xCTjBRY3N4bkY5QlNZQmFsNg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImRlZmF1bHQtcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlZlRTlXYjFoRVZFMTZUVVJGZDAxVVJYcE9WRlY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURTFVQ210b04yWnZVRk5sWkRkVk4zTndla3h5UjI5UlZEWkdVMkV4TkhnMmR6RTFjRkZpVG5GSVZGVmtRemhXTlhkUGRqaFFWa0UyYnpOeGVEQjFhVXc0TUhRS1NEZDRRM0ZyZDBaTFdpOXBPRTlCUVdWdGVIUXdkalZyU25CeE1qazNUVkZSVmpKMFlsbHJUMjFVVkhOcVZ5dFhaVlZ2TDJwR2FpczRjMjQzUlZkYVZ3cENPV0pCWW1aWlJYaGFVbkE1YURkRUwxTTNVVWhDY1ZseU1qSktOa1JzU3pSc2VYWjFOV2hzWW1sNmIxQXlTMUJXVVRCSmJXUmlTM041TDAxVUsyMDFDa0l6U1cxT1JtdFdaakprYmtwUmFrMVhSMnQxYUVsYWRFaHFkak5qTW5JemMyRmhkVkpNWVZJclZUZG5iaTl0VUhGTWRHaFpVa2xOUzNWV1lrNVpkRVFLWlVkcmNFTk5jV2RMUXpSTU5rbGhabEkxVXk5WldHaENlbGgyWlRadE5HeHZaelZJTDI0MU1EbFBkRUZ4ZGxCdGFUVk9TSEkyV1RkM2FXRXdkVGRSU2dvcmRsbFZTSEZsV1hSTE4yTkpSazloTVVKalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWNsTjRjV0lyU0VKM05GbHBjblJYVVUxSFpVVkZOazVyYkZCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlNYb3pNRm8wYVUxWVlqbEZNMmQ1TXpNeGJFVkdhWHBXZFU5Rk5WTk1hVkJTYlVkWWRVZzBObkVyTlVkWGJFRTJlQXBXWkdkNlltMHJha2haTVVoRU1FcFFabWhHTjFwR0x6SkpURFYwVUVvckx5c3dSVkF6WmxkVFNFeFBVRmM1VFhFNFJqUnZVRXRqTlM5R1dXSTBNRU5aQ2tKR1kxSlFZVkZRVm13d2IwaFNha3R0ZWk5MVkxcFhUekl3Wm5Cc1UzSkRUa2RMTjJnM1NqRmplbEZyT1dkM1NFbHBUVEpCYWxaa2ExaEtVbmR2TUZNS2RqSmtjVzFzSzNNM2NqQlpPWGxPTjFWd04yOUdTbkkzU1dzNFF5OTNlR1ozYUcxU1ptdE9TVVJ1TldzMVJETlJWbmhpZUdVMlYwNDJXbHB5VDNGeldRbzBVMWhEWVdOcE1sTmhUekJCTWpoT1MxcEtWbGRrT1VaU1EwNXdUMVZGT1dWVWEzUndUM1psVmtoUWJIZDFVamwzY0VSSVRrRk1ha2hGVEVWR1dqbFVDbGR0V25SRU9VMVVhVWhLUVZveGIwWXlSVnA0V1c0eU1rUXlSR1Z0UkhGeU1uVnViQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vN2MxOGIwZDgtYjRlOC00M2E4LThhYTktZmVlYTQ5NTBlODBlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGRlZmF1bHQtcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiZGVmYXVsdC1wb29sIgogICAgdXNlcjogZGVmYXVsdC1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AZGVmYXVsdC1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogZGVmYXVsdC1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBkV3FpRFAyejhMRzlWeU5DNFk5b0psTmJoNDJIcjRjMklsUnhyZjRZczBXYUVsazBoU0FUZncyTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2588"
@@ -2434,7 +2442,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:27 GMT
+      - Mon, 02 Jan 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2444,7 +2452,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca9a6744-c422-4d81-a3f2-924b5e3ddb24
+      - 3beaa18d-92fd-4203-b4d4-47ebe120667a
     status: 200 OK
     code: 200
     duration: ""
@@ -2453,12 +2461,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:28.439912330Z","type":"kapsule","name":"default-pool","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:59.617873541Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -2467,7 +2475,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:28 GMT
+      - Mon, 02 Jan 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2477,7 +2485,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0a77cbc-ceb0-46e1-b379-ad7508a181a5
+      - cad73a66-0d30-4422-a67c-46f92b3541b5
     status: 200 OK
     code: 200
     duration: ""
@@ -2486,12 +2494,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.486713Z","updated_at":"2022-10-25T08:40:28.439912Z","type":"kapsule","name":"default-pool","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"cluster_url":"https://6c04c6f8-5458-47b9-a787-f49dce6e938a.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6c04c6f8-5458-47b9-a787-f49dce6e938a.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":true,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:55:17.395324Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7c18b0d8-b4e8-43a8-8aa9-feea4950e80e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","ingress":"none","name":"default-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-01-02T13:55:59.617874Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1325"
@@ -2500,7 +2508,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:28 GMT
+      - Mon, 02 Jan 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2510,7 +2518,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d257e3f7-cd2a-4509-acf4-4c265a17db29
+      - 3d105b45-d0f6-4088-bcb2-5f2871a056a9
     status: 200 OK
     code: 200
     duration: ""
@@ -2519,12 +2527,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2533,7 +2541,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:34 GMT
+      - Mon, 02 Jan 2023 13:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2543,7 +2551,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b65a2615-f875-4c4d-bad7-4399ad46cc91
+      - 0f2d548d-c7e0-4dc8-8d79-d964eead4dda
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2552,12 +2560,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6c04c6f8-5458-47b9-a787-f49dce6e938a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7c18b0d8-b4e8-43a8-8aa9-feea4950e80e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6c04c6f8-5458-47b9-a787-f49dce6e938a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"7c18b0d8-b4e8-43a8-8aa9-feea4950e80e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2566,7 +2574,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:34 GMT
+      - Mon, 02 Jan 2023 13:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2576,7 +2584,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4fcd5dd-e095-47d9-ad52-da13514dc387
+      - 207edc81-585d-4ce8-997b-78c8188f8d03
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-autoscaling.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-autoscaling.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:22 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 944d2656-cc45-4762-88c7-102440bbfdf8
+      - 4641795b-bc16-4fa6-8e8a-136d06726602
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"autoscaler-01","description":"","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"version":"1.24.5","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"autoscaler-01","description":"","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"version":"1.24.7","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters
     method: POST
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485094661Z","updated_at":"2022-10-25T08:39:25.493939880Z","type":"kapsule","name":"autoscaler-01","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193751997Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:52.215171129Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1343"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d1dc46c-b7b2-4b92-a19f-76c5928de2fd
+      - 1f2085fb-969d-4e03-a548-3db992700b6f
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:25.493940Z","type":"kapsule","name":"autoscaler-01","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:52.215171Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1337"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86f9d4b6-a066-4046-b870-2fd75e6638ab
+      - af0a16ab-84ca-4152-89e8-793df475a911
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:27.145840Z","type":"kapsule","name":"autoscaler-01","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:53.895243Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1342"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69ae3828-fc33-47b8-be14-99d47539c770
+      - 7dab0e0d-6349-40d0-85cb-dacd6a505511
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:27.145840Z","type":"kapsule","name":"autoscaler-01","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:53.895243Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1342"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afd93b50-d374-4ff5-82d4-725f8ee6b68b
+      - ba41dce2-917c-4c40-b86c-78fb7bf81423
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDEiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU1c2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxSeUNuTTFiVUl6Wml0a2JITlJLMUEwZGxsVGVVSmFOVVVyZFVoekswWlJhbTExUmxodVJsQnZNRzFwWjFCM01sUnNTM0p4VEVKWFUyTmxhbms0UXpCclRrd0tjbkoyUWxRck5rcHRZMGsyYTJSdlpsbEhWa2c1Ym1jMVprRjNMelp3VlRock9FVllPV3BQWmpoM2NIazJibmhqSzNscWJHbE1iRk1yVFN0RVMwRk1Md3BEYW10UVVYSkdUVzlxWm0wemFtRmlWRTk1Y2xSSU9HeEtla0Y0VGxnNVZGQlpMMEZoWTBneldtbHJWRE5IU0ZCemQycDZNbUZoUWtOWWJFcFBPVW95Q21SSVVpOHZaRzVrU0VwREx6Um9NamxwTWpGWFRHeGxVVUZOUjNObVJua3JlRUV5Y0VGNlpuWXhVVkJwYkZCd1IxZDVlSEJoWjFWbVExVmlhUzk2WTFVS1JXMDRURmRyWWtwQmRIQjFOa0prYmxNMU0xUllPR3hqY0VGcUwwTkJkV3B3WWxKMk4wUmtZVzkwZWtSM05XcHVNRFpzYmpOWU5tcERkbUZoUXpreGNRb3ZkSGxXVTNoRmRFNDNLekZEVWtkbmJFcE5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNkVzQ1TWxSMmFYWk9NelJUY2tVNFVVUkVTRU5oVjI1alJuUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMWhRYlhaTVVUZHVOMFZHTUdGWmVVcGlPR3A1Ym1wdlRXRkJVbE5uVmsxc1FuWkNPRGxLVG01WlNGTTRTM1U1WmdwUVozRlFjVzlwVEhwWmRESk5aSEpTYTBkdFpHTlBjRmxpVlVORlVtVTNiSEY2Um1SR1JFWXZWa0VyUlVWNlltUllZWEF5TTNGeGEwc3JkemRyZGtOSUNqSjZiekZWWTNST01VMXJMME5ZTUdnd2FqZGlVek16Vmtoc1QwNHJXSFZCVm1kVVFtWm1UR1ptTUhwdlRHRlBUR0ZEUzNOTmRVRnRlSFpSYkRCMloyNEtaWEl5VGpCWVdYZG5MemRMWTJkTVREUnRja0ZvTHpoTlprWkxNblJwSzA1aVlqazVPWEUwYnpWWlIzSkNSM0ZUTVdGRlJWRlBhR1ZVVmtWMFVHdFhVUXAyZFRBMVoxSTJORloxYW1SVE5HdENMM3AzTWpWU01Ga3dTMVpoYWpkM1FXeExNMEp2YnpOeVluUllkSGd3YXpaR2NEZEpWRzVLZFRZM2FVWjJlSEJWQ2t4SVpEQmxZVE5LYlhWT1RXdDNXVUZsUzNaalN6ZG9kalZQVldoalVYUXZlaXR4ZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRiZDI3YjE5LWQzMmUtNGVjZi04OGQzLTljNmZhNjRlNThmZC5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAxCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAxIgogICAgdXNlcjogYXV0b3NjYWxlci0wMS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDEKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiNkpMUjZLdG91QUpGb1ptVHk5VmdSdG01YjFIdVlXYmJ5aTlPNDh0S2FONXRQa2NrakRHM2pnNw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDEiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU25SdUNuZDFWWFJUWmxCalNVSkRabnBzYURsMlVWRjVWMUJQV0VSS0wyNHpTRlo2ZFhORWRVeDRUVE5JVGpSSGRWZ3lRU3RDUjJ4QldrRk5ZbmQzWVVVeWJEQUtXV1JhTUZoWFJUWTBNRmM1ZG5kMlpXWjBObTlhZWtVclMyTkVNMEZ6U2xsdlpHOVNWVUpUWnpaUllUbFpUV3d5T1VONFJGb3pVbnBzUVVsSVNUZ3Jid3BtUlVGQlEzSXdUbmx1TjNoTVptOU1lR2M0THpORVZFdHdaVEJVTkhsWVJHVTNRWEJhUjBselZrNUdWREZRUzFCa01ESkhjMWxYVW1KWE1UUjZhMlUzQ25JM2MyVjJTeTg1VDIxRFluZDJSRXBLYWxaa1ZXVlFUV0pGZWxaSVQwWklZakZ6YnpNelMzTTRjRTlFZFRCeFdqTktXVXRJV0ZGM1MxSnZSR1UzVlhZS1ZtdFNXSFpIUldoelNUaEtOak13V0ZoU1VrcHhXVUZTYjB0c2JFVlNkMmRrUzA5bkx6SlBRVGRRVVZCcFVtWldaRFpXU1dSNkt5OVFLMEZCVldwUVJnb3JSMnREZWswd1RrazBkbXBJVUc5TGRHOXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdhbUY1VG1SWk9FUnFUVkpKVG5ZeFQxTmxhM00yWXpWV01HNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJka3R4U2s0MU5WaG1kSEF2UzBJeFkwZEpNV0ZrYzNSS2MxTjJVbVowWVRKeWRuTklkazB4YldrM2REQkZkWGxvWlFvMU56RkJLMmxDYUV0dVRUTkZXRkEwV0VsUFNrbHNiMmhtT1d4d2NVTkJjaTlXWkd4TU1rbGxOV2xvTjNKS2VGRjFaVEF6ZEZSeWJtZDFaeTlHYTNNMUNsaE5NRWxCYmxwMFVuY3ZNMXA2S3paR2RGaDVOV0UwZFM5TldEUk9UVVZLWWxCV1ltNW1VMGh5U0ZGQ1VWaFdkVnBLU0dOaFpuSXpjVnBYTm5WV2RHUUtXbEZhVWtseVRUQTJUVkJHU2pGb2FHRmpNWGhNUkZBeldsYzNibmh4UTNaaE1UVm5hMjVHY1hVNVFXNVhTRkIxZUhRMWQwUk1ZV3B5V2xab1VESktXUXBNWTBJNGJIUk5OMGhzUlVobGQzQXpNWGcyUjBKT1IzTXhkVFUwT1VWR2VYcHhVbmd5V2tKTU4zcHpVRXRMU0U5dWJWSm1ZakJCZVdjeGNIaHlPVTAwQ2s5dFZEQklaMUJ4ZHlzdlIxRXhSVWxCZVVsc1JtWnNSWGxWYlRaaGJqaHdja3RsUndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzBkMWM3YmI0LWU5YzMtNDYyMy04NmFlLWViN2NjNGM0Y2VkNy5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAxCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAxIgogICAgdXNlcjogYXV0b3NjYWxlci0wMS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDEKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBvNzRLS1hYRHA3SW5sSmozM3FNOG9qRE1FOG5uejd5bUx2UXNiYlM4OVRpUWg5UWliT0RhMFdYNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2596"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f220e26-7cec-4faa-b377-5d3dec6f5654
+      - 090673da-01ee-43cf-9ea5-e741dc99b065
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:27.145840Z","type":"kapsule","name":"autoscaler-01","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:53.895243Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1342"
@@ -223,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db8011c3-48f9-434b-a82f-f1bbb921bddf
+      - 82efc370-8b4f-4af6-bc8b-a3de20b5cf82
     status: 200 OK
     code: 200
     duration: ""
@@ -242,12 +243,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:27.145840Z","type":"kapsule","name":"autoscaler-01","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:53.895243Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1342"
@@ -256,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -266,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07b8763e-d24a-435b-ac6b-c9bc4dd21496
+      - a733be9c-9dd5-48d4-8137-0deba63d665e
     status: 200 OK
     code: 200
     duration: ""
@@ -275,12 +276,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDEiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU1c2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxSeUNuTTFiVUl6Wml0a2JITlJLMUEwZGxsVGVVSmFOVVVyZFVoekswWlJhbTExUmxodVJsQnZNRzFwWjFCM01sUnNTM0p4VEVKWFUyTmxhbms0UXpCclRrd0tjbkoyUWxRck5rcHRZMGsyYTJSdlpsbEhWa2c1Ym1jMVprRjNMelp3VlRock9FVllPV3BQWmpoM2NIazJibmhqSzNscWJHbE1iRk1yVFN0RVMwRk1Md3BEYW10UVVYSkdUVzlxWm0wemFtRmlWRTk1Y2xSSU9HeEtla0Y0VGxnNVZGQlpMMEZoWTBneldtbHJWRE5IU0ZCemQycDZNbUZoUWtOWWJFcFBPVW95Q21SSVVpOHZaRzVrU0VwREx6Um9NamxwTWpGWFRHeGxVVUZOUjNObVJua3JlRUV5Y0VGNlpuWXhVVkJwYkZCd1IxZDVlSEJoWjFWbVExVmlhUzk2WTFVS1JXMDRURmRyWWtwQmRIQjFOa0prYmxNMU0xUllPR3hqY0VGcUwwTkJkV3B3WWxKMk4wUmtZVzkwZWtSM05XcHVNRFpzYmpOWU5tcERkbUZoUXpreGNRb3ZkSGxXVTNoRmRFNDNLekZEVWtkbmJFcE5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNkVzQ1TWxSMmFYWk9NelJUY2tVNFVVUkVTRU5oVjI1alJuUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMWhRYlhaTVVUZHVOMFZHTUdGWmVVcGlPR3A1Ym1wdlRXRkJVbE5uVmsxc1FuWkNPRGxLVG01WlNGTTRTM1U1WmdwUVozRlFjVzlwVEhwWmRESk5aSEpTYTBkdFpHTlBjRmxpVlVORlVtVTNiSEY2Um1SR1JFWXZWa0VyUlVWNlltUllZWEF5TTNGeGEwc3JkemRyZGtOSUNqSjZiekZWWTNST01VMXJMME5ZTUdnd2FqZGlVek16Vmtoc1QwNHJXSFZCVm1kVVFtWm1UR1ptTUhwdlRHRlBUR0ZEUzNOTmRVRnRlSFpSYkRCMloyNEtaWEl5VGpCWVdYZG5MemRMWTJkTVREUnRja0ZvTHpoTlprWkxNblJwSzA1aVlqazVPWEUwYnpWWlIzSkNSM0ZUTVdGRlJWRlBhR1ZVVmtWMFVHdFhVUXAyZFRBMVoxSTJORloxYW1SVE5HdENMM3AzTWpWU01Ga3dTMVpoYWpkM1FXeExNMEp2YnpOeVluUllkSGd3YXpaR2NEZEpWRzVLZFRZM2FVWjJlSEJWQ2t4SVpEQmxZVE5LYlhWT1RXdDNXVUZsUzNaalN6ZG9kalZQVldoalVYUXZlaXR4ZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRiZDI3YjE5LWQzMmUtNGVjZi04OGQzLTljNmZhNjRlNThmZC5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAxCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAxIgogICAgdXNlcjogYXV0b3NjYWxlci0wMS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDEKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiNkpMUjZLdG91QUpGb1ptVHk5VmdSdG01YjFIdVlXYmJ5aTlPNDh0S2FONXRQa2NrakRHM2pnNw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDEiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU25SdUNuZDFWWFJUWmxCalNVSkRabnBzYURsMlVWRjVWMUJQV0VSS0wyNHpTRlo2ZFhORWRVeDRUVE5JVGpSSGRWZ3lRU3RDUjJ4QldrRk5ZbmQzWVVVeWJEQUtXV1JhTUZoWFJUWTBNRmM1ZG5kMlpXWjBObTlhZWtVclMyTkVNMEZ6U2xsdlpHOVNWVUpUWnpaUllUbFpUV3d5T1VONFJGb3pVbnBzUVVsSVNUZ3Jid3BtUlVGQlEzSXdUbmx1TjNoTVptOU1lR2M0THpORVZFdHdaVEJVTkhsWVJHVTNRWEJhUjBselZrNUdWREZRUzFCa01ESkhjMWxYVW1KWE1UUjZhMlUzQ25JM2MyVjJTeTg1VDIxRFluZDJSRXBLYWxaa1ZXVlFUV0pGZWxaSVQwWklZakZ6YnpNelMzTTRjRTlFZFRCeFdqTktXVXRJV0ZGM1MxSnZSR1UzVlhZS1ZtdFNXSFpIUldoelNUaEtOak13V0ZoU1VrcHhXVUZTYjB0c2JFVlNkMmRrUzA5bkx6SlBRVGRRVVZCcFVtWldaRFpXU1dSNkt5OVFLMEZCVldwUVJnb3JSMnREZWswd1RrazBkbXBJVUc5TGRHOXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdhbUY1VG1SWk9FUnFUVkpKVG5ZeFQxTmxhM00yWXpWV01HNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJka3R4U2s0MU5WaG1kSEF2UzBJeFkwZEpNV0ZrYzNSS2MxTjJVbVowWVRKeWRuTklkazB4YldrM2REQkZkWGxvWlFvMU56RkJLMmxDYUV0dVRUTkZXRkEwV0VsUFNrbHNiMmhtT1d4d2NVTkJjaTlXWkd4TU1rbGxOV2xvTjNKS2VGRjFaVEF6ZEZSeWJtZDFaeTlHYTNNMUNsaE5NRWxCYmxwMFVuY3ZNMXA2S3paR2RGaDVOV0UwZFM5TldEUk9UVVZLWWxCV1ltNW1VMGh5U0ZGQ1VWaFdkVnBLU0dOaFpuSXpjVnBYTm5WV2RHUUtXbEZhVWtseVRUQTJUVkJHU2pGb2FHRmpNWGhNUkZBeldsYzNibmh4UTNaaE1UVm5hMjVHY1hVNVFXNVhTRkIxZUhRMWQwUk1ZV3B5V2xab1VESktXUXBNWTBJNGJIUk5OMGhzUlVobGQzQXpNWGcyUjBKT1IzTXhkVFUwT1VWR2VYcHhVbmd5V2tKTU4zcHpVRXRMU0U5dWJWSm1ZakJCZVdjeGNIaHlPVTAwQ2s5dFZEQklaMUJ4ZHlzdlIxRXhSVWxCZVVsc1JtWnNSWGxWYlRaaGJqaHdja3RsUndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzBkMWM3YmI0LWU5YzMtNDYyMy04NmFlLWViN2NjNGM0Y2VkNy5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAxCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAxIgogICAgdXNlcjogYXV0b3NjYWxlci0wMS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDEKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBvNzRLS1hYRHA3SW5sSmozM3FNOG9qRE1FOG5uejd5bUx2UXNiYlM4OVRpUWg5UWliT0RhMFdYNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2596"
@@ -289,7 +290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -299,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 898da15b-d581-42cf-8abc-e464d4c9ea76
+      - 5bd6ffa7-f3d6-4a1f-9a26-2e66ddce9351
     status: 200 OK
     code: 200
     duration: ""
@@ -308,12 +309,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:27.145840Z","type":"kapsule","name":"autoscaler-01","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:53.895243Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1342"
@@ -322,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -332,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 585c94e2-1654-4fcd-8d7d-5e6a3f5156c9
+      - 65ff4140-6183-4792-9b85-f5d60e6f3573
     status: 200 OK
     code: 200
     duration: ""
@@ -341,12 +342,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDEiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU1c2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxSeUNuTTFiVUl6Wml0a2JITlJLMUEwZGxsVGVVSmFOVVVyZFVoekswWlJhbTExUmxodVJsQnZNRzFwWjFCM01sUnNTM0p4VEVKWFUyTmxhbms0UXpCclRrd0tjbkoyUWxRck5rcHRZMGsyYTJSdlpsbEhWa2c1Ym1jMVprRjNMelp3VlRock9FVllPV3BQWmpoM2NIazJibmhqSzNscWJHbE1iRk1yVFN0RVMwRk1Md3BEYW10UVVYSkdUVzlxWm0wemFtRmlWRTk1Y2xSSU9HeEtla0Y0VGxnNVZGQlpMMEZoWTBneldtbHJWRE5IU0ZCemQycDZNbUZoUWtOWWJFcFBPVW95Q21SSVVpOHZaRzVrU0VwREx6Um9NamxwTWpGWFRHeGxVVUZOUjNObVJua3JlRUV5Y0VGNlpuWXhVVkJwYkZCd1IxZDVlSEJoWjFWbVExVmlhUzk2WTFVS1JXMDRURmRyWWtwQmRIQjFOa0prYmxNMU0xUllPR3hqY0VGcUwwTkJkV3B3WWxKMk4wUmtZVzkwZWtSM05XcHVNRFpzYmpOWU5tcERkbUZoUXpreGNRb3ZkSGxXVTNoRmRFNDNLekZEVWtkbmJFcE5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNkVzQ1TWxSMmFYWk9NelJUY2tVNFVVUkVTRU5oVjI1alJuUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMWhRYlhaTVVUZHVOMFZHTUdGWmVVcGlPR3A1Ym1wdlRXRkJVbE5uVmsxc1FuWkNPRGxLVG01WlNGTTRTM1U1WmdwUVozRlFjVzlwVEhwWmRESk5aSEpTYTBkdFpHTlBjRmxpVlVORlVtVTNiSEY2Um1SR1JFWXZWa0VyUlVWNlltUllZWEF5TTNGeGEwc3JkemRyZGtOSUNqSjZiekZWWTNST01VMXJMME5ZTUdnd2FqZGlVek16Vmtoc1QwNHJXSFZCVm1kVVFtWm1UR1ptTUhwdlRHRlBUR0ZEUzNOTmRVRnRlSFpSYkRCMloyNEtaWEl5VGpCWVdYZG5MemRMWTJkTVREUnRja0ZvTHpoTlprWkxNblJwSzA1aVlqazVPWEUwYnpWWlIzSkNSM0ZUTVdGRlJWRlBhR1ZVVmtWMFVHdFhVUXAyZFRBMVoxSTJORloxYW1SVE5HdENMM3AzTWpWU01Ga3dTMVpoYWpkM1FXeExNMEp2YnpOeVluUllkSGd3YXpaR2NEZEpWRzVLZFRZM2FVWjJlSEJWQ2t4SVpEQmxZVE5LYlhWT1RXdDNXVUZsUzNaalN6ZG9kalZQVldoalVYUXZlaXR4ZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRiZDI3YjE5LWQzMmUtNGVjZi04OGQzLTljNmZhNjRlNThmZC5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAxCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAxIgogICAgdXNlcjogYXV0b3NjYWxlci0wMS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDEKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiNkpMUjZLdG91QUpGb1ptVHk5VmdSdG01YjFIdVlXYmJ5aTlPNDh0S2FONXRQa2NrakRHM2pnNw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDEiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU25SdUNuZDFWWFJUWmxCalNVSkRabnBzYURsMlVWRjVWMUJQV0VSS0wyNHpTRlo2ZFhORWRVeDRUVE5JVGpSSGRWZ3lRU3RDUjJ4QldrRk5ZbmQzWVVVeWJEQUtXV1JhTUZoWFJUWTBNRmM1ZG5kMlpXWjBObTlhZWtVclMyTkVNMEZ6U2xsdlpHOVNWVUpUWnpaUllUbFpUV3d5T1VONFJGb3pVbnBzUVVsSVNUZ3Jid3BtUlVGQlEzSXdUbmx1TjNoTVptOU1lR2M0THpORVZFdHdaVEJVTkhsWVJHVTNRWEJhUjBselZrNUdWREZRUzFCa01ESkhjMWxYVW1KWE1UUjZhMlUzQ25JM2MyVjJTeTg1VDIxRFluZDJSRXBLYWxaa1ZXVlFUV0pGZWxaSVQwWklZakZ6YnpNelMzTTRjRTlFZFRCeFdqTktXVXRJV0ZGM1MxSnZSR1UzVlhZS1ZtdFNXSFpIUldoelNUaEtOak13V0ZoU1VrcHhXVUZTYjB0c2JFVlNkMmRrUzA5bkx6SlBRVGRRVVZCcFVtWldaRFpXU1dSNkt5OVFLMEZCVldwUVJnb3JSMnREZWswd1RrazBkbXBJVUc5TGRHOXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdhbUY1VG1SWk9FUnFUVkpKVG5ZeFQxTmxhM00yWXpWV01HNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJka3R4U2s0MU5WaG1kSEF2UzBJeFkwZEpNV0ZrYzNSS2MxTjJVbVowWVRKeWRuTklkazB4YldrM2REQkZkWGxvWlFvMU56RkJLMmxDYUV0dVRUTkZXRkEwV0VsUFNrbHNiMmhtT1d4d2NVTkJjaTlXWkd4TU1rbGxOV2xvTjNKS2VGRjFaVEF6ZEZSeWJtZDFaeTlHYTNNMUNsaE5NRWxCYmxwMFVuY3ZNMXA2S3paR2RGaDVOV0UwZFM5TldEUk9UVVZLWWxCV1ltNW1VMGh5U0ZGQ1VWaFdkVnBLU0dOaFpuSXpjVnBYTm5WV2RHUUtXbEZhVWtseVRUQTJUVkJHU2pGb2FHRmpNWGhNUkZBeldsYzNibmh4UTNaaE1UVm5hMjVHY1hVNVFXNVhTRkIxZUhRMWQwUk1ZV3B5V2xab1VESktXUXBNWTBJNGJIUk5OMGhzUlVobGQzQXpNWGcyUjBKT1IzTXhkVFUwT1VWR2VYcHhVbmd5V2tKTU4zcHpVRXRMU0U5dWJWSm1ZakJCZVdjeGNIaHlPVTAwQ2s5dFZEQklaMUJ4ZHlzdlIxRXhSVWxCZVVsc1JtWnNSWGxWYlRaaGJqaHdja3RsUndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzBkMWM3YmI0LWU5YzMtNDYyMy04NmFlLWViN2NjNGM0Y2VkNy5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAxCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAxIgogICAgdXNlcjogYXV0b3NjYWxlci0wMS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDEKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBvNzRLS1hYRHA3SW5sSmozM3FNOG9qRE1FOG5uejd5bUx2UXNiYlM4OVRpUWg5UWliT0RhMFdYNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2596"
@@ -355,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -365,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6d40fd8-8701-48bd-a688-5b811fdb9a6a
+      - 73acb74d-bebe-4a04-8693-a00937671a79
     status: 200 OK
     code: 200
     duration: ""
@@ -376,12 +377,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: PATCH
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:33.826058741Z","type":"kapsule","name":"autoscaler-02","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:58.602843986Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1341"
@@ -390,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a4a5018-645d-410c-8a8b-cc4103080f33
+      - 8155f1dd-ebd0-4b93-9cd1-df8909fcdf93
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:33.826059Z","type":"kapsule","name":"autoscaler-02","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:58.602844Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1338"
@@ -423,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1f60355-9346-4a6f-92db-c681a4d06f26
+      - ed4004df-9d2d-40c0-8808-0d51ef7820a2
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:35.045039Z","type":"kapsule","name":"autoscaler-02","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:59.794665Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1343"
@@ -456,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:39 GMT
+      - Mon, 02 Jan 2023 13:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dd259fe-91bb-4bdc-a2f0-73745321f104
+      - 170db8e4-218b-442f-86e7-dfd64a460fb4
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:35.045039Z","type":"kapsule","name":"autoscaler-02","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:59.794665Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1343"
@@ -489,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:39 GMT
+      - Mon, 02 Jan 2023 13:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 873b7888-e077-4830-9412-009e09c95a85
+      - 5cc20550-fbe2-4269-9afc-2c2bdabc448d
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU1c2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxSeUNuTTFiVUl6Wml0a2JITlJLMUEwZGxsVGVVSmFOVVVyZFVoekswWlJhbTExUmxodVJsQnZNRzFwWjFCM01sUnNTM0p4VEVKWFUyTmxhbms0UXpCclRrd0tjbkoyUWxRck5rcHRZMGsyYTJSdlpsbEhWa2c1Ym1jMVprRjNMelp3VlRock9FVllPV3BQWmpoM2NIazJibmhqSzNscWJHbE1iRk1yVFN0RVMwRk1Md3BEYW10UVVYSkdUVzlxWm0wemFtRmlWRTk1Y2xSSU9HeEtla0Y0VGxnNVZGQlpMMEZoWTBneldtbHJWRE5IU0ZCemQycDZNbUZoUWtOWWJFcFBPVW95Q21SSVVpOHZaRzVrU0VwREx6Um9NamxwTWpGWFRHeGxVVUZOUjNObVJua3JlRUV5Y0VGNlpuWXhVVkJwYkZCd1IxZDVlSEJoWjFWbVExVmlhUzk2WTFVS1JXMDRURmRyWWtwQmRIQjFOa0prYmxNMU0xUllPR3hqY0VGcUwwTkJkV3B3WWxKMk4wUmtZVzkwZWtSM05XcHVNRFpzYmpOWU5tcERkbUZoUXpreGNRb3ZkSGxXVTNoRmRFNDNLekZEVWtkbmJFcE5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNkVzQ1TWxSMmFYWk9NelJUY2tVNFVVUkVTRU5oVjI1alJuUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMWhRYlhaTVVUZHVOMFZHTUdGWmVVcGlPR3A1Ym1wdlRXRkJVbE5uVmsxc1FuWkNPRGxLVG01WlNGTTRTM1U1WmdwUVozRlFjVzlwVEhwWmRESk5aSEpTYTBkdFpHTlBjRmxpVlVORlVtVTNiSEY2Um1SR1JFWXZWa0VyUlVWNlltUllZWEF5TTNGeGEwc3JkemRyZGtOSUNqSjZiekZWWTNST01VMXJMME5ZTUdnd2FqZGlVek16Vmtoc1QwNHJXSFZCVm1kVVFtWm1UR1ptTUhwdlRHRlBUR0ZEUzNOTmRVRnRlSFpSYkRCMloyNEtaWEl5VGpCWVdYZG5MemRMWTJkTVREUnRja0ZvTHpoTlprWkxNblJwSzA1aVlqazVPWEUwYnpWWlIzSkNSM0ZUTVdGRlJWRlBhR1ZVVmtWMFVHdFhVUXAyZFRBMVoxSTJORloxYW1SVE5HdENMM3AzTWpWU01Ga3dTMVpoYWpkM1FXeExNMEp2YnpOeVluUllkSGd3YXpaR2NEZEpWRzVLZFRZM2FVWjJlSEJWQ2t4SVpEQmxZVE5LYlhWT1RXdDNXVUZsUzNaalN6ZG9kalZQVldoalVYUXZlaXR4ZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRiZDI3YjE5LWQzMmUtNGVjZi04OGQzLTljNmZhNjRlNThmZC5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAyIgogICAgdXNlcjogYXV0b3NjYWxlci0wMi1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiNkpMUjZLdG91QUpGb1ptVHk5VmdSdG01YjFIdVlXYmJ5aTlPNDh0S2FONXRQa2NrakRHM2pnNw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU25SdUNuZDFWWFJUWmxCalNVSkRabnBzYURsMlVWRjVWMUJQV0VSS0wyNHpTRlo2ZFhORWRVeDRUVE5JVGpSSGRWZ3lRU3RDUjJ4QldrRk5ZbmQzWVVVeWJEQUtXV1JhTUZoWFJUWTBNRmM1ZG5kMlpXWjBObTlhZWtVclMyTkVNMEZ6U2xsdlpHOVNWVUpUWnpaUllUbFpUV3d5T1VONFJGb3pVbnBzUVVsSVNUZ3Jid3BtUlVGQlEzSXdUbmx1TjNoTVptOU1lR2M0THpORVZFdHdaVEJVTkhsWVJHVTNRWEJhUjBselZrNUdWREZRUzFCa01ESkhjMWxYVW1KWE1UUjZhMlUzQ25JM2MyVjJTeTg1VDIxRFluZDJSRXBLYWxaa1ZXVlFUV0pGZWxaSVQwWklZakZ6YnpNelMzTTRjRTlFZFRCeFdqTktXVXRJV0ZGM1MxSnZSR1UzVlhZS1ZtdFNXSFpIUldoelNUaEtOak13V0ZoU1VrcHhXVUZTYjB0c2JFVlNkMmRrUzA5bkx6SlBRVGRRVVZCcFVtWldaRFpXU1dSNkt5OVFLMEZCVldwUVJnb3JSMnREZWswd1RrazBkbXBJVUc5TGRHOXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdhbUY1VG1SWk9FUnFUVkpKVG5ZeFQxTmxhM00yWXpWV01HNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJka3R4U2s0MU5WaG1kSEF2UzBJeFkwZEpNV0ZrYzNSS2MxTjJVbVowWVRKeWRuTklkazB4YldrM2REQkZkWGxvWlFvMU56RkJLMmxDYUV0dVRUTkZXRkEwV0VsUFNrbHNiMmhtT1d4d2NVTkJjaTlXWkd4TU1rbGxOV2xvTjNKS2VGRjFaVEF6ZEZSeWJtZDFaeTlHYTNNMUNsaE5NRWxCYmxwMFVuY3ZNMXA2S3paR2RGaDVOV0UwZFM5TldEUk9UVVZLWWxCV1ltNW1VMGh5U0ZGQ1VWaFdkVnBLU0dOaFpuSXpjVnBYTm5WV2RHUUtXbEZhVWtseVRUQTJUVkJHU2pGb2FHRmpNWGhNUkZBeldsYzNibmh4UTNaaE1UVm5hMjVHY1hVNVFXNVhTRkIxZUhRMWQwUk1ZV3B5V2xab1VESktXUXBNWTBJNGJIUk5OMGhzUlVobGQzQXpNWGcyUjBKT1IzTXhkVFUwT1VWR2VYcHhVbmd5V2tKTU4zcHpVRXRMU0U5dWJWSm1ZakJCZVdjeGNIaHlPVTAwQ2s5dFZEQklaMUJ4ZHlzdlIxRXhSVWxCZVVsc1JtWnNSWGxWYlRaaGJqaHdja3RsUndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzBkMWM3YmI0LWU5YzMtNDYyMy04NmFlLWViN2NjNGM0Y2VkNy5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAyIgogICAgdXNlcjogYXV0b3NjYWxlci0wMi1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBvNzRLS1hYRHA3SW5sSmozM3FNOG9qRE1FOG5uejd5bUx2UXNiYlM4OVRpUWg5UWliT0RhMFdYNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2596"
@@ -522,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:40 GMT
+      - Mon, 02 Jan 2023 13:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e1b9c90-5b60-4af1-a577-d0a00197acbe
+      - 43ba6536-d839-4497-b752-99c73e86a85f
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:35.045039Z","type":"kapsule","name":"autoscaler-02","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:59.794665Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1343"
@@ -555,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:40 GMT
+      - Mon, 02 Jan 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0ad9acf-be6a-4678-b470-7a2c5136a46a
+      - 232c5e53-095b-446d-89ac-e3009547dc65
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:35.045039Z","type":"kapsule","name":"autoscaler-02","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:59.794665Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1343"
@@ -588,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:41 GMT
+      - Mon, 02 Jan 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a353ba82-6ac9-4afa-aad3-6772db07e23b
+      - d4e4ea1b-0f6f-415a-a0ee-66e4ba40318c
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU1c2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxSeUNuTTFiVUl6Wml0a2JITlJLMUEwZGxsVGVVSmFOVVVyZFVoekswWlJhbTExUmxodVJsQnZNRzFwWjFCM01sUnNTM0p4VEVKWFUyTmxhbms0UXpCclRrd0tjbkoyUWxRck5rcHRZMGsyYTJSdlpsbEhWa2c1Ym1jMVprRjNMelp3VlRock9FVllPV3BQWmpoM2NIazJibmhqSzNscWJHbE1iRk1yVFN0RVMwRk1Md3BEYW10UVVYSkdUVzlxWm0wemFtRmlWRTk1Y2xSSU9HeEtla0Y0VGxnNVZGQlpMMEZoWTBneldtbHJWRE5IU0ZCemQycDZNbUZoUWtOWWJFcFBPVW95Q21SSVVpOHZaRzVrU0VwREx6Um9NamxwTWpGWFRHeGxVVUZOUjNObVJua3JlRUV5Y0VGNlpuWXhVVkJwYkZCd1IxZDVlSEJoWjFWbVExVmlhUzk2WTFVS1JXMDRURmRyWWtwQmRIQjFOa0prYmxNMU0xUllPR3hqY0VGcUwwTkJkV3B3WWxKMk4wUmtZVzkwZWtSM05XcHVNRFpzYmpOWU5tcERkbUZoUXpreGNRb3ZkSGxXVTNoRmRFNDNLekZEVWtkbmJFcE5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNkVzQ1TWxSMmFYWk9NelJUY2tVNFVVUkVTRU5oVjI1alJuUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMWhRYlhaTVVUZHVOMFZHTUdGWmVVcGlPR3A1Ym1wdlRXRkJVbE5uVmsxc1FuWkNPRGxLVG01WlNGTTRTM1U1WmdwUVozRlFjVzlwVEhwWmRESk5aSEpTYTBkdFpHTlBjRmxpVlVORlVtVTNiSEY2Um1SR1JFWXZWa0VyUlVWNlltUllZWEF5TTNGeGEwc3JkemRyZGtOSUNqSjZiekZWWTNST01VMXJMME5ZTUdnd2FqZGlVek16Vmtoc1QwNHJXSFZCVm1kVVFtWm1UR1ptTUhwdlRHRlBUR0ZEUzNOTmRVRnRlSFpSYkRCMloyNEtaWEl5VGpCWVdYZG5MemRMWTJkTVREUnRja0ZvTHpoTlprWkxNblJwSzA1aVlqazVPWEUwYnpWWlIzSkNSM0ZUTVdGRlJWRlBhR1ZVVmtWMFVHdFhVUXAyZFRBMVoxSTJORloxYW1SVE5HdENMM3AzTWpWU01Ga3dTMVpoYWpkM1FXeExNMEp2YnpOeVluUllkSGd3YXpaR2NEZEpWRzVLZFRZM2FVWjJlSEJWQ2t4SVpEQmxZVE5LYlhWT1RXdDNXVUZsUzNaalN6ZG9kalZQVldoalVYUXZlaXR4ZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRiZDI3YjE5LWQzMmUtNGVjZi04OGQzLTljNmZhNjRlNThmZC5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAyIgogICAgdXNlcjogYXV0b3NjYWxlci0wMi1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiNkpMUjZLdG91QUpGb1ptVHk5VmdSdG01YjFIdVlXYmJ5aTlPNDh0S2FONXRQa2NrakRHM2pnNw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImF1dG9zY2FsZXItMDIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU25SdUNuZDFWWFJUWmxCalNVSkRabnBzYURsMlVWRjVWMUJQV0VSS0wyNHpTRlo2ZFhORWRVeDRUVE5JVGpSSGRWZ3lRU3RDUjJ4QldrRk5ZbmQzWVVVeWJEQUtXV1JhTUZoWFJUWTBNRmM1ZG5kMlpXWjBObTlhZWtVclMyTkVNMEZ6U2xsdlpHOVNWVUpUWnpaUllUbFpUV3d5T1VONFJGb3pVbnBzUVVsSVNUZ3Jid3BtUlVGQlEzSXdUbmx1TjNoTVptOU1lR2M0THpORVZFdHdaVEJVTkhsWVJHVTNRWEJhUjBselZrNUdWREZRUzFCa01ESkhjMWxYVW1KWE1UUjZhMlUzQ25JM2MyVjJTeTg1VDIxRFluZDJSRXBLYWxaa1ZXVlFUV0pGZWxaSVQwWklZakZ6YnpNelMzTTRjRTlFZFRCeFdqTktXVXRJV0ZGM1MxSnZSR1UzVlhZS1ZtdFNXSFpIUldoelNUaEtOak13V0ZoU1VrcHhXVUZTYjB0c2JFVlNkMmRrUzA5bkx6SlBRVGRRVVZCcFVtWldaRFpXU1dSNkt5OVFLMEZCVldwUVJnb3JSMnREZWswd1RrazBkbXBJVUc5TGRHOXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdhbUY1VG1SWk9FUnFUVkpKVG5ZeFQxTmxhM00yWXpWV01HNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJka3R4U2s0MU5WaG1kSEF2UzBJeFkwZEpNV0ZrYzNSS2MxTjJVbVowWVRKeWRuTklkazB4YldrM2REQkZkWGxvWlFvMU56RkJLMmxDYUV0dVRUTkZXRkEwV0VsUFNrbHNiMmhtT1d4d2NVTkJjaTlXWkd4TU1rbGxOV2xvTjNKS2VGRjFaVEF6ZEZSeWJtZDFaeTlHYTNNMUNsaE5NRWxCYmxwMFVuY3ZNMXA2S3paR2RGaDVOV0UwZFM5TldEUk9UVVZLWWxCV1ltNW1VMGh5U0ZGQ1VWaFdkVnBLU0dOaFpuSXpjVnBYTm5WV2RHUUtXbEZhVWtseVRUQTJUVkJHU2pGb2FHRmpNWGhNUkZBeldsYzNibmh4UTNaaE1UVm5hMjVHY1hVNVFXNVhTRkIxZUhRMWQwUk1ZV3B5V2xab1VESktXUXBNWTBJNGJIUk5OMGhzUlVobGQzQXpNWGcyUjBKT1IzTXhkVFUwT1VWR2VYcHhVbmd5V2tKTU4zcHpVRXRMU0U5dWJWSm1ZakJCZVdjeGNIaHlPVTAwQ2s5dFZEQklaMUJ4ZHlzdlIxRXhSVWxCZVVsc1JtWnNSWGxWYlRaaGJqaHdja3RsUndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzBkMWM3YmI0LWU5YzMtNDYyMy04NmFlLWViN2NjNGM0Y2VkNy5hcGkuazhzLm5sLWFtcy5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBhdXRvc2NhbGVyLTAyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJhdXRvc2NhbGVyLTAyIgogICAgdXNlcjogYXV0b3NjYWxlci0wMi1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQGF1dG9zY2FsZXItMDIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBhdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBvNzRLS1hYRHA3SW5sSmozM3FNOG9qRE1FOG5uejd5bUx2UXNiYlM4OVRpUWg5UWliT0RhMFdYNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2596"
@@ -621,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:41 GMT
+      - Mon, 02 Jan 2023 13:55:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4b6e989-f774-4a5d-8cba-8a81656a59d3
+      - 23ea5ac7-d4e1-44d5-99e5-c6d214becb31
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:42.387862684Z","type":"kapsule","name":"autoscaler-02","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.246789637Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1341"
@@ -654,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:42 GMT
+      - Mon, 02 Jan 2023 13:55:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bdf314c-1a04-474f-80aa-0fce7a9692a4
+      - dd9c7f21-11b1-40e4-a3f7-11e940ef6d79
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.485095Z","updated_at":"2022-10-25T08:39:42.387863Z","type":"kapsule","name":"autoscaler-02","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"cluster_url":"https://4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.193752Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","ingress":"none","name":"autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.246790Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1338"
@@ -687,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:42 GMT
+      - Mon, 02 Jan 2023 13:55:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8a8d4f3-a4b1-4fc2-bbce-088f13e0856e
+      - af7c5512-28d6-4bf4-9236-d4f84efe8ad5
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -720,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:47 GMT
+      - Mon, 02 Jan 2023 13:55:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2c8e861-330b-48b0-95fb-71f0d699feda
+      - 8397c242-04f3-4e1d-bb86-ded9c53babb9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -739,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4bd27b19-d32e-4ecf-88d3-9c6fa64e58fd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0d1c7bb4-e9c3-4623-86ae-eb7cc4c4ced7","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -753,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:47 GMT
+      - Mon, 02 Jan 2023 13:55:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45342b42-aa39-4e48-a125-b2ee1ec26355
+      - 9ab9e9a5-634f-4135-b6f8-4d56eed86041
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-basic.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-basic.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:22 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee8fd5d6-362a-4656-b58b-a8fa13c07c93
+      - 0f61f238-d186-4bcb-9671-96396316e2e9
     status: 200 OK
     code: 200
     duration: ""
@@ -42,15 +43,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -59,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:22 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,23 +71,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9197c88-291a-43f9-8901-e29c5d86d467
+      - d61925a3-5671-41a7-bcc2-040294d1090a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"ClusterConfigMinimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.23.11","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"ClusterConfigMinimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.23.13","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382712643Z","updated_at":"2022-10-25T08:39:25.394014998Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"creating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224191Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:52.235050839Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1335"
@@ -94,7 +96,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -104,7 +106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18f5556a-b700-4e2f-af36-4bcfc291a9b6
+      - ec187124-5675-46e2-9e4c-b6488a0b247a
     status: 200 OK
     code: 200
     duration: ""
@@ -113,12 +115,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:25.394015Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"creating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:52.235051Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1329"
@@ -127,7 +129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf37235b-9a69-49d5-a960-b22b50144f1a
+      - fdba37fe-e7d9-4472-9859-38ebcf83a96e
     status: 200 OK
     code: 200
     duration: ""
@@ -146,12 +148,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:28.846521Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.742985Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1334"
@@ -160,7 +162,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 319422c0-0721-4087-8879-473b51cf163d
+      - 2a183c24-d502-4b4a-9ec3-0ede46bee277
     status: 200 OK
     code: 200
     duration: ""
@@ -179,12 +181,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:28.846521Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.742985Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1334"
@@ -193,7 +195,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +205,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1397d405-4ad7-4f7b-8329-a9482926b2bd
+      - c0d4d00e-0c88-4805-afed-b955008a0fd0
     status: 200 OK
     code: 200
     duration: ""
@@ -212,12 +214,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRWTkhDazl4WjB4MlR6VlpaMUUyZFhkeFVqTlNVMUZuUkdRelNHOTJhMVZsWVdOT1VURklkbTF1VEcxaloxSjRhRzV1Vm5KM01HRmlkbFpPY0V4QlNYZFhia2tLVG1OUlpYTnhSMUV2VlRVemMwMUhlbW95Y1c0eVFXOWphMXA1V25GRmQyZEJUV1U1ZG5SMVJuSlRORU5ZYjJaa0szZGFNV2RUYjBGdWFTOVlkalF6U3dwa2RHSnhZVXBPTUc1eGEwMDFUelpEUldRelMwaDNXbUp3YTBwWmFWaElTWFZRWkhSRVRuZE5jSFJRVlRjMVoxQXZaek5TWVRRd05EQnVjVUZFUm1wQkNpODJOVzh4U25kcGFTOUtVMkZSYUhvM1ZIWldXak55Ykd0d1lrSTRhbVJzU21nd1ptY3JOazlzUTNaWlVYQjNVVGg2UjB0TE9IWm1RbXRDUVhKWmRuRUtUbFZtYVdWWlRXSlVURzVKYmtKTGVtRXZNVGhyYnk5WU1WaE1NRTFZVTFoNGMyUklSSHBUVERsd2VGVlBZa0l3U25KWVJVOU5WMWh6V0c1NmJIUkRZd3BCVXpFME4yUjZPRzVGUm5CMVlYQlJPVTR3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDU0ZSb1pXMTFkV1ZUVkZocUt6TnZWV2g1VVZsWVdEWldNM0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCZUZGcVQzUkpVbmt6VUc5blVsQlZabEU0Ym5aamRrOUJhRWxMZEVGemFsWjNUemM1T1UxNU4weFhkamhoVTBVMlVBcHBjbFF5ZFVGU1MwZHZiSGhhVW1ndmVtWjFjM1ZUY0dObVdYTlBNazlMV2t0V1RtOUNlbkZrTkhGQ1dUUTRXbkY0VVhWNVdreG1RMmRpVldaR2VtSnpDakZqYkVwaE1VWTNWbVJhTmtwS2NFUkNPVWxqUzBST1VXeFdUSGt4TldGQ01sZFFZM2N5WW1wQlFYQlFSMUpTTVRSRFQwZEhaWFJ3ZGpkMVZsTkVVRXNLY0N0V2RXY3lOelp6UTNWaE5uQm9kVmxvTldRM1l6aExRVFU1TW5oQ2REQTBZbHBQV0dWS2VuUk5TbnB3TDBJMFFYUXhSMFpRVjBjeVNscFJVbXhJV2dwWk5EQmhjakpCVFc4eGJUVXJiMk56UmxKd1NtUnhialJZU0ZWRlEySTFVR3BPYTI1NGEybFZNblYxUjFNNVFVWjFNVUUwT0VwcWIybzFOblY2Y1dWU0NrUmtXRGRTY0VZeWFtOHJhMk42V25OWmFHVk5Za0ZPYkc5aFJ5dEpVbWhzYkRoeVZBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82MjM4YTIzNi04YWU3LTQ4ZjktOTQxNC1lNDViNTI2MWU0MzUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKbVJ5eEZURFdreENHSVlXU0hRMlhISk01b3FpRFlVb3lYdXloYmM3OFp6U3VvblNxSVNRSUJ4RA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVY2VGxSUk1VNUdiMWhFVkUxNlRVUkZkMDFVUlhwT1ZGRXhUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNpdHVDa2xzUTBoT2JGcFZhVmswZVRoRFRUWkNZa1pLWjJaSlZGY3hhSEZEVG5WQ05IZFhibEI2ZVVwUloyWTFNRmRvYXpkbFJUUlBUM2RIUkM5V09YbEVWVUVLU0dKeWRYSXlXbVJvU3k4M01FdzVWMjAwTms5eldYaE5SMkpQUVhGb1NYTkxNelExT0c1bWMxTjNjakY0TVRoMkwxVXdWblJGVWxrMGVHeHZkV0l6THdvclVsVkhLMFkzWlcxc01teHFTR3RGVDJwUE1tVm5WMDFVTUhWcE5YZEJiVGRGWjFsQmVERkJUVGxFVkN0cWMyNXZaR1pDTWpkVlRVc3ZOakpXYjAxcUNrNDJLemhOWTB0UlZqbHNiRXhvY0dvNFZqRnZXbU5CYTFKTWFWZEdPVlUxWWsxbFQxUkhTMUpQV2poTGFsQTVVREJyV2s1TU1TOXpNMlpYU21ad1NXd0tSa2RXUTIxUU5FcElTMVl2TTBsM1NVUnVSVGxOUXpGUlMybDZVWFJ3TWpsSWNEQnBXWFp6WmxCcGVYTkViekkwZUVwMVYzTkxVSHBST0c5SGFuQmxNQXA2WlRod09FTlhOVlJLWVdsMFdHdG5RamRyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpHTVhSSlZURXZWblJtTDBoeWMxTkdXRFJyUmt4MFNDOTFkVVpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCYVVGNVNuZHNWU3RWVm5oSVdWaG5OM00wUlZKdVdVRjZjblV2UzJGa09VNUZUMEY0Tm1RdlVtOUthVk5KTjNwemFnbzVSa3haTUV4Mk5sUk5SMGhSVkM5Tk16QlJWbmhQT0VGd1lWZERVRVY0WjNab2NVRm5iRzUxZEVOc2FtSmxPVkpqTmt4TFdWTkhWakk1UkRCT2RuSXdDa2hUVFZNclRHcGhTQzlNUmtGQ09EQXhibm94V1VweFVUQnRhbFEyTUhveE5rdEdVM1pNYkZSMk5YbHdOblo1SzFGaVIyNURjbUpXV2t4WVdHWjBNWGNLWkU5UldEVlhkWGt5YVU5QlFtaG9aQzlLWVd0dGJWQnVWMnR3YjFac09GTkxjbEJKWkV3MFJXOTBhM1EzWXpORFoxZFVja054ZW14WFNWWjZlVnAxTUFwWFZIUlZSekp6WkhkdmMzSkNOekJHUkhsSVkweHRlR1ZKVkd0S1dETmFRakYzTkZKU1EydDJVbTlsU1VkWVUySnBUSE5uU2xWa1ZWZEZLMU5rVVZKVkNsRlBjekppZFRKa2EzSnNNU3R4Tm0xNldWTmpPSGhLWTJKRlJIQlFVU3RUYzB4M1dBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lOTVjZGRkYi00ZjcyLTQwYWUtYTMyMS0wN2U2Y2ViN2VkMjAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxOTB1bVU1b04zQkhBbU9xOXlFZjliMWVYaWQ1bEpXNU5zUlQ0Y1NFZkVLVG9Idml0VDgzM0RIbg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -226,7 +228,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +238,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ef861f1-8d78-46ca-985c-7ebe3f0d8d1b
+      - 7b168bf7-6e27-43e3-bc33-833e2fce1ee0
     status: 200 OK
     code: 200
     duration: ""
@@ -245,12 +247,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:28.846521Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.742985Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1334"
@@ -259,7 +261,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +271,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d0e7b13-6d54-42cf-a88d-bb2213a3396b
+      - 7c41a1a9-8d8a-43da-b4ca-faf23ea08f80
     status: 200 OK
     code: 200
     duration: ""
@@ -278,12 +280,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:28.846521Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.742985Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1334"
@@ -292,7 +294,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +304,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a926a6f8-a7ce-46b7-8ddd-93c2ca4eb7d3
+      - f80e344c-9eae-4799-9d3a-9bd2521db5e7
     status: 200 OK
     code: 200
     duration: ""
@@ -311,12 +313,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRWTkhDazl4WjB4MlR6VlpaMUUyZFhkeFVqTlNVMUZuUkdRelNHOTJhMVZsWVdOT1VURklkbTF1VEcxaloxSjRhRzV1Vm5KM01HRmlkbFpPY0V4QlNYZFhia2tLVG1OUlpYTnhSMUV2VlRVemMwMUhlbW95Y1c0eVFXOWphMXA1V25GRmQyZEJUV1U1ZG5SMVJuSlRORU5ZYjJaa0szZGFNV2RUYjBGdWFTOVlkalF6U3dwa2RHSnhZVXBPTUc1eGEwMDFUelpEUldRelMwaDNXbUp3YTBwWmFWaElTWFZRWkhSRVRuZE5jSFJRVlRjMVoxQXZaek5TWVRRd05EQnVjVUZFUm1wQkNpODJOVzh4U25kcGFTOUtVMkZSYUhvM1ZIWldXak55Ykd0d1lrSTRhbVJzU21nd1ptY3JOazlzUTNaWlVYQjNVVGg2UjB0TE9IWm1RbXRDUVhKWmRuRUtUbFZtYVdWWlRXSlVURzVKYmtKTGVtRXZNVGhyYnk5WU1WaE1NRTFZVTFoNGMyUklSSHBUVERsd2VGVlBZa0l3U25KWVJVOU5WMWh6V0c1NmJIUkRZd3BCVXpFME4yUjZPRzVGUm5CMVlYQlJPVTR3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDU0ZSb1pXMTFkV1ZUVkZocUt6TnZWV2g1VVZsWVdEWldNM0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCZUZGcVQzUkpVbmt6VUc5blVsQlZabEU0Ym5aamRrOUJhRWxMZEVGemFsWjNUemM1T1UxNU4weFhkamhoVTBVMlVBcHBjbFF5ZFVGU1MwZHZiSGhhVW1ndmVtWjFjM1ZUY0dObVdYTlBNazlMV2t0V1RtOUNlbkZrTkhGQ1dUUTRXbkY0VVhWNVdreG1RMmRpVldaR2VtSnpDakZqYkVwaE1VWTNWbVJhTmtwS2NFUkNPVWxqUzBST1VXeFdUSGt4TldGQ01sZFFZM2N5WW1wQlFYQlFSMUpTTVRSRFQwZEhaWFJ3ZGpkMVZsTkVVRXNLY0N0V2RXY3lOelp6UTNWaE5uQm9kVmxvTldRM1l6aExRVFU1TW5oQ2REQTBZbHBQV0dWS2VuUk5TbnB3TDBJMFFYUXhSMFpRVjBjeVNscFJVbXhJV2dwWk5EQmhjakpCVFc4eGJUVXJiMk56UmxKd1NtUnhialJZU0ZWRlEySTFVR3BPYTI1NGEybFZNblYxUjFNNVFVWjFNVUUwT0VwcWIybzFOblY2Y1dWU0NrUmtXRGRTY0VZeWFtOHJhMk42V25OWmFHVk5Za0ZPYkc5aFJ5dEpVbWhzYkRoeVZBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82MjM4YTIzNi04YWU3LTQ4ZjktOTQxNC1lNDViNTI2MWU0MzUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKbVJ5eEZURFdreENHSVlXU0hRMlhISk01b3FpRFlVb3lYdXloYmM3OFp6U3VvblNxSVNRSUJ4RA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVY2VGxSUk1VNUdiMWhFVkUxNlRVUkZkMDFVUlhwT1ZGRXhUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNpdHVDa2xzUTBoT2JGcFZhVmswZVRoRFRUWkNZa1pLWjJaSlZGY3hhSEZEVG5WQ05IZFhibEI2ZVVwUloyWTFNRmRvYXpkbFJUUlBUM2RIUkM5V09YbEVWVUVLU0dKeWRYSXlXbVJvU3k4M01FdzVWMjAwTms5eldYaE5SMkpQUVhGb1NYTkxNelExT0c1bWMxTjNjakY0TVRoMkwxVXdWblJGVWxrMGVHeHZkV0l6THdvclVsVkhLMFkzWlcxc01teHFTR3RGVDJwUE1tVm5WMDFVTUhWcE5YZEJiVGRGWjFsQmVERkJUVGxFVkN0cWMyNXZaR1pDTWpkVlRVc3ZOakpXYjAxcUNrNDJLemhOWTB0UlZqbHNiRXhvY0dvNFZqRnZXbU5CYTFKTWFWZEdPVlUxWWsxbFQxUkhTMUpQV2poTGFsQTVVREJyV2s1TU1TOXpNMlpYU21ad1NXd0tSa2RXUTIxUU5FcElTMVl2TTBsM1NVUnVSVGxOUXpGUlMybDZVWFJ3TWpsSWNEQnBXWFp6WmxCcGVYTkViekkwZUVwMVYzTkxVSHBST0c5SGFuQmxNQXA2WlRod09FTlhOVlJLWVdsMFdHdG5RamRyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpHTVhSSlZURXZWblJtTDBoeWMxTkdXRFJyUmt4MFNDOTFkVVpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCYVVGNVNuZHNWU3RWVm5oSVdWaG5OM00wUlZKdVdVRjZjblV2UzJGa09VNUZUMEY0Tm1RdlVtOUthVk5KTjNwemFnbzVSa3haTUV4Mk5sUk5SMGhSVkM5Tk16QlJWbmhQT0VGd1lWZERVRVY0WjNab2NVRm5iRzUxZEVOc2FtSmxPVkpqTmt4TFdWTkhWakk1UkRCT2RuSXdDa2hUVFZNclRHcGhTQzlNUmtGQ09EQXhibm94V1VweFVUQnRhbFEyTUhveE5rdEdVM1pNYkZSMk5YbHdOblo1SzFGaVIyNURjbUpXV2t4WVdHWjBNWGNLWkU5UldEVlhkWGt5YVU5QlFtaG9aQzlLWVd0dGJWQnVWMnR3YjFac09GTkxjbEJKWkV3MFJXOTBhM1EzWXpORFoxZFVja054ZW14WFNWWjZlVnAxTUFwWFZIUlZSekp6WkhkdmMzSkNOekJHUkhsSVkweHRlR1ZKVkd0S1dETmFRakYzTkZKU1EydDJVbTlsU1VkWVUySnBUSE5uU2xWa1ZWZEZLMU5rVVZKVkNsRlBjekppZFRKa2EzSnNNU3R4Tm0xNldWTmpPSGhLWTJKRlJIQlFVU3RUYzB4M1dBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lOTVjZGRkYi00ZjcyLTQwYWUtYTMyMS0wN2U2Y2ViN2VkMjAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxOTB1bVU1b04zQkhBbU9xOXlFZjliMWVYaWQ1bEpXNU5zUlQ0Y1NFZkVLVG9Idml0VDgzM0RIbg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -325,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c917934d-e0ef-4d8e-9457-4178d0820530
+      - c57abe17-b5a0-4932-b100-986532fc63f7
     status: 200 OK
     code: 200
     duration: ""
@@ -344,12 +346,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:28.846521Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.742985Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1334"
@@ -358,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 228b007c-5d23-4174-a236-3574f569433b
+      - ecbf61e6-e52c-47d6-94ac-94da3fe4a92b
     status: 200 OK
     code: 200
     duration: ""
@@ -377,12 +379,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRWTkhDazl4WjB4MlR6VlpaMUUyZFhkeFVqTlNVMUZuUkdRelNHOTJhMVZsWVdOT1VURklkbTF1VEcxaloxSjRhRzV1Vm5KM01HRmlkbFpPY0V4QlNYZFhia2tLVG1OUlpYTnhSMUV2VlRVemMwMUhlbW95Y1c0eVFXOWphMXA1V25GRmQyZEJUV1U1ZG5SMVJuSlRORU5ZYjJaa0szZGFNV2RUYjBGdWFTOVlkalF6U3dwa2RHSnhZVXBPTUc1eGEwMDFUelpEUldRelMwaDNXbUp3YTBwWmFWaElTWFZRWkhSRVRuZE5jSFJRVlRjMVoxQXZaek5TWVRRd05EQnVjVUZFUm1wQkNpODJOVzh4U25kcGFTOUtVMkZSYUhvM1ZIWldXak55Ykd0d1lrSTRhbVJzU21nd1ptY3JOazlzUTNaWlVYQjNVVGg2UjB0TE9IWm1RbXRDUVhKWmRuRUtUbFZtYVdWWlRXSlVURzVKYmtKTGVtRXZNVGhyYnk5WU1WaE1NRTFZVTFoNGMyUklSSHBUVERsd2VGVlBZa0l3U25KWVJVOU5WMWh6V0c1NmJIUkRZd3BCVXpFME4yUjZPRzVGUm5CMVlYQlJPVTR3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDU0ZSb1pXMTFkV1ZUVkZocUt6TnZWV2g1VVZsWVdEWldNM0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCZUZGcVQzUkpVbmt6VUc5blVsQlZabEU0Ym5aamRrOUJhRWxMZEVGemFsWjNUemM1T1UxNU4weFhkamhoVTBVMlVBcHBjbFF5ZFVGU1MwZHZiSGhhVW1ndmVtWjFjM1ZUY0dObVdYTlBNazlMV2t0V1RtOUNlbkZrTkhGQ1dUUTRXbkY0VVhWNVdreG1RMmRpVldaR2VtSnpDakZqYkVwaE1VWTNWbVJhTmtwS2NFUkNPVWxqUzBST1VXeFdUSGt4TldGQ01sZFFZM2N5WW1wQlFYQlFSMUpTTVRSRFQwZEhaWFJ3ZGpkMVZsTkVVRXNLY0N0V2RXY3lOelp6UTNWaE5uQm9kVmxvTldRM1l6aExRVFU1TW5oQ2REQTBZbHBQV0dWS2VuUk5TbnB3TDBJMFFYUXhSMFpRVjBjeVNscFJVbXhJV2dwWk5EQmhjakpCVFc4eGJUVXJiMk56UmxKd1NtUnhialJZU0ZWRlEySTFVR3BPYTI1NGEybFZNblYxUjFNNVFVWjFNVUUwT0VwcWIybzFOblY2Y1dWU0NrUmtXRGRTY0VZeWFtOHJhMk42V25OWmFHVk5Za0ZPYkc5aFJ5dEpVbWhzYkRoeVZBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82MjM4YTIzNi04YWU3LTQ4ZjktOTQxNC1lNDViNTI2MWU0MzUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKbVJ5eEZURFdreENHSVlXU0hRMlhISk01b3FpRFlVb3lYdXloYmM3OFp6U3VvblNxSVNRSUJ4RA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVY2VGxSUk1VNUdiMWhFVkUxNlRVUkZkMDFVUlhwT1ZGRXhUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNpdHVDa2xzUTBoT2JGcFZhVmswZVRoRFRUWkNZa1pLWjJaSlZGY3hhSEZEVG5WQ05IZFhibEI2ZVVwUloyWTFNRmRvYXpkbFJUUlBUM2RIUkM5V09YbEVWVUVLU0dKeWRYSXlXbVJvU3k4M01FdzVWMjAwTms5eldYaE5SMkpQUVhGb1NYTkxNelExT0c1bWMxTjNjakY0TVRoMkwxVXdWblJGVWxrMGVHeHZkV0l6THdvclVsVkhLMFkzWlcxc01teHFTR3RGVDJwUE1tVm5WMDFVTUhWcE5YZEJiVGRGWjFsQmVERkJUVGxFVkN0cWMyNXZaR1pDTWpkVlRVc3ZOakpXYjAxcUNrNDJLemhOWTB0UlZqbHNiRXhvY0dvNFZqRnZXbU5CYTFKTWFWZEdPVlUxWWsxbFQxUkhTMUpQV2poTGFsQTVVREJyV2s1TU1TOXpNMlpYU21ad1NXd0tSa2RXUTIxUU5FcElTMVl2TTBsM1NVUnVSVGxOUXpGUlMybDZVWFJ3TWpsSWNEQnBXWFp6WmxCcGVYTkViekkwZUVwMVYzTkxVSHBST0c5SGFuQmxNQXA2WlRod09FTlhOVlJLWVdsMFdHdG5RamRyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpHTVhSSlZURXZWblJtTDBoeWMxTkdXRFJyUmt4MFNDOTFkVVpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCYVVGNVNuZHNWU3RWVm5oSVdWaG5OM00wUlZKdVdVRjZjblV2UzJGa09VNUZUMEY0Tm1RdlVtOUthVk5KTjNwemFnbzVSa3haTUV4Mk5sUk5SMGhSVkM5Tk16QlJWbmhQT0VGd1lWZERVRVY0WjNab2NVRm5iRzUxZEVOc2FtSmxPVkpqTmt4TFdWTkhWakk1UkRCT2RuSXdDa2hUVFZNclRHcGhTQzlNUmtGQ09EQXhibm94V1VweFVUQnRhbFEyTUhveE5rdEdVM1pNYkZSMk5YbHdOblo1SzFGaVIyNURjbUpXV2t4WVdHWjBNWGNLWkU5UldEVlhkWGt5YVU5QlFtaG9aQzlLWVd0dGJWQnVWMnR3YjFac09GTkxjbEJKWkV3MFJXOTBhM1EzWXpORFoxZFVja054ZW14WFNWWjZlVnAxTUFwWFZIUlZSekp6WkhkdmMzSkNOekJHUkhsSVkweHRlR1ZKVkd0S1dETmFRakYzTkZKU1EydDJVbTlsU1VkWVUySnBUSE5uU2xWa1ZWZEZLMU5rVVZKVkNsRlBjekppZFRKa2EzSnNNU3R4Tm0xNldWTmpPSGhLWTJKRlJIQlFVU3RUYzB4M1dBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lOTVjZGRkYi00ZjcyLTQwYWUtYTMyMS0wN2U2Y2ViN2VkMjAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxOTB1bVU1b04zQkhBbU9xOXlFZjliMWVYaWQ1bEpXNU5zUlQ0Y1NFZkVLVG9Idml0VDgzM0RIbg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -391,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bab1e9c-0a44-4e01-bd05-b383d7315792
+      - bb64e4b1-bd66-4372-b903-cc38683216a0
     status: 200 OK
     code: 200
     duration: ""
@@ -410,12 +412,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:28.846521Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.742985Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1334"
@@ -424,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0613e47-d887-4450-a35b-87172ed65b22
+      - c8a80a18-727e-47ca-bf22-10f724fbf7f5
     status: 200 OK
     code: 200
     duration: ""
@@ -445,12 +447,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:33.821086077Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"updating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:58.607688771Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1332"
@@ -459,7 +461,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80e7be8c-8e6f-480b-8d34-a8ebc832559a
+      - 4a5aa230-aac9-4281-ac63-5ecace661f65
     status: 200 OK
     code: 200
     duration: ""
@@ -478,12 +480,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:33.821086Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"updating","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:58.607689Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1329"
@@ -492,7 +494,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 226b478e-81c1-4497-ae74-6e3f7f1976d2
+      - 82ce317b-7268-4c5d-a9f6-34baf54d8b7e
     status: 200 OK
     code: 200
     duration: ""
@@ -511,12 +513,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:35.227098Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.23.11","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":true,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:54:58.718886Z","upgrade_available":true,"version":"1.23.13"}'
     headers:
       Content-Length:
       - "1334"
@@ -525,7 +527,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:39 GMT
+      - Mon, 02 Jan 2023 13:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,23 +537,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31e77eb9-4b96-4972-9335-e9d2d31f7add
+      - 9fd9044d-f1c3-4ede-b360-894bf23793a3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"version":"1.24.5","upgrade_pools":true}'
+    body: '{"version":"1.24.7","upgrade_pools":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435/upgrade
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20/upgrade
     method: POST
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:39.800769420Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:55:03.924521675Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -560,7 +562,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:40 GMT
+      - Mon, 02 Jan 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c79ce020-d8ed-46e5-8af3-fee743875897
+      - d6e16ea4-ee00-4253-baf4-a4f710c4e4d0
     status: 200 OK
     code: 200
     duration: ""
@@ -579,12 +581,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:39.800769Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"updating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:55:03.924522Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -593,7 +595,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:40 GMT
+      - Mon, 02 Jan 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -603,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f1e14cf-3f71-43e2-bbe7-f0c1368fbd1b
+      - 21181d71-2ee1-4f04-81c8-3544a381b808
     status: 200 OK
     code: 200
     duration: ""
@@ -612,12 +614,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:42.902898Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.300432Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -626,7 +628,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:46 GMT
+      - Mon, 02 Jan 2023 13:55:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -636,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b582bd22-5527-4328-bfac-753e0c3d0247
+      - bc2e4f70-7fe5-41fb-a300-8fe44133d9c1
     status: 200 OK
     code: 200
     duration: ""
@@ -645,12 +647,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:42.902898Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.300432Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -659,7 +661,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:46 GMT
+      - Mon, 02 Jan 2023 13:55:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -669,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3bd3fcb-e8f4-4606-a107-630da7186f2f
+      - 5203452a-e74b-47db-864d-6cbb9d4c972e
     status: 200 OK
     code: 200
     duration: ""
@@ -678,12 +680,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRWTkhDazl4WjB4MlR6VlpaMUUyZFhkeFVqTlNVMUZuUkdRelNHOTJhMVZsWVdOT1VURklkbTF1VEcxaloxSjRhRzV1Vm5KM01HRmlkbFpPY0V4QlNYZFhia2tLVG1OUlpYTnhSMUV2VlRVemMwMUhlbW95Y1c0eVFXOWphMXA1V25GRmQyZEJUV1U1ZG5SMVJuSlRORU5ZYjJaa0szZGFNV2RUYjBGdWFTOVlkalF6U3dwa2RHSnhZVXBPTUc1eGEwMDFUelpEUldRelMwaDNXbUp3YTBwWmFWaElTWFZRWkhSRVRuZE5jSFJRVlRjMVoxQXZaek5TWVRRd05EQnVjVUZFUm1wQkNpODJOVzh4U25kcGFTOUtVMkZSYUhvM1ZIWldXak55Ykd0d1lrSTRhbVJzU21nd1ptY3JOazlzUTNaWlVYQjNVVGg2UjB0TE9IWm1RbXRDUVhKWmRuRUtUbFZtYVdWWlRXSlVURzVKYmtKTGVtRXZNVGhyYnk5WU1WaE1NRTFZVTFoNGMyUklSSHBUVERsd2VGVlBZa0l3U25KWVJVOU5WMWh6V0c1NmJIUkRZd3BCVXpFME4yUjZPRzVGUm5CMVlYQlJPVTR3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDU0ZSb1pXMTFkV1ZUVkZocUt6TnZWV2g1VVZsWVdEWldNM0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCZUZGcVQzUkpVbmt6VUc5blVsQlZabEU0Ym5aamRrOUJhRWxMZEVGemFsWjNUemM1T1UxNU4weFhkamhoVTBVMlVBcHBjbFF5ZFVGU1MwZHZiSGhhVW1ndmVtWjFjM1ZUY0dObVdYTlBNazlMV2t0V1RtOUNlbkZrTkhGQ1dUUTRXbkY0VVhWNVdreG1RMmRpVldaR2VtSnpDakZqYkVwaE1VWTNWbVJhTmtwS2NFUkNPVWxqUzBST1VXeFdUSGt4TldGQ01sZFFZM2N5WW1wQlFYQlFSMUpTTVRSRFQwZEhaWFJ3ZGpkMVZsTkVVRXNLY0N0V2RXY3lOelp6UTNWaE5uQm9kVmxvTldRM1l6aExRVFU1TW5oQ2REQTBZbHBQV0dWS2VuUk5TbnB3TDBJMFFYUXhSMFpRVjBjeVNscFJVbXhJV2dwWk5EQmhjakpCVFc4eGJUVXJiMk56UmxKd1NtUnhialJZU0ZWRlEySTFVR3BPYTI1NGEybFZNblYxUjFNNVFVWjFNVUUwT0VwcWIybzFOblY2Y1dWU0NrUmtXRGRTY0VZeWFtOHJhMk42V25OWmFHVk5Za0ZPYkc5aFJ5dEpVbWhzYkRoeVZBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82MjM4YTIzNi04YWU3LTQ4ZjktOTQxNC1lNDViNTI2MWU0MzUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKbVJ5eEZURFdreENHSVlXU0hRMlhISk01b3FpRFlVb3lYdXloYmM3OFp6U3VvblNxSVNRSUJ4RA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVY2VGxSUk1VNUdiMWhFVkUxNlRVUkZkMDFVUlhwT1ZGRXhUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNpdHVDa2xzUTBoT2JGcFZhVmswZVRoRFRUWkNZa1pLWjJaSlZGY3hhSEZEVG5WQ05IZFhibEI2ZVVwUloyWTFNRmRvYXpkbFJUUlBUM2RIUkM5V09YbEVWVUVLU0dKeWRYSXlXbVJvU3k4M01FdzVWMjAwTms5eldYaE5SMkpQUVhGb1NYTkxNelExT0c1bWMxTjNjakY0TVRoMkwxVXdWblJGVWxrMGVHeHZkV0l6THdvclVsVkhLMFkzWlcxc01teHFTR3RGVDJwUE1tVm5WMDFVTUhWcE5YZEJiVGRGWjFsQmVERkJUVGxFVkN0cWMyNXZaR1pDTWpkVlRVc3ZOakpXYjAxcUNrNDJLemhOWTB0UlZqbHNiRXhvY0dvNFZqRnZXbU5CYTFKTWFWZEdPVlUxWWsxbFQxUkhTMUpQV2poTGFsQTVVREJyV2s1TU1TOXpNMlpYU21ad1NXd0tSa2RXUTIxUU5FcElTMVl2TTBsM1NVUnVSVGxOUXpGUlMybDZVWFJ3TWpsSWNEQnBXWFp6WmxCcGVYTkViekkwZUVwMVYzTkxVSHBST0c5SGFuQmxNQXA2WlRod09FTlhOVlJLWVdsMFdHdG5RamRyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpHTVhSSlZURXZWblJtTDBoeWMxTkdXRFJyUmt4MFNDOTFkVVpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCYVVGNVNuZHNWU3RWVm5oSVdWaG5OM00wUlZKdVdVRjZjblV2UzJGa09VNUZUMEY0Tm1RdlVtOUthVk5KTjNwemFnbzVSa3haTUV4Mk5sUk5SMGhSVkM5Tk16QlJWbmhQT0VGd1lWZERVRVY0WjNab2NVRm5iRzUxZEVOc2FtSmxPVkpqTmt4TFdWTkhWakk1UkRCT2RuSXdDa2hUVFZNclRHcGhTQzlNUmtGQ09EQXhibm94V1VweFVUQnRhbFEyTUhveE5rdEdVM1pNYkZSMk5YbHdOblo1SzFGaVIyNURjbUpXV2t4WVdHWjBNWGNLWkU5UldEVlhkWGt5YVU5QlFtaG9aQzlLWVd0dGJWQnVWMnR3YjFac09GTkxjbEJKWkV3MFJXOTBhM1EzWXpORFoxZFVja054ZW14WFNWWjZlVnAxTUFwWFZIUlZSekp6WkhkdmMzSkNOekJHUkhsSVkweHRlR1ZKVkd0S1dETmFRakYzTkZKU1EydDJVbTlsU1VkWVUySnBUSE5uU2xWa1ZWZEZLMU5rVVZKVkNsRlBjekppZFRKa2EzSnNNU3R4Tm0xNldWTmpPSGhLWTJKRlJIQlFVU3RUYzB4M1dBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lOTVjZGRkYi00ZjcyLTQwYWUtYTMyMS0wN2U2Y2ViN2VkMjAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxOTB1bVU1b04zQkhBbU9xOXlFZjliMWVYaWQ1bEpXNU5zUlQ0Y1NFZkVLVG9Idml0VDgzM0RIbg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -692,7 +694,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:47 GMT
+      - Mon, 02 Jan 2023 13:55:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -702,7 +704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ae7747c-f42e-464c-9b78-6866cb30af05
+      - 03708326-c3c4-4a01-8e21-bacada6f398b
     status: 200 OK
     code: 200
     duration: ""
@@ -711,12 +713,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:42.902898Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.300432Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -725,7 +727,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:48 GMT
+      - Mon, 02 Jan 2023 13:55:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -735,7 +737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85622e71-f46e-4f9c-9470-ad9bcfa4237b
+      - 7791ee48-10c9-482e-8543-43ad560342e7
     status: 200 OK
     code: 200
     duration: ""
@@ -744,12 +746,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:42.902898Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.300432Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -758,7 +760,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:49 GMT
+      - Mon, 02 Jan 2023 13:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3af64920-941d-4317-9d1c-7b6231b2f0c5
+      - 1b00de1d-4302-4e9a-8ad1-24f6f042636d
     status: 200 OK
     code: 200
     duration: ""
@@ -777,12 +779,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRWTkhDazl4WjB4MlR6VlpaMUUyZFhkeFVqTlNVMUZuUkdRelNHOTJhMVZsWVdOT1VURklkbTF1VEcxaloxSjRhRzV1Vm5KM01HRmlkbFpPY0V4QlNYZFhia2tLVG1OUlpYTnhSMUV2VlRVemMwMUhlbW95Y1c0eVFXOWphMXA1V25GRmQyZEJUV1U1ZG5SMVJuSlRORU5ZYjJaa0szZGFNV2RUYjBGdWFTOVlkalF6U3dwa2RHSnhZVXBPTUc1eGEwMDFUelpEUldRelMwaDNXbUp3YTBwWmFWaElTWFZRWkhSRVRuZE5jSFJRVlRjMVoxQXZaek5TWVRRd05EQnVjVUZFUm1wQkNpODJOVzh4U25kcGFTOUtVMkZSYUhvM1ZIWldXak55Ykd0d1lrSTRhbVJzU21nd1ptY3JOazlzUTNaWlVYQjNVVGg2UjB0TE9IWm1RbXRDUVhKWmRuRUtUbFZtYVdWWlRXSlVURzVKYmtKTGVtRXZNVGhyYnk5WU1WaE1NRTFZVTFoNGMyUklSSHBUVERsd2VGVlBZa0l3U25KWVJVOU5WMWh6V0c1NmJIUkRZd3BCVXpFME4yUjZPRzVGUm5CMVlYQlJPVTR3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDU0ZSb1pXMTFkV1ZUVkZocUt6TnZWV2g1VVZsWVdEWldNM0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCZUZGcVQzUkpVbmt6VUc5blVsQlZabEU0Ym5aamRrOUJhRWxMZEVGemFsWjNUemM1T1UxNU4weFhkamhoVTBVMlVBcHBjbFF5ZFVGU1MwZHZiSGhhVW1ndmVtWjFjM1ZUY0dObVdYTlBNazlMV2t0V1RtOUNlbkZrTkhGQ1dUUTRXbkY0VVhWNVdreG1RMmRpVldaR2VtSnpDakZqYkVwaE1VWTNWbVJhTmtwS2NFUkNPVWxqUzBST1VXeFdUSGt4TldGQ01sZFFZM2N5WW1wQlFYQlFSMUpTTVRSRFQwZEhaWFJ3ZGpkMVZsTkVVRXNLY0N0V2RXY3lOelp6UTNWaE5uQm9kVmxvTldRM1l6aExRVFU1TW5oQ2REQTBZbHBQV0dWS2VuUk5TbnB3TDBJMFFYUXhSMFpRVjBjeVNscFJVbXhJV2dwWk5EQmhjakpCVFc4eGJUVXJiMk56UmxKd1NtUnhialJZU0ZWRlEySTFVR3BPYTI1NGEybFZNblYxUjFNNVFVWjFNVUUwT0VwcWIybzFOblY2Y1dWU0NrUmtXRGRTY0VZeWFtOHJhMk42V25OWmFHVk5Za0ZPYkc5aFJ5dEpVbWhzYkRoeVZBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82MjM4YTIzNi04YWU3LTQ4ZjktOTQxNC1lNDViNTI2MWU0MzUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKbVJ5eEZURFdreENHSVlXU0hRMlhISk01b3FpRFlVb3lYdXloYmM3OFp6U3VvblNxSVNRSUJ4RA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVY2VGxSUk1VNUdiMWhFVkUxNlRVUkZkMDFVUlhwT1ZGRXhUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNpdHVDa2xzUTBoT2JGcFZhVmswZVRoRFRUWkNZa1pLWjJaSlZGY3hhSEZEVG5WQ05IZFhibEI2ZVVwUloyWTFNRmRvYXpkbFJUUlBUM2RIUkM5V09YbEVWVUVLU0dKeWRYSXlXbVJvU3k4M01FdzVWMjAwTms5eldYaE5SMkpQUVhGb1NYTkxNelExT0c1bWMxTjNjakY0TVRoMkwxVXdWblJGVWxrMGVHeHZkV0l6THdvclVsVkhLMFkzWlcxc01teHFTR3RGVDJwUE1tVm5WMDFVTUhWcE5YZEJiVGRGWjFsQmVERkJUVGxFVkN0cWMyNXZaR1pDTWpkVlRVc3ZOakpXYjAxcUNrNDJLemhOWTB0UlZqbHNiRXhvY0dvNFZqRnZXbU5CYTFKTWFWZEdPVlUxWWsxbFQxUkhTMUpQV2poTGFsQTVVREJyV2s1TU1TOXpNMlpYU21ad1NXd0tSa2RXUTIxUU5FcElTMVl2TTBsM1NVUnVSVGxOUXpGUlMybDZVWFJ3TWpsSWNEQnBXWFp6WmxCcGVYTkViekkwZUVwMVYzTkxVSHBST0c5SGFuQmxNQXA2WlRod09FTlhOVlJLWVdsMFdHdG5RamRyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpHTVhSSlZURXZWblJtTDBoeWMxTkdXRFJyUmt4MFNDOTFkVVpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCYVVGNVNuZHNWU3RWVm5oSVdWaG5OM00wUlZKdVdVRjZjblV2UzJGa09VNUZUMEY0Tm1RdlVtOUthVk5KTjNwemFnbzVSa3haTUV4Mk5sUk5SMGhSVkM5Tk16QlJWbmhQT0VGd1lWZERVRVY0WjNab2NVRm5iRzUxZEVOc2FtSmxPVkpqTmt4TFdWTkhWakk1UkRCT2RuSXdDa2hUVFZNclRHcGhTQzlNUmtGQ09EQXhibm94V1VweFVUQnRhbFEyTUhveE5rdEdVM1pNYkZSMk5YbHdOblo1SzFGaVIyNURjbUpXV2t4WVdHWjBNWGNLWkU5UldEVlhkWGt5YVU5QlFtaG9aQzlLWVd0dGJWQnVWMnR3YjFac09GTkxjbEJKWkV3MFJXOTBhM1EzWXpORFoxZFVja054ZW14WFNWWjZlVnAxTUFwWFZIUlZSekp6WkhkdmMzSkNOekJHUkhsSVkweHRlR1ZKVkd0S1dETmFRakYzTkZKU1EydDJVbTlsU1VkWVUySnBUSE5uU2xWa1ZWZEZLMU5rVVZKVkNsRlBjekppZFRKa2EzSnNNU3R4Tm0xNldWTmpPSGhLWTJKRlJIQlFVU3RUYzB4M1dBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lOTVjZGRkYi00ZjcyLTQwYWUtYTMyMS0wN2U2Y2ViN2VkMjAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AY2x1c3RlcmNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogImNsdXN0ZXJjb25maWdtaW5pbWFsIgogICAgdXNlcjogY2x1c3RlcmNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBjbHVzdGVyY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGNsdXN0ZXJjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxOTB1bVU1b04zQkhBbU9xOXlFZjliMWVYaWQ1bEpXNU5zUlQ0Y1NFZkVLVG9Idml0VDgzM0RIbg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -791,7 +793,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:50 GMT
+      - Mon, 02 Jan 2023 13:55:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,7 +803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa3229e6-3bb0-407a-838e-b33987d43386
+      - 4bad8c85-c3b1-42bf-b8be-0bbbfac985fa
     status: 200 OK
     code: 200
     duration: ""
@@ -810,12 +812,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:51.134661595Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:55:12.531250340Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -824,7 +826,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:51 GMT
+      - Mon, 02 Jan 2023 13:55:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -834,7 +836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 028c2305-bdac-4cd4-9d99-a2043b5b30f2
+      - 4bea4229-7743-45e4-b3b1-d1b049f27d1c
     status: 200 OK
     code: 200
     duration: ""
@@ -843,12 +845,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:51.134662Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e95cdddb-4f72-40ae-a321-07e6ceb7ed20.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T13:54:52.226224Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e95cdddb-4f72-40ae-a321-07e6ceb7ed20.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","ingress":"none","name":"ClusterConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T13:55:12.531250Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -857,7 +859,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:52 GMT
+      - Mon, 02 Jan 2023 13:55:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 521ff99d-1ec0-4f4a-9547-5813d70de173
+      - 355e5313-0e67-4d77-a30a-366fd83eaf44
     status: 200 OK
     code: 200
     duration: ""
@@ -876,45 +878,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"region":"fr-par","id":"6238a236-8ae7-48f9-9414-e45b5261e435","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.382713Z","updated_at":"2022-10-25T08:39:51.134662Z","type":"kapsule","name":"ClusterConfigMinimal","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://6238a236-8ae7-48f9-9414-e45b5261e435.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.6238a236-8ae7-48f9-9414-e45b5261e435.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1329"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:39:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 06c44c45-d43c-4f8d-afa1-52730eb07f36
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6238a236-8ae7-48f9-9414-e45b5261e435","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -923,7 +892,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:03 GMT
+      - Mon, 02 Jan 2023 13:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20f22992-a5ff-488c-865a-bb7e2f814fea
+      - d0170c8d-b0d4-4fb8-aeca-da50e44da874
     status: 404 Not Found
     code: 404
     duration: ""
@@ -942,12 +911,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6238a236-8ae7-48f9-9414-e45b5261e435
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e95cdddb-4f72-40ae-a321-07e6ceb7ed20
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6238a236-8ae7-48f9-9414-e45b5261e435","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e95cdddb-4f72-40ae-a321-07e6ceb7ed20","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -956,7 +925,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:03 GMT
+      - Mon, 02 Jan 2023 13:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -966,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12d6e3fe-858b-489c-9f27-32048a9e8727
+      - 79388415-0a85-4e9f-8ece-40a68459c727
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-multicloud.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-multicloud.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:23 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21e9208e-1cce-4589-bdc7-95074b8dce5e
+      - 3c74906c-b197-4620-b9ff-d174ee4871f8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"multicloud","name":"test-multicloud","description":"","tags":null,"version":"1.24.5","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud","name":"test-multicloud","description":"","tags":null,"version":"1.24.7","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477392853Z","updated_at":"2022-10-25T08:39:25.488316023Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736489Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308892662Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1282"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60956259-5372-4ee2-89e0-8b456a18f4b2
+      - 949368a5-d2dc-4f01-846a-9636401d0bea
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af3b18b0-0aff-4ef1-bb3f-e77955826542
+      - 2efbe4fd-dfeb-4fa8-89bc-aad6f703e7bb
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c88eff8-a257-4936-bb22-1d2e6f2c5269
+      - 26a52898-5473-486a-a796-b840e9938d8f
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:36 GMT
+      - Mon, 02 Jan 2023 13:55:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bef8180-8f2f-4edd-a3a1-22443436dcc5
+      - 5855635d-c59b-4388-b84f-cf81a5eb372c
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:42 GMT
+      - Mon, 02 Jan 2023 13:55:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b885546-ab1e-4236-aac0-18ae3af7bc9b
+      - e07ee4ae-6c77-46ae-9ea5-f199096e7446
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -223,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:47 GMT
+      - Mon, 02 Jan 2023 13:55:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d933c929-b982-43c3-abbd-91f6c6ed5f08
+      - 02ada9b7-eecd-4bca-8944-b861f1101efa
     status: 200 OK
     code: 200
     duration: ""
@@ -242,12 +243,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -256,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:53 GMT
+      - Mon, 02 Jan 2023 13:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -266,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c643f98d-2ec1-4a26-b0f7-0d8b0e189ffb
+      - 1155d91c-0b00-4abd-bdf5-55fb99c1c835
     status: 200 OK
     code: 200
     duration: ""
@@ -275,12 +276,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -289,7 +290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:58 GMT
+      - Mon, 02 Jan 2023 13:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -299,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9443dc8c-4132-4413-8089-a98e0f5790e4
+      - 6d12a0f3-7cc6-4932-b1f7-557a08681d14
     status: 200 OK
     code: 200
     duration: ""
@@ -308,12 +309,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -322,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:03 GMT
+      - Mon, 02 Jan 2023 13:55:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -332,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf1a6ac8-ba05-4182-b9eb-d7eae8f51508
+      - 61252e7a-cae4-4287-9331-b58cd41adc8a
     status: 200 OK
     code: 200
     duration: ""
@@ -341,12 +342,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -355,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:09 GMT
+      - Mon, 02 Jan 2023 13:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -365,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 819604c5-103d-4ee3-87db-397277e0a7cb
+      - 32822fa3-81e9-42ce-814a-3a0b862024fb
     status: 200 OK
     code: 200
     duration: ""
@@ -374,12 +375,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -388,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:14 GMT
+      - Mon, 02 Jan 2023 13:55:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -398,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec316ed3-1b79-4e0d-8660-8f556a3d389a
+      - 634d0417-ffd4-440c-9b19-11e847a02f3a
     status: 200 OK
     code: 200
     duration: ""
@@ -407,12 +408,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:54:52.308893Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -421,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:20 GMT
+      - Mon, 02 Jan 2023 13:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d670e55f-6df2-43ed-86c7-3b33c03eb8b8
+      - 73c544cc-c237-4e31-9f5d-53b1170b8674
     status: 200 OK
     code: 200
     duration: ""
@@ -440,111 +441,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1276"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:40:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8433233b-5a63-4e55-9bb3-0812ae7deeb7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1276"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:40:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f70d788e-10d2-4e87-88b0-30e8cdd8feb6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:39:25.488316Z","type":"multicloud","name":"test-multicloud","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1276"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:40:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 72e564e1-ef0a-46e3-b56c-d987d29bccc7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:40:39.434678Z","type":"multicloud","name":"test-multicloud","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:55:48.651859Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1273"
@@ -553,7 +455,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:40 GMT
+      - Mon, 02 Jan 2023 13:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 218c5220-a8ff-4158-8220-687fbfcb9ca0
+      - f7ab4688-f631-4f30-ad1d-36dd59c0f613
     status: 200 OK
     code: 200
     duration: ""
@@ -572,12 +474,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:40:39.434678Z","type":"multicloud","name":"test-multicloud","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:55:48.651859Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1273"
@@ -586,7 +488,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:41 GMT
+      - Mon, 02 Jan 2023 13:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8843356-6866-4f26-82ae-269bfcdf0e91
+      - f864cdd2-53ce-4054-99a0-506bc0183616
     status: 200 OK
     code: 200
     duration: ""
@@ -605,12 +507,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTR4YjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV3BhQ2pWeVFVMHllblI0Yld4TlFTOUJSMnBZVm1WdFNVTkRWVXRpSzFkbGMxWnpaWG95V2pKUGQzTnNhRk5LYzIwd09VcFJNazlDTWtOSVpFVTFiRWRGVlVnS1owSnNjbTVOVDFveVNUVnhOalI2V0hvcmEweHpja3B6UzA0NVVYYzRUMHhXVm1WbllWbE1Ra3BuVGtKalJVVjNWMHQ1YURWSGJWUkJRbTQzV2xCS1R3bzViVFZoYkVSeGVEZHZaVWw0UXl0NmRIZzNlREZ2UW1aMU5FaEtSMngyY2pBNFVDdGFiV3ByVFRjek0xZFJXbFk0UVhsa1NFSnBXRXN5WmxCUmFua3lDamhDTm14U2NFRXliRGRGY0VOUU1IRTJjQzlOY1dORVdHcHNPWFp6WmxWaWJreFVXa0pMYzNwRlJHdEtNV05SU3pCelJtZHFTWGhNV0VsV1FuSktaRVFLZFhRNFltWTNObWRRU0V0d1lWRjZjSGh0V0d3M2IyTTVkMEZHUzFoV1RFSlJTRTh5TTBsbk1EbHpSVlp3YVhZM1ZESkRjM2R3ZVRGWlltTXJlaXRVY1FwcmNqVkJOVWhOYm5CRE1FODBOVkpyUkZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVUydGpRbWR3VFVrdk1uVkhUSFI2UkdReVZHcEdUR2d4Ym5kTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1JXdE9hbVJUT1ZaU1JUWlhVMFJDWVdNelpTdGthSHAxYURsVVpHOXlVa2xhV25odk4xcDNaVFpuWVVjM05tWkpWZ3BPY1hocFUwaHlWa1ZUVjFodFNraDJRMjUyY1VkeWIxQTNWR3gwZEVWSmVGVjBVbmwwUjJ4dVVIRnJlVlEwT1hWS00wNUtkR0pHYVdKbmIyVktOR1JzQ2s1allqQmFObEJYZDA5U1MwRlhieloyY0ZwMFMxWmxUSGxLT1dZMVVHMVVOVmh6TUdKaVN5OVRia00yVEZvMVIySnVTa2RLVTFseGQzRkdaVFJWY20wS04xbFFkRFpsYUhVNVlYUkNTRE42VjJORmRqSmtWa0pUU1VkaU0yc3ZaMkZNYVhCRFZXRlRVR0ZKVWxSck0xZFFSRUl6TjFSaFRHMXhZVVphWjFweWR3b3dWR3hJYjNSVk1qZEtUMjFOYjBGdVlXUTVjRTVDTm5oRmVIWkdablpwV1VjdlQwRk5aVFl3VEhKTFkyYzJkMjVTYjNaVVlteHhlRWs1ZEVaamMyOTBDbGhxVG5selF6UnNXR1JHVlhKSWRHWXhPVGxGUkd0WlpIQk1UekoyVGpScmFIRjFUZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTJhNzVkNzQtYjk3MS00MDdkLWE0ZTctN2ZlYmVmYzFkZjNmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBsaGc0SUdOakJ1RllzeU82WmpOaW9YUlB3M1N3c0duR3lid2NLY2x3U1ZkQzAxYVhqYmVZbW5ucg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlJNVTVHYjFoRVZFMTZUVVJGZDAxVVJYcE9WRkV4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTak55Q2xGNWFqSTRhRVZCUlcxTFFYVkNlVFJFUjA5NmJrSm1aVXh4TDJsMGNERXhkMGRhVXpGaVRFczJjazByYUZoNGVVdEtiRmd6WVV0c2FHSnFNa3d5VFVvS2JEUlhOemRhVmxCRFpsTkRSVVV6UkRjdmRIQTFOVGREV2xZMGJIQkZUWFJaTldScWJ6bEZZWGhsZWtGcGNqSTVRMEpVVms5RFJUWlJaelJNVjBSd09BcGFRMnRtYW14TVVWSlNhV2x3ZDJGeFRWWnBUSEp1YTNWNk9HaHBjMUF4Y0dJdldYTkdaV0YyVnpKb1kwTkxkWGcxVTA1WU0xTklRbFJwSzBaUEsyZGhDbE15VjJkclRqSnpTRWNyY25WM1VsQkVlVFpIUTJkdGNWRTNabTUzVTNCVU5uSkpkMng0YkVKRFJrbEtTa3BHYlhCb2IyNVFiRXd2Tkd0cFIzcFZUR1FLYUN0TFdrMUhMekIwWWs5UFl6bHBkVVY2VkhCclNuRjFhMWxYYkZJck0yazBVelJCTlRReVpYWnZheklyTVZSWVZHbEZlVFJhVXpoM00zSk1TRzVzZVFwdk5FcHBlRXNyWlhKYWJWbEZZM0ZKTmpWRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaR1JrVTBXRGRxWlhrMU9HSjBRV1k1Vlhnd09XdEVNRVZuUlZoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1EzWmlUR1l3VTNCMlMwWTBVMkZITldGTE1VZFJhRzk1TUdWU1ZWQjNNWFIxVUhCNk9XcG5XbXR0WTFCWWVIaEJOZ3BoVW1rMU1sSjRiakZ2TWtSQ1VtdEhWbGhyYlhKaVMydG1WM0J0ZFRSM1NtZDJVWEUxWlVKc01uRnVTRTFIU2psSVkxcFFSSFpDVVcwdmQwZDBiV1JoQ20xVVYwdHljRGw1UjFoVVFsRkxkM2xOTnpGRGRqUmlaVVEwZDNoRGQxQkRWamxHVkdwdmJVOWlVMVZEUkdrNFltbDFVa1p3T1doTlMzSXhZbnBDTDFvS05IWkthMnRyY3pkTGIweHdTR1ZEUm5ad01tcHNLMjVuSzJWb2NYSnRiRGg0VUV0RVQyZG9Vazh2YVhsdFVGQTJTMjlWYkV4VVkyUm5RV2xwYjJKRFJRcHlhMFJxYjBsTWRVcHdSMDQxZDNsT1ZsUmtOMVJ3TDBWUk4zWTVTbEExYzBwT2N6STVWV05TTUhGWFpGQkNURzB3WldSNFMybHNWRGc0Vm10bk1XZG1DblY0U2tSWEsyd3lSMWxRUVdFM0wxcGFXVTg0V21KSk1VSkllV2RJVkZKdWJEbHJWZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2M4M2I0ODgtN2MxZS00M2NjLThhZDktMmI4MjQ1NTA2MWMzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1aVB3VXFhYU41cUt0MzFUZTVDOGFVOWpFamM0VjlWd29jNkhXaWlIZURrSGF0MndXbDVIVmpTSw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -619,7 +521,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:41 GMT
+      - Mon, 02 Jan 2023 13:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a195eda-0b4c-4724-968c-512512412e01
+      - 56d9e741-ad2a-491e-ae5e-34a3dae1d4ca
     status: 200 OK
     code: 200
     duration: ""
@@ -638,12 +540,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:40:39.434678Z","type":"multicloud","name":"test-multicloud","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:55:48.651859Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1273"
@@ -652,7 +554,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:41 GMT
+      - Mon, 02 Jan 2023 13:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0346454a-9e4e-4397-8641-c93e8ec80d20
+      - 82e59866-9ed4-4f33-9ec4-06a7b8b190fd
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +575,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141259Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506272Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "579"
@@ -687,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:43 GMT
+      - Mon, 02 Jan 2023 13:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 868133cb-5918-4cc6-9b01-6670d67450ff
+      - b996f521-7173-49b3-89ec-b3a1f0d0d946
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -720,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:43 GMT
+      - Mon, 02 Jan 2023 13:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6909c1c3-31a0-4b16-91f7-234eb523ec80
+      - 122d8e39-b601-4fee-82b4-d351566c140f
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -753,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:49 GMT
+      - Mon, 02 Jan 2023 13:55:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcf20cfb-ede6-41a9-bcf6-531af1b22eb3
+      - 73a233a0-a581-40e2-b051-846f1fd3afc0
     status: 200 OK
     code: 200
     duration: ""
@@ -772,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -786,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:54 GMT
+      - Mon, 02 Jan 2023 13:56:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41de0c5e-c681-4fd6-ac21-b56afc1ffbce
+      - cca5cdec-36ec-486e-a211-476bed46eb5c
     status: 200 OK
     code: 200
     duration: ""
@@ -805,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -819,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:59 GMT
+      - Mon, 02 Jan 2023 13:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c57f7e22-a213-4162-9e0e-18c0fd43c416
+      - 1a3edc48-8ff7-4790-889e-66e44a04f354
     status: 200 OK
     code: 200
     duration: ""
@@ -838,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -852,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:05 GMT
+      - Mon, 02 Jan 2023 13:56:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcef9b62-f7ba-4d3b-813b-0c2bb60967d0
+      - 17271e27-b299-4426-9d40-b6e1d279b928
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -885,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:11 GMT
+      - Mon, 02 Jan 2023 13:56:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd2f7d44-e6cb-47b7-9453-fefa69f66cf2
+      - a71c0f15-8683-43c7-827f-a297c9e535b9
     status: 200 OK
     code: 200
     duration: ""
@@ -904,12 +806,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -918,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:16 GMT
+      - Mon, 02 Jan 2023 13:56:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89343425-193d-45cf-a85a-cc89fe69e2d1
+      - 6466824e-2170-4be4-b307-1b27f9a29b9f
     status: 200 OK
     code: 200
     duration: ""
@@ -937,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -951,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:22 GMT
+      - Mon, 02 Jan 2023 13:56:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a091d6a-75e9-4ea4-a691-f4906c25d302
+      - 6df15688-5e21-446d-9766-b09d0ca0efe1
     status: 200 OK
     code: 200
     duration: ""
@@ -970,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -984,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:27 GMT
+      - Mon, 02 Jan 2023 13:56:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8816f212-2c89-4f76-a04d-b9930dd5cdb1
+      - e50e5a8a-12b4-4db6-82e9-a40dfab1191a
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1017,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:33 GMT
+      - Mon, 02 Jan 2023 13:56:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da448c11-e0b3-4107-ab27-5065ccfb7c5c
+      - ce516b8c-8d9f-40dc-9241-46e7a6a56967
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1050,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:39 GMT
+      - Mon, 02 Jan 2023 13:56:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d2440de-c510-4dc0-bed7-a427a279813e
+      - 2f998c55-a58e-43c2-b34c-f7bdb610c187
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1083,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:44 GMT
+      - Mon, 02 Jan 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 584bbbfa-c3c0-49d1-9607-69cbe50d5e48
+      - cecc6960-7109-472c-893a-8a9f12757cb7
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1116,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:50 GMT
+      - Mon, 02 Jan 2023 13:56:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0839f011-1cf3-45a0-9e7e-071c4e4e687a
+      - 3663d2bb-b5d2-41ef-b5bd-a71358084a16
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1149,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:55 GMT
+      - Mon, 02 Jan 2023 13:56:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a24346a-56dd-4351-9fa7-eba134e30ed6
+      - f7132fef-0259-41fa-aefe-a8121aa04862
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1182,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:00 GMT
+      - Mon, 02 Jan 2023 13:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27d4702f-15cb-45b7-97cb-af9defae3d29
+      - 4735a711-6d15-4d95-a7eb-54b0ce63b4fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1215,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:05 GMT
+      - Mon, 02 Jan 2023 13:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9250d005-6449-49f2-96ad-0b9a13af6fac
+      - bcf9979b-b681-4eb3-ad12-56252e5f7135
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1248,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:11 GMT
+      - Mon, 02 Jan 2023 13:57:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 119da6dc-7ceb-4804-9ed1-da20ef7bdd1e
+      - 52f793c7-e67c-48af-9672-3f4c3b55e7f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1281,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:17 GMT
+      - Mon, 02 Jan 2023 13:57:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72f47e11-5be0-409f-8bc9-d0b59bcc191d
+      - 517b4565-cce7-411a-9e11-341c1ecc2be3
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1202,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1314,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:22 GMT
+      - Mon, 02 Jan 2023 13:57:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2024ee72-90de-4808-ae64-97d9246827d6
+      - fbe20b36-6dec-48a9-9536-e0e03a1a726e
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1235,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1347,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:27 GMT
+      - Mon, 02 Jan 2023 13:57:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 746ebca7-c6aa-4a60-bd5c-9ba78e7b2c29
+      - 5e0ff7a3-1703-4d8c-a0fa-a736c4600e97
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1268,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1380,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:33 GMT
+      - Mon, 02 Jan 2023 13:57:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bfda285-c0d0-4312-b83e-a97a9da56797
+      - 87911f27-3e00-46ec-b278-0cc688f58e7e
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1301,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1413,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:38 GMT
+      - Mon, 02 Jan 2023 13:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1649329d-bcdb-49a4-a84a-16894dcc18e5
+      - 3a364895-ac50-4b54-8f49-8337b0065516
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1446,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:43 GMT
+      - Mon, 02 Jan 2023 13:57:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f59c8b46-5dfd-43e6-a05f-25f3df5390b7
+      - df2f4189-b7a2-453a-b083-201e0c8e09ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,12 +1367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1479,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:48 GMT
+      - Mon, 02 Jan 2023 13:57:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d2e888d-29ff-4958-a1a2-3b76e3824d6b
+      - 27a1720b-346e-424e-832d-3188ec069c96
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,12 +1400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1512,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:54 GMT
+      - Mon, 02 Jan 2023 13:57:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2576b22e-fc7a-4b66-92e8-46ca1ea6936c
+      - e4eaf48b-ddce-4ce4-9143-274eae742b26
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,12 +1433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1545,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:59 GMT
+      - Mon, 02 Jan 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39d1b24e-02cb-485c-85d6-9029f8815cbd
+      - deb0c2ba-264f-40b7-8250-e65aa290acef
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,12 +1466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1578,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:04 GMT
+      - Mon, 02 Jan 2023 13:58:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdc04d6b-4812-4459-b555-19322e54e923
+      - 72113a7e-c19c-462b-9499-8d78f8aa853b
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,12 +1499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1611,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:10 GMT
+      - Mon, 02 Jan 2023 13:58:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b24cd2d-d33c-4d43-a899-4b399648b5f8
+      - 9db96d9b-f42f-4649-a777-e0f741a33f5b
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,12 +1532,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1644,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:15 GMT
+      - Mon, 02 Jan 2023 13:58:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ccfbb51-e121-44d2-8581-a756758a1801
+      - 7d55b708-f4de-4049-b968-44aaad8c6454
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,12 +1565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1677,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:20 GMT
+      - Mon, 02 Jan 2023 13:58:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61052131-6765-45cf-b866-eab61ee23328
+      - cf6e15e6-853e-4497-a2ab-6046680c96fb
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,12 +1598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1710,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:25 GMT
+      - Mon, 02 Jan 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5d3e00a-3cce-4100-b9ae-4069c33510a8
+      - d6edc7f5-f827-4adc-9d4c-9d09d45689d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1743,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:31 GMT
+      - Mon, 02 Jan 2023 13:58:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bf4bbc9-e6c4-45fb-b9b9-172622896339
+      - c8e917bc-8423-4615-b2b8-436b32c8e61a
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,12 +1664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1776,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:36 GMT
+      - Mon, 02 Jan 2023 13:58:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bbaf5c7-4dfe-4624-ad5c-daf91e9f4218
+      - 782cc2f9-b8c4-456e-8eda-b9b674757b3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,12 +1697,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1809,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:41 GMT
+      - Mon, 02 Jan 2023 13:58:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 451af175-d650-4d4b-861c-a726ecf0b5c8
+      - 2bf26a59-6874-4caa-a66d-060205d43ae0
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,12 +1730,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:40:42.324141Z","name":"test-multicloud","status":"scaling","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "576"
@@ -1842,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:47 GMT
+      - Mon, 02 Jan 2023 13:58:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25f2371f-d114-4058-a4d8-300b291fedbe
+      - c4729072-d599-41e5-95c4-7249e2db9923
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,12 +1763,342 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:43:51.518114Z","name":"test-multicloud","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:58:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a358689-241a-47c4-8533-5c9ce872f925
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:58:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aed0689b-6365-4f41-a529-ca447216c582
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:58:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5065368-cbd1-4997-891d-dc033a3c47cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bcd570cd-34b6-4f09-a7ea-884d464c3210
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4a79d1bc-2a97-4a52-a529-d1a964255d11
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a81f52e2-1cc6-4ffd-99e1-095716924ae9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a045a160-4d52-47ee-ab54-50fecca53cd7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bca3c906-2b52-48f6-b0b1-dba355f2f8e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bcebd810-54db-480b-bde7-5b494471e2b1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T13:55:49.288506Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "576"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 13:59:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14ae124a-617b-4ba1-8178-c90b7c62a491
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T13:59:34.802288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -1875,7 +2107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:52 GMT
+      - Mon, 02 Jan 2023 13:59:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce311c46-0c77-41ee-bddc-93191e230823
+      - 4e169e62-59fa-4e8c-9449-2b82e2f4a798
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,12 +2126,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:43:51.518114Z","name":"test-multicloud","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T13:59:34.802288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -1908,7 +2140,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:52 GMT
+      - Mon, 02 Jan 2023 13:59:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a47a6a9a-ed12-426c-b507-18a49d5dbdc9
+      - db296210-f09c-4a16-b3ed-435227da8569
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,12 +2159,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f/nodes?order_by=created_at_asc&page=1&pool_id=9005a363-ed5e-48f9-944f-9d4dabe47761&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3/nodes?order_by=created_at_asc&page=1&pool_id=1a82b297-3bd7-4b02-943c-95f92a05a0a6&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"f7feaf75-5b0d-4532-9690-00e588b5bb8a","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:43.810399Z","updated_at":"2022-10-25T08:43:51.504580Z","pool_id":"9005a363-ed5e-48f9-944f-9d4dabe47761","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-multicloud-test-multicloud-f7feaf755b","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/e7b02390-6f70-4b6e-a23c-f656b67e9c43","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T13:57:09.224226Z","error_message":null,"id":"6e285445-1bdf-46d8-ace0-c1a5c57440f1","name":"scw-test-multicloud-test-multicloud-6e2854451b","pool_id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","provider_id":"scaleway://instance/fr-par-1/0f2f8343-d87b-4b3d-a218-2ba716081db0","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T13:59:34.764367Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -1941,7 +2173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:53 GMT
+      - Mon, 02 Jan 2023 13:59:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1951,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83844ca5-05ed-4d6d-9273-2b2cf14b293c
+      - b38a8e1c-6d42-4f5a-95fb-6ded1974aac7
     status: 200 OK
     code: 200
     duration: ""
@@ -1960,12 +2192,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:40:39.434678Z","type":"multicloud","name":"test-multicloud","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:55:48.651859Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1273"
@@ -1974,7 +2206,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:53 GMT
+      - Mon, 02 Jan 2023 13:59:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1984,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84b6fd24-d532-4570-ad38-e8cfbe519771
+      - 17804f8a-d613-4025-8a4c-3ffbe1f34a1e
     status: 200 OK
     code: 200
     duration: ""
@@ -1993,12 +2225,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:40:39.434678Z","type":"multicloud","name":"test-multicloud","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:55:48.651859Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1273"
@@ -2007,7 +2239,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:54 GMT
+      - Mon, 02 Jan 2023 13:59:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2017,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91fd1d6f-6522-4769-bfd5-67e5d2977b36
+      - 2a14fc63-f474-4dcc-ba6d-b64c6d750bc3
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,12 +2258,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTR4YjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV3BhQ2pWeVFVMHllblI0Yld4TlFTOUJSMnBZVm1WdFNVTkRWVXRpSzFkbGMxWnpaWG95V2pKUGQzTnNhRk5LYzIwd09VcFJNazlDTWtOSVpFVTFiRWRGVlVnS1owSnNjbTVOVDFveVNUVnhOalI2V0hvcmEweHpja3B6UzA0NVVYYzRUMHhXVm1WbllWbE1Ra3BuVGtKalJVVjNWMHQ1YURWSGJWUkJRbTQzV2xCS1R3bzViVFZoYkVSeGVEZHZaVWw0UXl0NmRIZzNlREZ2UW1aMU5FaEtSMngyY2pBNFVDdGFiV3ByVFRjek0xZFJXbFk0UVhsa1NFSnBXRXN5WmxCUmFua3lDamhDTm14U2NFRXliRGRGY0VOUU1IRTJjQzlOY1dORVdHcHNPWFp6WmxWaWJreFVXa0pMYzNwRlJHdEtNV05SU3pCelJtZHFTWGhNV0VsV1FuSktaRVFLZFhRNFltWTNObWRRU0V0d1lWRjZjSGh0V0d3M2IyTTVkMEZHUzFoV1RFSlJTRTh5TTBsbk1EbHpSVlp3YVhZM1ZESkRjM2R3ZVRGWlltTXJlaXRVY1FwcmNqVkJOVWhOYm5CRE1FODBOVkpyUkZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVUydGpRbWR3VFVrdk1uVkhUSFI2UkdReVZHcEdUR2d4Ym5kTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1JXdE9hbVJUT1ZaU1JUWlhVMFJDWVdNelpTdGthSHAxYURsVVpHOXlVa2xhV25odk4xcDNaVFpuWVVjM05tWkpWZ3BPY1hocFUwaHlWa1ZUVjFodFNraDJRMjUyY1VkeWIxQTNWR3gwZEVWSmVGVjBVbmwwUjJ4dVVIRnJlVlEwT1hWS00wNUtkR0pHYVdKbmIyVktOR1JzQ2s1allqQmFObEJYZDA5U1MwRlhieloyY0ZwMFMxWmxUSGxLT1dZMVVHMVVOVmh6TUdKaVN5OVRia00yVEZvMVIySnVTa2RLVTFseGQzRkdaVFJWY20wS04xbFFkRFpsYUhVNVlYUkNTRE42VjJORmRqSmtWa0pUU1VkaU0yc3ZaMkZNYVhCRFZXRlRVR0ZKVWxSck0xZFFSRUl6TjFSaFRHMXhZVVphWjFweWR3b3dWR3hJYjNSVk1qZEtUMjFOYjBGdVlXUTVjRTVDTm5oRmVIWkdablpwV1VjdlQwRk5aVFl3VEhKTFkyYzJkMjVTYjNaVVlteHhlRWs1ZEVaamMyOTBDbGhxVG5selF6UnNXR1JHVlhKSWRHWXhPVGxGUkd0WlpIQk1UekoyVGpScmFIRjFUZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTJhNzVkNzQtYjk3MS00MDdkLWE0ZTctN2ZlYmVmYzFkZjNmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBsaGc0SUdOakJ1RllzeU82WmpOaW9YUlB3M1N3c0duR3lid2NLY2x3U1ZkQzAxYVhqYmVZbW5ucg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVWNlRsUlJNVTVHYjFoRVZFMTZUVVJGZDAxVVJYcE9WRkV4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTak55Q2xGNWFqSTRhRVZCUlcxTFFYVkNlVFJFUjA5NmJrSm1aVXh4TDJsMGNERXhkMGRhVXpGaVRFczJjazByYUZoNGVVdEtiRmd6WVV0c2FHSnFNa3d5VFVvS2JEUlhOemRhVmxCRFpsTkRSVVV6UkRjdmRIQTFOVGREV2xZMGJIQkZUWFJaTldScWJ6bEZZWGhsZWtGcGNqSTVRMEpVVms5RFJUWlJaelJNVjBSd09BcGFRMnRtYW14TVVWSlNhV2x3ZDJGeFRWWnBUSEp1YTNWNk9HaHBjMUF4Y0dJdldYTkdaV0YyVnpKb1kwTkxkWGcxVTA1WU0xTklRbFJwSzBaUEsyZGhDbE15VjJkclRqSnpTRWNyY25WM1VsQkVlVFpIUTJkdGNWRTNabTUzVTNCVU5uSkpkMng0YkVKRFJrbEtTa3BHYlhCb2IyNVFiRXd2Tkd0cFIzcFZUR1FLYUN0TFdrMUhMekIwWWs5UFl6bHBkVVY2VkhCclNuRjFhMWxYYkZJck0yazBVelJCTlRReVpYWnZheklyTVZSWVZHbEZlVFJhVXpoM00zSk1TRzVzZVFwdk5FcHBlRXNyWlhKYWJWbEZZM0ZKTmpWRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaR1JrVTBXRGRxWlhrMU9HSjBRV1k1Vlhnd09XdEVNRVZuUlZoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1EzWmlUR1l3VTNCMlMwWTBVMkZITldGTE1VZFJhRzk1TUdWU1ZWQjNNWFIxVUhCNk9XcG5XbXR0WTFCWWVIaEJOZ3BoVW1rMU1sSjRiakZ2TWtSQ1VtdEhWbGhyYlhKaVMydG1WM0J0ZFRSM1NtZDJVWEUxWlVKc01uRnVTRTFIU2psSVkxcFFSSFpDVVcwdmQwZDBiV1JoQ20xVVYwdHljRGw1UjFoVVFsRkxkM2xOTnpGRGRqUmlaVVEwZDNoRGQxQkRWamxHVkdwdmJVOWlVMVZEUkdrNFltbDFVa1p3T1doTlMzSXhZbnBDTDFvS05IWkthMnRyY3pkTGIweHdTR1ZEUm5ad01tcHNLMjVuSzJWb2NYSnRiRGg0VUV0RVQyZG9Vazh2YVhsdFVGQTJTMjlWYkV4VVkyUm5RV2xwYjJKRFJRcHlhMFJxYjBsTWRVcHdSMDQxZDNsT1ZsUmtOMVJ3TDBWUk4zWTVTbEExYzBwT2N6STVWV05TTUhGWFpGQkNURzB3WldSNFMybHNWRGc0Vm10bk1XZG1DblY0U2tSWEsyd3lSMWxRUVdFM0wxcGFXVTg0V21KSk1VSkllV2RJVkZKdWJEbHJWZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vM2M4M2I0ODgtN2MxZS00M2NjLThhZDktMmI4MjQ1NTA2MWMzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1aVB3VXFhYU41cUt0MzFUZTVDOGFVOWpFamM0VjlWd29jNkhXaWlIZURrSGF0MndXbDVIVmpTSw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2040,7 +2272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:54 GMT
+      - Mon, 02 Jan 2023 13:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2050,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3331b7f-1585-432c-b9e1-2622860cb3a7
+      - 8cce750b-b9ca-422f-84d6-962c38399b41
     status: 200 OK
     code: 200
     duration: ""
@@ -2059,12 +2291,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: GET
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:43:51.518114Z","name":"test-multicloud","status":"ready","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T13:59:34.802288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -2073,7 +2305,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:54 GMT
+      - Mon, 02 Jan 2023 13:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2083,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 230fffef-82dd-4f41-821e-6e4fd656e24c
+      - 9673a22a-7358-4922-bc71-2cd138f057ff
     status: 200 OK
     code: 200
     duration: ""
@@ -2092,12 +2324,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f/nodes?order_by=created_at_asc&page=1&pool_id=9005a363-ed5e-48f9-944f-9d4dabe47761&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3/nodes?order_by=created_at_asc&page=1&pool_id=1a82b297-3bd7-4b02-943c-95f92a05a0a6&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"f7feaf75-5b0d-4532-9690-00e588b5bb8a","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:43.810399Z","updated_at":"2022-10-25T08:43:51.504580Z","pool_id":"9005a363-ed5e-48f9-944f-9d4dabe47761","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-test-multicloud-test-multicloud-f7feaf755b","public_ip_v4":"51.158.112.105","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/e7b02390-6f70-4b6e-a23c-f656b67e9c43","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T13:57:09.224226Z","error_message":null,"id":"6e285445-1bdf-46d8-ace0-c1a5c57440f1","name":"scw-test-multicloud-test-multicloud-6e2854451b","pool_id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","provider_id":"scaleway://instance/fr-par-1/0f2f8343-d87b-4b3d-a218-2ba716081db0","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T13:59:34.764367Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -2106,7 +2338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:54 GMT
+      - Mon, 02 Jan 2023 13:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2116,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edaa533f-ce5c-467d-a809-4e27e68b82f0
+      - 562696c2-f98a-49af-b98c-a1562eb205ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2125,12 +2357,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9005a363-ed5e-48f9-944f-9d4dabe47761
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a82b297-3bd7-4b02-943c-95f92a05a0a6
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"9005a363-ed5e-48f9-944f-9d4dabe47761","cluster_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","created_at":"2022-10-25T08:40:42.313882Z","updated_at":"2022-10-25T08:43:55.793736939Z","name":"test-multicloud","status":"deleting","version":"1.24.5","node_type":"dev1_m","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":40000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","container_runtime":"containerd","created_at":"2023-01-02T13:55:49.280661Z","id":"1a82b297-3bd7-4b02-943c-95f92a05a0a6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-01-02T13:59:38.391184703Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "580"
@@ -2139,7 +2371,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:55 GMT
+      - Mon, 02 Jan 2023 13:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1db3d515-dc5a-4449-9f38-0ef06b55c13e
+      - 06769491-ec24-415a-9cfa-b30ef7be3e9c
     status: 200 OK
     code: 200
     duration: ""
@@ -2158,12 +2390,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134495647Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307332Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1279"
@@ -2172,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:56 GMT
+      - Mon, 02 Jan 2023 13:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8fc3f0a-d566-4a23-a554-43b46604cd66
+      - c2e4a40e-524d-4588-bd7d-c29845a3c837
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,12 +2423,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134496Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -2205,7 +2437,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:56 GMT
+      - Mon, 02 Jan 2023 13:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2215,7 +2447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbb470b9-c764-40c3-9d00-878e0992f17a
+      - db2be368-8739-42d0-996a-83a228e9bb66
     status: 200 OK
     code: 200
     duration: ""
@@ -2224,12 +2456,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134496Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -2238,7 +2470,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:01 GMT
+      - Mon, 02 Jan 2023 13:59:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2248,7 +2480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da85dcb4-d8af-49f5-80bc-06511565c46c
+      - f7e8dcd5-b807-4ec6-abd9-75e60944dcaa
     status: 200 OK
     code: 200
     duration: ""
@@ -2257,12 +2489,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134496Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -2271,7 +2503,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:07 GMT
+      - Mon, 02 Jan 2023 13:59:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2281,7 +2513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38afd637-d042-4f00-a61c-ed21b3fa19c2
+      - b1f1bbbc-74ae-4f94-b130-51add3501ff5
     status: 200 OK
     code: 200
     duration: ""
@@ -2290,12 +2522,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134496Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -2304,7 +2536,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:12 GMT
+      - Mon, 02 Jan 2023 13:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b1a26dc-3e8a-47cd-b5d9-88fdbc880110
+      - 8e7ba246-6691-47bd-bbbd-dff95308b8db
     status: 200 OK
     code: 200
     duration: ""
@@ -2323,12 +2555,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134496Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -2337,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:17 GMT
+      - Mon, 02 Jan 2023 13:59:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1442cfc5-871f-4572-8b1c-968aba9911f2
+      - 1a919490-4058-4f59-9d0f-40c26e79b117
     status: 200 OK
     code: 200
     duration: ""
@@ -2356,12 +2588,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134496Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -2370,7 +2602,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2380,7 +2612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee0dbae5-d5dc-4097-aa75-7e22ff2ca9d7
+      - 0e4f1cc8-a6f2-4d22-b5ba-cceab5726eff
     status: 200 OK
     code: 200
     duration: ""
@@ -2389,12 +2621,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134496Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -2403,7 +2635,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:28 GMT
+      - Mon, 02 Jan 2023 14:00:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2413,7 +2645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88e203bb-e04c-412c-b51f-a758f479760b
+      - b8838895-4950-4e73-aa0d-9e1eb0585ba5
     status: 200 OK
     code: 200
     duration: ""
@@ -2422,12 +2654,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"region":"fr-par","id":"92a75d74-b971-407d-a4e7-7febefc1df3f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477393Z","updated_at":"2022-10-25T08:43:56.134496Z","type":"multicloud","name":"test-multicloud","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":[],"cluster_url":"https://92a75d74-b971-407d-a4e7-7febefc1df3f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.92a75d74-b971-407d-a4e7-7febefc1df3f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1276"
@@ -2436,7 +2668,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:33 GMT
+      - Mon, 02 Jan 2023 14:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2446,7 +2678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ae6c27f-77a5-4087-a727-33f312442051
+      - 2d9d84df-2501-42f3-b617-4b2f468508eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2455,12 +2687,111 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1276"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:00:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee37c804-6563-4af0-a515-0d6065121ac3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1276"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:00:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54d8da7b-dde1-418f-81bb-ac2223be3949
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3c83b488-7c1e-43cc-8ad9-2b82455061c3.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T13:54:52.277736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3c83b488-7c1e-43cc-8ad9-2b82455061c3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-01-02T13:59:38.462307Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1276"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:00:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5d2a5e77-ffb7-495c-a273-62ab09f29922
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2469,7 +2800,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:39 GMT
+      - Mon, 02 Jan 2023 14:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2479,7 +2810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fd1ba0d-3b8b-449c-9542-58e863d3ee39
+      - 4cc8852f-23db-4778-9a80-6706f2b8f5a6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2488,12 +2819,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/92a75d74-b971-407d-a4e7-7febefc1df3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3c83b488-7c1e-43cc-8ad9-2b82455061c3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"92a75d74-b971-407d-a4e7-7febefc1df3f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"3c83b488-7c1e-43cc-8ad9-2b82455061c3","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2502,7 +2833,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:40 GMT
+      - Mon, 02 Jan 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2512,7 +2843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6e302e3-d388-40d2-b5e5-da39aae9764e
+      - 651f31b0-5557-4b4c-b422-974ed88d5c5c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-oidc.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-oidc.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:22 GMT
+      - Mon, 02 Jan 2023 13:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9504c1e1-3625-4539-be08-3cc8d56c2b38
+      - 8d71f5dc-b382-46bc-870c-dc566892487b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"oidc","description":"","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"version":"1.24.5","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":null,"groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"oidc","description":"","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"version":"1.24.7","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":null,"groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":null},"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513453892Z","updated_at":"2022-10-25T08:39:25.549335305Z","type":"kapsule","name":"oidc","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":"","groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222224512Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:52.232384725Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1383"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5cf21d1-c9e9-48d7-9698-6003c801e75a
+      - 5f7aaf59-f617-4564-acd4-2a263b1ab6e5
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:25.549335Z","type":"kapsule","name":"oidc","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":"","groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:52.232385Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1377"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 840963dc-1414-4958-925f-ac4bee35ed30
+      - 4070da63-dd89-43a3-92b2-f1ddc2e908ea
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:28.939218Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":"","groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.424851Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1382"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e79930ea-f680-4a72-b0ba-c22256ba9afb
+      - 5a83bb83-f583-4705-a585-c839af7b4131
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:28.939218Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":"","groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.424851Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1382"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 116928d1-eff6-4894-9874-17530e3c4d66
+      - e80592d7-9199-46a7-b3b5-3a9afa2481f2
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU5R2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVQwWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdSakNuaDNSSFV6TDFVNFQxcFNUWGRsY0ZFNWJYaERRa2d6YVRoaVozZDBlbTl4VUdzM1MzbFNRM1E1U0hGaU1WQjRTbWt6TWpFMVJtTXhhemRJUjBGV1FYSUtNMnhzV1M5d1EzVmhTRnBSZFhrMlptTm9lVWQ1WkZaRFRrOXBLMDVhYW1GSmRrTkNjV1kwT1VacmVXaE5VakkyUmt0SWJqTnhTRnBSWm01RVFVMXhVQXA1V2tGcE5UWm5VVWxzTlVkNGFsUlJVVTFKYjJ4bVdWQXpTWFp1U1VscFUwUTFiRXhNVUhka1ZEaEZUMWx3TURKM1NrbEhTMGxET0ZkemVsaDNaamh5Q21SeFNHOVNVbTEwVldOS1UxSnpWbkJzYkU1TU1GbGtSVVJSZVhoUlptbzJPRWRwU2paT1pUWlhNVlJPVG1SMFNUVkRVMVZsZVhnM2MwVnlSR0oyTUdnS0swWnFjV1ZOVjFGemRWQjRLMDlJY0ZGTldVZzBOVEJqUTNwWGVXZHhVMDltTm0xM2FYbHBLMFpGU0RZdk5tZFpjelUzVWtSWlpIUk9VMEZsWW5OdmF3cFJWMEZUUnpsWGJEUkVPVXRUUWxKRk5ucFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxVMmxZTUhOclNHRXZSelJJVlU5NVdUVnRTMHRWTTBwWGR6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJiVmh1VjNWTWNESTBkREJxYzJKdU5sVTBXakU0WWtsTlduWnJkRlZGYW5SMFVIbERWRVZKUmxaNWMwMVplazl5ZGdwMFlrZEJNMVJtTUZWT05FTlRjbWx3WVdKbFEzVnlSRFJ5YlhFemNEUmFVVVJ5TDFVNWFtUjFlQzlJZEVoMVFtSTJNM00zUVV0TU9XMVJaM00xWkdzMUNtSkNOMU5VV1hoTlJXaDVRa1JaU0dkSVF6TXpla0ZpTUVOcWJHOUtOV1JGVkdFeGF6ZzVlQzl2V0VWcVEyMUtOekJzWkRab1lVWXpVMmhIU0cweWRVOEtaRFl6Um5GbVJEZG5aMk5VYUhFMlUzRjNiVUZzVURGTVMwSm1URE50ZVhkemNsVnJWeTlRZVRoT1pFZFdkWFJwSzBZcmVtSm5jWFZzUWxGalUzVk5Nd3B3TURWVk4wOW5WRlV4TkU5eWRHdzFhRTk0Y20xcU9HbGtWVE5RYXpCcFFqVmlVbnA1UkRCRmJUbGphVzV3WTFkaFpqaFllRloxY2psVlptWlRTM0pVQ25KYWNuUmtaRFoyZDBGeVpHUjZSRVJWVXpaU1JHVlRSM2wwTkZaWVNWZHhLME5IWlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzMzYTU1YTU4LTdkYmItNDQyOC1iYTQwLWY5MTAxODA1NGExZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBjblFmUDk5bHpXMHZrWTl0emlpVWhGd0FLbDR2YmdYYWVKVEl2M0F3SEpZejhIWmZGcU9sa0hvbQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEd4b0NrOVpObEY2ZGpKeVNIWkhZbWswWnpZeU0yaE1jbUp5T0U1SFZISkliSEZEWlRKUmIweFVRVGxxZWpkTmVscENibGc1YVRWd056aEdURXBLU214aFFqSUtaalZCY2xScWMwcGlZbmR4TTJJNWFITnRSMGhCVkc1bU56VlpNV1ZqY0dSc1lYRjFiM0ZuYVhKd09HUnNhSGRYTlhoMGFtWnhkMkpzYmtnck4xRTVUd3BoYWs1M2N6UjRTbFJJZEhCQ2NGaGxMM0ZDWjJ4emRUUTFiRGcwWm5CNU1WVlpkV3RLZERoME4wUnNkbGxPYW5Kbk5VMXllWEZwYzNsMGJsZzNUbWRIQ2paamJsUkZlWGR3VFZKbE5VbHJVREY0VVU0MFJYZHdTMWQxWVhaM1FVdElUamRTWTFodFoyVnVVR2xwZFVJM2JFMW9hbXhFZG5Oa05rYzRRM2htTUZJS2FVMU5hV0k1YUZBNFIzSnFlblJvYzFWS1FsVjZibkUyTDNGeFRYQktRbFpJU2pKd05UZDVVa0p3ZVZGdFpFZ3JRVFl2YTNkcVkzQkJkaXRzTnpkRVl3cEdhMjFIUVVOMFVuZGhaWGN2WW5WVlJsRlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRNVGxvT0hsTVVFYzVNazlhUlZvclRWVm5lV3RrUVN0bFNVaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSVGczVERWeEswUkxkbEZoWjJaUlRGSndkM0ZMUVZrclkwNVNhVmwyUlZsWEt6VnNVa1J2V0VOUUszbG5SM2x3ZGdwM1NraHNTM0pwZG5CeVFqSkZhVU14WVhWUU1ESjNZWFF4YTBkQmRsTTRNM0p6YWxaQlJFTndUbWRDTUdkQldVTlFURzU1U21wUE5sSXpWMUZ2V21kaUNrNDBiamw1UlZJMVRtVnlhWGRvTTNBd01WUnRPRVZ0YUVzek9VRklaalJxUjBSbFpVVlFZMWhpTDA4M09FMDJZMmhVT1V4TmVVNXhjRmRtZVd4cldYSUtPRGRrT1ZseFVGVkJlbTlIWkZORlZsbEViazlOTTFGR2F5dDRWSGROTVRsMldHdDRkQzgwYVU1UFUxTkxZM0ZEZVRSRVkwbFhhQzh2ZUVSUk9YZGlad295YkZkaVJYWlhZVU55TW5oeVpIQTFlalp6U0dnMGFHZDVhek5sYkNzMlNERmhjMlJWTlRCNFIyaGpWak5ZS3pVdlNWcGxTM1JCYVdOYU5rSTVNMnA2Q2tWRmVtWlllVTAzUmxWRU1YZDBjRUZyUzJaR1VUTlFURlp3T0hJeVNVaHJVa0UyTkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzkxZjE0M2RlLWJiNWUtNDZlNy1iMGZiLWMzODJiZTdhNmY4Mi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFWXdRSFdTcEI5VHBzVjZEbnlDZUI1emlNV1FEdW5vZGJCbERDSHBzMlhiS1EwZlliRTFVQTE3ag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2524"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a964750-a089-4753-a664-92ad30bb3f61
+      - 71d2d4e7-6e06-4a1a-9ad9-b8593e2a2552
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:28.939218Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":"","groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.424851Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1382"
@@ -223,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d56dbd0c-85cc-4858-a4ab-d117a98ee543
+      - 40afd638-1a0c-403c-ac9d-a74d8f2103eb
     status: 200 OK
     code: 200
     duration: ""
@@ -242,12 +243,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:28.939218Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":"","groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.424851Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1382"
@@ -256,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -266,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6662322-9121-405d-a0aa-c51ea9aa565d
+      - 520012ec-b889-484c-b69c-7f10a48aca66
     status: 200 OK
     code: 200
     duration: ""
@@ -275,12 +276,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU5R2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVQwWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdSakNuaDNSSFV6TDFVNFQxcFNUWGRsY0ZFNWJYaERRa2d6YVRoaVozZDBlbTl4VUdzM1MzbFNRM1E1U0hGaU1WQjRTbWt6TWpFMVJtTXhhemRJUjBGV1FYSUtNMnhzV1M5d1EzVmhTRnBSZFhrMlptTm9lVWQ1WkZaRFRrOXBLMDVhYW1GSmRrTkNjV1kwT1VacmVXaE5VakkyUmt0SWJqTnhTRnBSWm01RVFVMXhVQXA1V2tGcE5UWm5VVWxzTlVkNGFsUlJVVTFKYjJ4bVdWQXpTWFp1U1VscFUwUTFiRXhNVUhka1ZEaEZUMWx3TURKM1NrbEhTMGxET0ZkemVsaDNaamh5Q21SeFNHOVNVbTEwVldOS1UxSnpWbkJzYkU1TU1GbGtSVVJSZVhoUlptbzJPRWRwU2paT1pUWlhNVlJPVG1SMFNUVkRVMVZsZVhnM2MwVnlSR0oyTUdnS0swWnFjV1ZOVjFGemRWQjRLMDlJY0ZGTldVZzBOVEJqUTNwWGVXZHhVMDltTm0xM2FYbHBLMFpGU0RZdk5tZFpjelUzVWtSWlpIUk9VMEZsWW5OdmF3cFJWMEZUUnpsWGJEUkVPVXRUUWxKRk5ucFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxVMmxZTUhOclNHRXZSelJJVlU5NVdUVnRTMHRWTTBwWGR6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJiVmh1VjNWTWNESTBkREJxYzJKdU5sVTBXakU0WWtsTlduWnJkRlZGYW5SMFVIbERWRVZKUmxaNWMwMVplazl5ZGdwMFlrZEJNMVJtTUZWT05FTlRjbWx3WVdKbFEzVnlSRFJ5YlhFemNEUmFVVVJ5TDFVNWFtUjFlQzlJZEVoMVFtSTJNM00zUVV0TU9XMVJaM00xWkdzMUNtSkNOMU5VV1hoTlJXaDVRa1JaU0dkSVF6TXpla0ZpTUVOcWJHOUtOV1JGVkdFeGF6ZzVlQzl2V0VWcVEyMUtOekJzWkRab1lVWXpVMmhIU0cweWRVOEtaRFl6Um5GbVJEZG5aMk5VYUhFMlUzRjNiVUZzVURGTVMwSm1URE50ZVhkemNsVnJWeTlRZVRoT1pFZFdkWFJwSzBZcmVtSm5jWFZzUWxGalUzVk5Nd3B3TURWVk4wOW5WRlV4TkU5eWRHdzFhRTk0Y20xcU9HbGtWVE5RYXpCcFFqVmlVbnA1UkRCRmJUbGphVzV3WTFkaFpqaFllRloxY2psVlptWlRTM0pVQ25KYWNuUmtaRFoyZDBGeVpHUjZSRVJWVXpaU1JHVlRSM2wwTkZaWVNWZHhLME5IWlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzMzYTU1YTU4LTdkYmItNDQyOC1iYTQwLWY5MTAxODA1NGExZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBjblFmUDk5bHpXMHZrWTl0emlpVWhGd0FLbDR2YmdYYWVKVEl2M0F3SEpZejhIWmZGcU9sa0hvbQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEd4b0NrOVpObEY2ZGpKeVNIWkhZbWswWnpZeU0yaE1jbUp5T0U1SFZISkliSEZEWlRKUmIweFVRVGxxZWpkTmVscENibGc1YVRWd056aEdURXBLU214aFFqSUtaalZCY2xScWMwcGlZbmR4TTJJNWFITnRSMGhCVkc1bU56VlpNV1ZqY0dSc1lYRjFiM0ZuYVhKd09HUnNhSGRYTlhoMGFtWnhkMkpzYmtnck4xRTVUd3BoYWs1M2N6UjRTbFJJZEhCQ2NGaGxMM0ZDWjJ4emRUUTFiRGcwWm5CNU1WVlpkV3RLZERoME4wUnNkbGxPYW5Kbk5VMXllWEZwYzNsMGJsZzNUbWRIQ2paamJsUkZlWGR3VFZKbE5VbHJVREY0VVU0MFJYZHdTMWQxWVhaM1FVdElUamRTWTFodFoyVnVVR2xwZFVJM2JFMW9hbXhFZG5Oa05rYzRRM2htTUZJS2FVMU5hV0k1YUZBNFIzSnFlblJvYzFWS1FsVjZibkUyTDNGeFRYQktRbFpJU2pKd05UZDVVa0p3ZVZGdFpFZ3JRVFl2YTNkcVkzQkJkaXRzTnpkRVl3cEdhMjFIUVVOMFVuZGhaWGN2WW5WVlJsRlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRNVGxvT0hsTVVFYzVNazlhUlZvclRWVm5lV3RrUVN0bFNVaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSVGczVERWeEswUkxkbEZoWjJaUlRGSndkM0ZMUVZrclkwNVNhVmwyUlZsWEt6VnNVa1J2V0VOUUszbG5SM2x3ZGdwM1NraHNTM0pwZG5CeVFqSkZhVU14WVhWUU1ESjNZWFF4YTBkQmRsTTRNM0p6YWxaQlJFTndUbWRDTUdkQldVTlFURzU1U21wUE5sSXpWMUZ2V21kaUNrNDBiamw1UlZJMVRtVnlhWGRvTTNBd01WUnRPRVZ0YUVzek9VRklaalJxUjBSbFpVVlFZMWhpTDA4M09FMDJZMmhVT1V4TmVVNXhjRmRtZVd4cldYSUtPRGRrT1ZseFVGVkJlbTlIWkZORlZsbEViazlOTTFGR2F5dDRWSGROTVRsMldHdDRkQzgwYVU1UFUxTkxZM0ZEZVRSRVkwbFhhQzh2ZUVSUk9YZGlad295YkZkaVJYWlhZVU55TW5oeVpIQTFlalp6U0dnMGFHZDVhek5sYkNzMlNERmhjMlJWTlRCNFIyaGpWak5ZS3pVdlNWcGxTM1JCYVdOYU5rSTVNMnA2Q2tWRmVtWlllVTAzUmxWRU1YZDBjRUZyUzJaR1VUTlFURlp3T0hJeVNVaHJVa0UyTkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzkxZjE0M2RlLWJiNWUtNDZlNy1iMGZiLWMzODJiZTdhNmY4Mi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFWXdRSFdTcEI5VHBzVjZEbnlDZUI1emlNV1FEdW5vZGJCbERDSHBzMlhiS1EwZlliRTFVQTE3ag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2524"
@@ -289,7 +290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -299,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5079192d-b30d-4148-ac46-f06982601e1f
+      - ddbb80e0-c17d-4446-a878-7e5934da899e
     status: 200 OK
     code: 200
     duration: ""
@@ -308,12 +309,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:28.939218Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":"","groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:54.424851Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1382"
@@ -322,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -332,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39ae8a6f-8c52-47d7-bb8b-bccd81cae92f
+      - c9ef5975-11d6-43e1-a152-65979676d85d
     status: 200 OK
     code: 200
     duration: ""
@@ -341,12 +342,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU5R2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVQwWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdSakNuaDNSSFV6TDFVNFQxcFNUWGRsY0ZFNWJYaERRa2d6YVRoaVozZDBlbTl4VUdzM1MzbFNRM1E1U0hGaU1WQjRTbWt6TWpFMVJtTXhhemRJUjBGV1FYSUtNMnhzV1M5d1EzVmhTRnBSZFhrMlptTm9lVWQ1WkZaRFRrOXBLMDVhYW1GSmRrTkNjV1kwT1VacmVXaE5VakkyUmt0SWJqTnhTRnBSWm01RVFVMXhVQXA1V2tGcE5UWm5VVWxzTlVkNGFsUlJVVTFKYjJ4bVdWQXpTWFp1U1VscFUwUTFiRXhNVUhka1ZEaEZUMWx3TURKM1NrbEhTMGxET0ZkemVsaDNaamh5Q21SeFNHOVNVbTEwVldOS1UxSnpWbkJzYkU1TU1GbGtSVVJSZVhoUlptbzJPRWRwU2paT1pUWlhNVlJPVG1SMFNUVkRVMVZsZVhnM2MwVnlSR0oyTUdnS0swWnFjV1ZOVjFGemRWQjRLMDlJY0ZGTldVZzBOVEJqUTNwWGVXZHhVMDltTm0xM2FYbHBLMFpGU0RZdk5tZFpjelUzVWtSWlpIUk9VMEZsWW5OdmF3cFJWMEZUUnpsWGJEUkVPVXRUUWxKRk5ucFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxVMmxZTUhOclNHRXZSelJJVlU5NVdUVnRTMHRWTTBwWGR6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJiVmh1VjNWTWNESTBkREJxYzJKdU5sVTBXakU0WWtsTlduWnJkRlZGYW5SMFVIbERWRVZKUmxaNWMwMVplazl5ZGdwMFlrZEJNMVJtTUZWT05FTlRjbWx3WVdKbFEzVnlSRFJ5YlhFemNEUmFVVVJ5TDFVNWFtUjFlQzlJZEVoMVFtSTJNM00zUVV0TU9XMVJaM00xWkdzMUNtSkNOMU5VV1hoTlJXaDVRa1JaU0dkSVF6TXpla0ZpTUVOcWJHOUtOV1JGVkdFeGF6ZzVlQzl2V0VWcVEyMUtOekJzWkRab1lVWXpVMmhIU0cweWRVOEtaRFl6Um5GbVJEZG5aMk5VYUhFMlUzRjNiVUZzVURGTVMwSm1URE50ZVhkemNsVnJWeTlRZVRoT1pFZFdkWFJwSzBZcmVtSm5jWFZzUWxGalUzVk5Nd3B3TURWVk4wOW5WRlV4TkU5eWRHdzFhRTk0Y20xcU9HbGtWVE5RYXpCcFFqVmlVbnA1UkRCRmJUbGphVzV3WTFkaFpqaFllRloxY2psVlptWlRTM0pVQ25KYWNuUmtaRFoyZDBGeVpHUjZSRVJWVXpaU1JHVlRSM2wwTkZaWVNWZHhLME5IWlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzMzYTU1YTU4LTdkYmItNDQyOC1iYTQwLWY5MTAxODA1NGExZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBjblFmUDk5bHpXMHZrWTl0emlpVWhGd0FLbDR2YmdYYWVKVEl2M0F3SEpZejhIWmZGcU9sa0hvbQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEd4b0NrOVpObEY2ZGpKeVNIWkhZbWswWnpZeU0yaE1jbUp5T0U1SFZISkliSEZEWlRKUmIweFVRVGxxZWpkTmVscENibGc1YVRWd056aEdURXBLU214aFFqSUtaalZCY2xScWMwcGlZbmR4TTJJNWFITnRSMGhCVkc1bU56VlpNV1ZqY0dSc1lYRjFiM0ZuYVhKd09HUnNhSGRYTlhoMGFtWnhkMkpzYmtnck4xRTVUd3BoYWs1M2N6UjRTbFJJZEhCQ2NGaGxMM0ZDWjJ4emRUUTFiRGcwWm5CNU1WVlpkV3RLZERoME4wUnNkbGxPYW5Kbk5VMXllWEZwYzNsMGJsZzNUbWRIQ2paamJsUkZlWGR3VFZKbE5VbHJVREY0VVU0MFJYZHdTMWQxWVhaM1FVdElUamRTWTFodFoyVnVVR2xwZFVJM2JFMW9hbXhFZG5Oa05rYzRRM2htTUZJS2FVMU5hV0k1YUZBNFIzSnFlblJvYzFWS1FsVjZibkUyTDNGeFRYQktRbFpJU2pKd05UZDVVa0p3ZVZGdFpFZ3JRVFl2YTNkcVkzQkJkaXRzTnpkRVl3cEdhMjFIUVVOMFVuZGhaWGN2WW5WVlJsRlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRNVGxvT0hsTVVFYzVNazlhUlZvclRWVm5lV3RrUVN0bFNVaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSVGczVERWeEswUkxkbEZoWjJaUlRGSndkM0ZMUVZrclkwNVNhVmwyUlZsWEt6VnNVa1J2V0VOUUszbG5SM2x3ZGdwM1NraHNTM0pwZG5CeVFqSkZhVU14WVhWUU1ESjNZWFF4YTBkQmRsTTRNM0p6YWxaQlJFTndUbWRDTUdkQldVTlFURzU1U21wUE5sSXpWMUZ2V21kaUNrNDBiamw1UlZJMVRtVnlhWGRvTTNBd01WUnRPRVZ0YUVzek9VRklaalJxUjBSbFpVVlFZMWhpTDA4M09FMDJZMmhVT1V4TmVVNXhjRmRtZVd4cldYSUtPRGRrT1ZseFVGVkJlbTlIWkZORlZsbEViazlOTTFGR2F5dDRWSGROTVRsMldHdDRkQzgwYVU1UFUxTkxZM0ZEZVRSRVkwbFhhQzh2ZUVSUk9YZGlad295YkZkaVJYWlhZVU55TW5oeVpIQTFlalp6U0dnMGFHZDVhek5sYkNzMlNERmhjMlJWTlRCNFIyaGpWak5ZS3pVdlNWcGxTM1JCYVdOYU5rSTVNMnA2Q2tWRmVtWlllVTAzUmxWRU1YZDBjRUZyUzJaR1VUTlFURlp3T0hJeVNVaHJVa0UyTkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzkxZjE0M2RlLWJiNWUtNDZlNy1iMGZiLWMzODJiZTdhNmY4Mi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFWXdRSFdTcEI5VHBzVjZEbnlDZUI1emlNV1FEdW5vZGJCbERDSHBzMlhiS1EwZlliRTFVQTE3ag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2524"
@@ -355,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -365,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7d16b55-08c9-472f-ac17-6679a4aced6f
+      - dd5a0516-a962-4d10-9d79-42fb58b6be4d
     status: 200 OK
     code: 200
     duration: ""
@@ -376,12 +377,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:33.702239956Z","type":"kapsule","name":"oidc","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:58.550522295Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1369"
@@ -390,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04f1ce20-83e7-4062-b7d3-4ceb27f94018
+      - 7c97cdff-3666-4f01-a708-6bfedd15de02
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:33.702240Z","type":"kapsule","name":"oidc","description":"","status":"updating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:58.550522Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1366"
@@ -423,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 13:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97730956-dcf4-4537-a79f-780cf81bbc8b
+      - d4c837f7-42b6-48ef-acc4-f773ec69a6d3
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:34.860970Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:59.694117Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1371"
@@ -456,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:39 GMT
+      - Mon, 02 Jan 2023 13:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9da1c49e-0210-4aa7-84af-8b1cd39d558a
+      - e5d76a38-7072-4761-82ca-6f3f9f9a82f1
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:34.860970Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:59.694117Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1371"
@@ -489,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:39 GMT
+      - Mon, 02 Jan 2023 13:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50087596-d3b2-4f95-8ed5-f568f2127145
+      - e510d329-ef70-4e0f-8fc7-101da0005745
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU5R2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVQwWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdSakNuaDNSSFV6TDFVNFQxcFNUWGRsY0ZFNWJYaERRa2d6YVRoaVozZDBlbTl4VUdzM1MzbFNRM1E1U0hGaU1WQjRTbWt6TWpFMVJtTXhhemRJUjBGV1FYSUtNMnhzV1M5d1EzVmhTRnBSZFhrMlptTm9lVWQ1WkZaRFRrOXBLMDVhYW1GSmRrTkNjV1kwT1VacmVXaE5VakkyUmt0SWJqTnhTRnBSWm01RVFVMXhVQXA1V2tGcE5UWm5VVWxzTlVkNGFsUlJVVTFKYjJ4bVdWQXpTWFp1U1VscFUwUTFiRXhNVUhka1ZEaEZUMWx3TURKM1NrbEhTMGxET0ZkemVsaDNaamh5Q21SeFNHOVNVbTEwVldOS1UxSnpWbkJzYkU1TU1GbGtSVVJSZVhoUlptbzJPRWRwU2paT1pUWlhNVlJPVG1SMFNUVkRVMVZsZVhnM2MwVnlSR0oyTUdnS0swWnFjV1ZOVjFGemRWQjRLMDlJY0ZGTldVZzBOVEJqUTNwWGVXZHhVMDltTm0xM2FYbHBLMFpGU0RZdk5tZFpjelUzVWtSWlpIUk9VMEZsWW5OdmF3cFJWMEZUUnpsWGJEUkVPVXRUUWxKRk5ucFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxVMmxZTUhOclNHRXZSelJJVlU5NVdUVnRTMHRWTTBwWGR6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJiVmh1VjNWTWNESTBkREJxYzJKdU5sVTBXakU0WWtsTlduWnJkRlZGYW5SMFVIbERWRVZKUmxaNWMwMVplazl5ZGdwMFlrZEJNMVJtTUZWT05FTlRjbWx3WVdKbFEzVnlSRFJ5YlhFemNEUmFVVVJ5TDFVNWFtUjFlQzlJZEVoMVFtSTJNM00zUVV0TU9XMVJaM00xWkdzMUNtSkNOMU5VV1hoTlJXaDVRa1JaU0dkSVF6TXpla0ZpTUVOcWJHOUtOV1JGVkdFeGF6ZzVlQzl2V0VWcVEyMUtOekJzWkRab1lVWXpVMmhIU0cweWRVOEtaRFl6Um5GbVJEZG5aMk5VYUhFMlUzRjNiVUZzVURGTVMwSm1URE50ZVhkemNsVnJWeTlRZVRoT1pFZFdkWFJwSzBZcmVtSm5jWFZzUWxGalUzVk5Nd3B3TURWVk4wOW5WRlV4TkU5eWRHdzFhRTk0Y20xcU9HbGtWVE5RYXpCcFFqVmlVbnA1UkRCRmJUbGphVzV3WTFkaFpqaFllRloxY2psVlptWlRTM0pVQ25KYWNuUmtaRFoyZDBGeVpHUjZSRVJWVXpaU1JHVlRSM2wwTkZaWVNWZHhLME5IWlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzMzYTU1YTU4LTdkYmItNDQyOC1iYTQwLWY5MTAxODA1NGExZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBjblFmUDk5bHpXMHZrWTl0emlpVWhGd0FLbDR2YmdYYWVKVEl2M0F3SEpZejhIWmZGcU9sa0hvbQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEd4b0NrOVpObEY2ZGpKeVNIWkhZbWswWnpZeU0yaE1jbUp5T0U1SFZISkliSEZEWlRKUmIweFVRVGxxZWpkTmVscENibGc1YVRWd056aEdURXBLU214aFFqSUtaalZCY2xScWMwcGlZbmR4TTJJNWFITnRSMGhCVkc1bU56VlpNV1ZqY0dSc1lYRjFiM0ZuYVhKd09HUnNhSGRYTlhoMGFtWnhkMkpzYmtnck4xRTVUd3BoYWs1M2N6UjRTbFJJZEhCQ2NGaGxMM0ZDWjJ4emRUUTFiRGcwWm5CNU1WVlpkV3RLZERoME4wUnNkbGxPYW5Kbk5VMXllWEZwYzNsMGJsZzNUbWRIQ2paamJsUkZlWGR3VFZKbE5VbHJVREY0VVU0MFJYZHdTMWQxWVhaM1FVdElUamRTWTFodFoyVnVVR2xwZFVJM2JFMW9hbXhFZG5Oa05rYzRRM2htTUZJS2FVMU5hV0k1YUZBNFIzSnFlblJvYzFWS1FsVjZibkUyTDNGeFRYQktRbFpJU2pKd05UZDVVa0p3ZVZGdFpFZ3JRVFl2YTNkcVkzQkJkaXRzTnpkRVl3cEdhMjFIUVVOMFVuZGhaWGN2WW5WVlJsRlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRNVGxvT0hsTVVFYzVNazlhUlZvclRWVm5lV3RrUVN0bFNVaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSVGczVERWeEswUkxkbEZoWjJaUlRGSndkM0ZMUVZrclkwNVNhVmwyUlZsWEt6VnNVa1J2V0VOUUszbG5SM2x3ZGdwM1NraHNTM0pwZG5CeVFqSkZhVU14WVhWUU1ESjNZWFF4YTBkQmRsTTRNM0p6YWxaQlJFTndUbWRDTUdkQldVTlFURzU1U21wUE5sSXpWMUZ2V21kaUNrNDBiamw1UlZJMVRtVnlhWGRvTTNBd01WUnRPRVZ0YUVzek9VRklaalJxUjBSbFpVVlFZMWhpTDA4M09FMDJZMmhVT1V4TmVVNXhjRmRtZVd4cldYSUtPRGRrT1ZseFVGVkJlbTlIWkZORlZsbEViazlOTTFGR2F5dDRWSGROTVRsMldHdDRkQzgwYVU1UFUxTkxZM0ZEZVRSRVkwbFhhQzh2ZUVSUk9YZGlad295YkZkaVJYWlhZVU55TW5oeVpIQTFlalp6U0dnMGFHZDVhek5sYkNzMlNERmhjMlJWTlRCNFIyaGpWak5ZS3pVdlNWcGxTM1JCYVdOYU5rSTVNMnA2Q2tWRmVtWlllVTAzUmxWRU1YZDBjRUZyUzJaR1VUTlFURlp3T0hJeVNVaHJVa0UyTkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzkxZjE0M2RlLWJiNWUtNDZlNy1iMGZiLWMzODJiZTdhNmY4Mi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFWXdRSFdTcEI5VHBzVjZEbnlDZUI1emlNV1FEdW5vZGJCbERDSHBzMlhiS1EwZlliRTFVQTE3ag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2524"
@@ -522,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:40 GMT
+      - Mon, 02 Jan 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef2648f2-7f81-4433-820c-d5502582265c
+      - 6bcceb53-cb79-4f4c-a1cf-16cbcdf2b49a
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:34.860970Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:59.694117Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1371"
@@ -555,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:40 GMT
+      - Mon, 02 Jan 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 385e6e5b-92ac-4357-8653-014cada699ed
+      - d8a90ca2-e9b9-4881-b064-23e649cbc4be
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:34.860970Z","type":"kapsule","name":"oidc","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:54:59.694117Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1371"
@@ -588,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:41 GMT
+      - Mon, 02 Jan 2023 13:55:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fd8e272-f1d6-4f77-994c-8ce8cf6a08f6
+      - 3f178dca-000f-4e65-96fb-530ee9bc75e3
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplVTFVUVhsT1JFRTBUWHByZVU5R2IxaEVWRTE1VFZSQmVVNUVRVFJOZW10NVQwWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdSakNuaDNSSFV6TDFVNFQxcFNUWGRsY0ZFNWJYaERRa2d6YVRoaVozZDBlbTl4VUdzM1MzbFNRM1E1U0hGaU1WQjRTbWt6TWpFMVJtTXhhemRJUjBGV1FYSUtNMnhzV1M5d1EzVmhTRnBSZFhrMlptTm9lVWQ1WkZaRFRrOXBLMDVhYW1GSmRrTkNjV1kwT1VacmVXaE5VakkyUmt0SWJqTnhTRnBSWm01RVFVMXhVQXA1V2tGcE5UWm5VVWxzTlVkNGFsUlJVVTFKYjJ4bVdWQXpTWFp1U1VscFUwUTFiRXhNVUhka1ZEaEZUMWx3TURKM1NrbEhTMGxET0ZkemVsaDNaamh5Q21SeFNHOVNVbTEwVldOS1UxSnpWbkJzYkU1TU1GbGtSVVJSZVhoUlptbzJPRWRwU2paT1pUWlhNVlJPVG1SMFNUVkRVMVZsZVhnM2MwVnlSR0oyTUdnS0swWnFjV1ZOVjFGemRWQjRLMDlJY0ZGTldVZzBOVEJqUTNwWGVXZHhVMDltTm0xM2FYbHBLMFpGU0RZdk5tZFpjelUzVWtSWlpIUk9VMEZsWW5OdmF3cFJWMEZUUnpsWGJEUkVPVXRUUWxKRk5ucFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxVMmxZTUhOclNHRXZSelJJVlU5NVdUVnRTMHRWTTBwWGR6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJiVmh1VjNWTWNESTBkREJxYzJKdU5sVTBXakU0WWtsTlduWnJkRlZGYW5SMFVIbERWRVZKUmxaNWMwMVplazl5ZGdwMFlrZEJNMVJtTUZWT05FTlRjbWx3WVdKbFEzVnlSRFJ5YlhFemNEUmFVVVJ5TDFVNWFtUjFlQzlJZEVoMVFtSTJNM00zUVV0TU9XMVJaM00xWkdzMUNtSkNOMU5VV1hoTlJXaDVRa1JaU0dkSVF6TXpla0ZpTUVOcWJHOUtOV1JGVkdFeGF6ZzVlQzl2V0VWcVEyMUtOekJzWkRab1lVWXpVMmhIU0cweWRVOEtaRFl6Um5GbVJEZG5aMk5VYUhFMlUzRjNiVUZzVURGTVMwSm1URE50ZVhkemNsVnJWeTlRZVRoT1pFZFdkWFJwSzBZcmVtSm5jWFZzUWxGalUzVk5Nd3B3TURWVk4wOW5WRlV4TkU5eWRHdzFhRTk0Y20xcU9HbGtWVE5RYXpCcFFqVmlVbnA1UkRCRmJUbGphVzV3WTFkaFpqaFllRloxY2psVlptWlRTM0pVQ25KYWNuUmtaRFoyZDBGeVpHUjZSRVJWVXpaU1JHVlRSM2wwTkZaWVNWZHhLME5IWlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzMzYTU1YTU4LTdkYmItNDQyOC1iYTQwLWY5MTAxODA1NGExZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBjblFmUDk5bHpXMHZrWTl0emlpVWhGd0FLbDR2YmdYYWVKVEl2M0F3SEpZejhIWmZGcU9sa0hvbQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIm9pZGMiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFFUlhkTlZFVjZUbFJSTVUweGIxaEVWRTE2VFVSRmQwMVVSWHBPVkZFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEd4b0NrOVpObEY2ZGpKeVNIWkhZbWswWnpZeU0yaE1jbUp5T0U1SFZISkliSEZEWlRKUmIweFVRVGxxZWpkTmVscENibGc1YVRWd056aEdURXBLU214aFFqSUtaalZCY2xScWMwcGlZbmR4TTJJNWFITnRSMGhCVkc1bU56VlpNV1ZqY0dSc1lYRjFiM0ZuYVhKd09HUnNhSGRYTlhoMGFtWnhkMkpzYmtnck4xRTVUd3BoYWs1M2N6UjRTbFJJZEhCQ2NGaGxMM0ZDWjJ4emRUUTFiRGcwWm5CNU1WVlpkV3RLZERoME4wUnNkbGxPYW5Kbk5VMXllWEZwYzNsMGJsZzNUbWRIQ2paamJsUkZlWGR3VFZKbE5VbHJVREY0VVU0MFJYZHdTMWQxWVhaM1FVdElUamRTWTFodFoyVnVVR2xwZFVJM2JFMW9hbXhFZG5Oa05rYzRRM2htTUZJS2FVMU5hV0k1YUZBNFIzSnFlblJvYzFWS1FsVjZibkUyTDNGeFRYQktRbFpJU2pKd05UZDVVa0p3ZVZGdFpFZ3JRVFl2YTNkcVkzQkJkaXRzTnpkRVl3cEdhMjFIUVVOMFVuZGhaWGN2WW5WVlJsRlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRNVGxvT0hsTVVFYzVNazlhUlZvclRWVm5lV3RrUVN0bFNVaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSVGczVERWeEswUkxkbEZoWjJaUlRGSndkM0ZMUVZrclkwNVNhVmwyUlZsWEt6VnNVa1J2V0VOUUszbG5SM2x3ZGdwM1NraHNTM0pwZG5CeVFqSkZhVU14WVhWUU1ESjNZWFF4YTBkQmRsTTRNM0p6YWxaQlJFTndUbWRDTUdkQldVTlFURzU1U21wUE5sSXpWMUZ2V21kaUNrNDBiamw1UlZJMVRtVnlhWGRvTTNBd01WUnRPRVZ0YUVzek9VRklaalJxUjBSbFpVVlFZMWhpTDA4M09FMDJZMmhVT1V4TmVVNXhjRmRtZVd4cldYSUtPRGRrT1ZseFVGVkJlbTlIWkZORlZsbEViazlOTTFGR2F5dDRWSGROTVRsMldHdDRkQzgwYVU1UFUxTkxZM0ZEZVRSRVkwbFhhQzh2ZUVSUk9YZGlad295YkZkaVJYWlhZVU55TW5oeVpIQTFlalp6U0dnMGFHZDVhek5sYkNzMlNERmhjMlJWTlRCNFIyaGpWak5ZS3pVdlNWcGxTM1JCYVdOYU5rSTVNMnA2Q2tWRmVtWlllVTAzUmxWRU1YZDBjRUZyUzJaR1VUTlFURlp3T0hJeVNVaHJVa0UyTkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzkxZjE0M2RlLWJiNWUtNDZlNy1iMGZiLWMzODJiZTdhNmY4Mi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkBvaWRjCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJvaWRjIgogICAgdXNlcjogb2lkYy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQG9pZGMKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiBvaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFWXdRSFdTcEI5VHBzVjZEbnlDZUI1emlNV1FEdW5vZGJCbERDSHBzMlhiS1EwZlliRTFVQTE3ag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2524"
@@ -621,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:42 GMT
+      - Mon, 02 Jan 2023 13:55:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 287095d9-d46b-4ed4-901f-bef3ab3e306a
+      - 8e8f1d7f-52d7-4454-b9f7-89ad734754fa
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:42.923105442Z","type":"kapsule","name":"oidc","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.548890208Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1369"
@@ -654,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:43 GMT
+      - Mon, 02 Jan 2023 13:55:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f200867a-6a53-48c3-8e82-b971cebe0941
+      - 9de6146a-e287-41d1-98d6-280b672015fb
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:42.923105Z","type":"kapsule","name":"oidc","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.548890Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1366"
@@ -687,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:43 GMT
+      - Mon, 02 Jan 2023 13:55:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a77d036-4a31-4e30-9cba-886c3313bc00
+      - 2b9dc6bc-76c4-404e-a29f-86b96497a4cd
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"region":"fr-par","id":"33a55a58-7dbb-4428-ba40-f91018054a1f","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.513454Z","updated_at":"2022-10-25T08:39:42.923105Z","type":"kapsule","name":"oidc","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"cluster_url":"https://33a55a58-7dbb-4428-ba40-f91018054a1f.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.33a55a58-7dbb-4428-ba40-f91018054a1f.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://91f143de-bb5e-46e7-b0fb-c382be7a6f82.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T13:54:52.222225Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.91f143de-bb5e-46e7-b0fb-c382be7a6f82.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","ingress":"none","name":"oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-01-02T13:55:05.548890Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1366"
@@ -720,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:49 GMT
+      - Mon, 02 Jan 2023 13:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae1fcab9-6303-4d8e-975d-63ba4e852678
+      - 5679845c-7e45-44a3-a675-f20626257b8a
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"33a55a58-7dbb-4428-ba40-f91018054a1f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -753,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:54 GMT
+      - Mon, 02 Jan 2023 13:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3edcbb2f-879b-4805-81f8-aece183bedc3
+      - c4eee761-9b0b-422c-b3ee-83ab15d0102e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -772,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/33a55a58-7dbb-4428-ba40-f91018054a1f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/91f143de-bb5e-46e7-b0fb-c382be7a6f82
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"33a55a58-7dbb-4428-ba40-f91018054a1f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"91f143de-bb5e-46e7-b0fb-c382be7a6f82","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -786,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:54 GMT
+      - Mon, 02 Jan 2023 13:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2398ba67-cf15-46c6-807e-be28b9dbbddc
+      - e9d594f7-c9d8-4725-9282-30b41ce6bd5f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-basic.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-basic.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:23 GMT
+      - Mon, 02 Jan 2023 14:10:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f493550d-9600-4a5b-8690-1195fde74c9f
+      - 31c0ccf7-cbb6-4fef-947e-389061d5fbe0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"K8SPoolConfigMinimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.24.5","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"K8SPoolConfigMinimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.24.7","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654305Z","updated_at":"2022-10-25T08:39:25.489220701Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560409531Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.595879199Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1335"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc5c7a99-cd33-4679-ba03-a4604810ccad
+      - fe1507a5-678d-4682-a2d0-645d16649c76
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:39:25.489221Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.595879Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61195751-928c-4c2b-953f-0faa7b3d1d3c
+      - 4a306a9a-1ca0-4b1b-9a29-2b16c7be332e
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:39:28.944826Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.513231Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f69a7c41-7c22-40ec-868a-192cca517b3b
+      - 7892ce04-03b4-4142-87f9-da7c186bf3ae
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:39:28.944826Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.513231Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0f48263-07c9-4529-ac42-400e43db7584
+      - 28998f50-ed5f-4906-9f4c-f919ee9be24b
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQXJDazVtYkZSeWRFbE5OWE5wUzBsU2RYSkNTbU00YmxSMUswWlZaRWx1TURRNFIxRnFVRU4wUkdnM1l6RlZNMkp3TVd4RmRtaEVOWFpWUmxGaVZXaDNPVFlLU25sV1kxZGFiamRvWlRVMEt6VndURmQwVTNCRVZtODRZWGwyUzFsUldsVktOVXRFVTAxR05YWkdiV3RCWVdoVVR5OW9ORlJxVkU1Q1YxRXdMMkpxVmdwNE9FUndWalJ0WVZKaVNUVTRNVFJaUkVod1ZuRnBTM1ZTUTBaVFExRTFLME42ZGt0aWNIWkNNRGw0UmpSbFpsUk9Ua0UzT0RGUFpsbE5VRWc1Y0dkb0NsaExRVUpKVFVOMmN6Um1UM0J1ZW1aNlltbFhiVk5aZUVSWE1HTlZWa2RKWjBKWk1VSlJkMDVRVWs5VVZ5OUZVV1ZGUm5sV1IyRkNNRkozVjJwT2FYQUthVm8xVWxaWFdUQnJTa0phVTB0dUx5OUhhVEJ0YjNoS1F6ZE5jMUZFWTFkVk1uRlpSbVU1WlZKbmFVRmFhVTgxYW04dmJsUkhNamhFYkhSa1VXOVdSQXBUVVU1UVdXbEhOMHd3YjFkSGRITlZkaTg0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTBGMFkxcHJSbW95YWs5S1dUY3hlRnBTVFVsUFRtVmxXV1ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDV1VWNFpUQjRVbVpUZGpsNVZrTjVRamh6VEVSdEszWTVabUZvZWt0UksydzBWRWd3VlRSYVFXcG1jMFJFWVhFeVZ3b3hLMVozTjFseWMyeHJObkp1ZGxKaldFZHJiM0ZPWVdsQlVWbEROV1l3U1ZoalpHcG1aazFMZWtOTE1XOXNjVUZtWmpCSWVYaEVXWGh0TTFGUE1ra3ZDa1ExV0ZWMWJtcEtUalpUTjNKWlZYRnFkRzVLU0RsV2VYRXdkQzgyY2xZMk4wUTBaalk0TUdRNVkwMDVMMGRzTW5veWVYaHZhbGN6VTJGMVoxRmxhelFLU1dOV1JEQldXakpQZUZORlV6ZE9Ra3BKVjBkek0zSk5ZbXAwVlhSMmNVRjVjRVZPVW1KaFRuWnJTa2RzWm5aa1dtbGhSMGQ0WWt4Nk5YazNaamN3ZWdwdk1qTlZZVkJYZFM5NFVHdGtURkZJYkU1V2RrOWliMGhOYTBSTlNIQkRUaTlvV1RseGVHcFNXVmN4YldsNWRYUnhXVloxY1dKWmNHNUxiRkpUWldwaENraFVla3BqWWxONlExZFZhMFZGVFdVeFprVmlhRTFaVkc1aVRqUjNZVWhaVEZweWVRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wNjkzMDEwZS0zZTJkLTRkNWItOWZmNC1lMTY1NjdmM2VlN2IuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBaZ3dxRjAwT3N2UlFQVUoxREpNMW5vVUphN1NGRXhmZVdteEtXU2xrSHdsa2R0QVVDZ2hhdXFRRw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMyNHZDbVZpUld4amVrazFaVGx3WVRGWlRVVnFlbWxpVEVnMFpqWjBjM1ZYVUdGS1FrMHdTMGhYU2pOTlJGbE9OVk5wT0hCbmEwZ3ljM1Z6U1dKdlVrazBVMWNLUlM4MFdFWkNZMUpYWkhOUFNsQXZTMU5oWTJoTGRuVTBWbUpSVEZKcmVHSndTall2YzBSTFFsTkhaRmQyZVRSVmFsTnJaREl4VDFaSlRFWm1jVU16UXdwRVJ6UkdSVUp1ZW5aRlNsQkpkV1JXZEcxRE9HTklSWEJEYTJONGVYY3hSMVUyUm1GUFowRmtSakJsTjJKSU5ESnVOVTVCVVhreVZFaDBNMlE1YXl0Q0NrUjNNVXBZVEcwMVZqSktUbmhOVWpKRmRtSndNMjlEVVcweFJuQXZWV1pzZGtNck1uRmFPVzVXVVVKTE9IaHhSRnBaZGpGU1oyOWtabTVoWnpWTVRtOEtlVGgwWW1OdWVFcHFNMGxaVml0alFVY3JSWFp5Um5OTWVUTmlRVmh1VmpSSVFUWnhjVWs0WVVNNGRHNTZiekZ1T0RGWWRubzFOSFJ1U0N0U1lVaDNOd3BrVFZGcWIxSjVXSHBsTUM5eVZGWm1ZMjA0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZWtSalFqbHBZVWhhSzNSb04wTmFOSGs0ZFZOUVZVdHdNMWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCVGpWalp6SXhOemx4VGxneFdVUk5SbmxKWVRCV1NURkhXRVEyT0RSeWJGTnVOVlpEYW5WT1NVVjBPVEJzVW5SamNncFpWMk5yWlRNelF6SkVWVklyVGt4dGJteDRSMXB5VkhBeGJ6RktWbUZIVEdaWGREbHNVVGx0TDFkYVV6QXhWakpSTkhoSVpIcE1UbWRJVUdjeWRIWkxDamhJTkd4VVdrNURNSE5aTXl0M1ZFeE9Wa056UjNKcloxSTNVMlp2T0d4R1dtTmtLMWRzZFdScFZXWm1abTFKYmxSTEwyaGpXRFUyV0dzMGJuZFpSbk1LTTBNNVJrVk1hMHhLVDBobVVYUk1TRUZpTDJVNVFtbDNSWGMwWmtSc2MxRmFVekZaYlRkRFlVWkhlUzl2WWtsd1pUWlJkVEJLT0RKWlEzWm1UbUpxZFFveE5FSjBhSGxIYm1kUEt6TTVlRTVWTDBkMWRYQnJObGxCWTJwRVdrOTRVMUZDVjFvd2MwSjZiVWw1YjNvNVpURjZlRE5TTHpkb1YzVlJaMWd2ZHpndkNuaFFNRVZEY1ZsdlF6UlBZVGhZZGpGc05GZFhjRXhpWVRrck1HbHlaV1JOZEcxTVRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82YTg3ZDIyOS01YmYzLTQ3YWItYjk0My1iOTcyOTZkNzNkM2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYTnZhekVsbks5Nktxb3QxcXRBVXFjbWtTWnduQTVOMGM0STVNRUdLamI4Mng0VXdSUmZjdmtMZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd3cc64f-7de3-4b5a-9428-da47f548a5ae
+      - 03c60ec3-5eaa-423a-b135-103875a82de6
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:39:28.944826Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.513231Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1334"
@@ -223,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cce6e20f-39ca-411f-b0e5-f299495bf6b6
+      - 296b7f6b-f7fd-446e-888b-2cb48a9934cb
     status: 200 OK
     code: 200
     duration: ""
@@ -244,12 +245,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606038Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290258837Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "619"
@@ -258,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 14:10:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -268,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac3cf6e0-539b-4c8c-b968-c6d213c0c249
+      - 116bcb6a-1fa6-42a2-bf32-5ade963bc1bf
     status: 200 OK
     code: 200
     duration: ""
@@ -277,12 +278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -291,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 14:10:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -301,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95bb8035-643e-4466-8d66-581357c4e044
+      - 61f4f09e-1a3e-451a-b1f7-11062936c381
     status: 200 OK
     code: 200
     duration: ""
@@ -310,12 +311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -324,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:38 GMT
+      - Mon, 02 Jan 2023 14:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -334,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cb0004a-b024-4854-8749-aea3dd405016
+      - ac5b1c1d-aa3e-4939-830f-f70fc7dd9db4
     status: 200 OK
     code: 200
     duration: ""
@@ -343,12 +344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -357,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:43 GMT
+      - Mon, 02 Jan 2023 14:10:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -367,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ced4f653-b5e4-42b8-aab6-077331cc6ddc
+      - 126b1ade-fb30-4422-aa86-ec021d5858b5
     status: 200 OK
     code: 200
     duration: ""
@@ -376,12 +377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -390,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:49 GMT
+      - Mon, 02 Jan 2023 14:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edb47b06-5449-4260-b0c6-e39670374025
+      - 6b1b7a50-eb8d-491e-9525-1b1d5f0a5faf
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -423,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:55 GMT
+      - Mon, 02 Jan 2023 14:11:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b675aa0c-8613-4305-9d1b-4df83ee0daf4
+      - 3541004f-44b5-4d82-a2a7-8068cee21663
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -456,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:00 GMT
+      - Mon, 02 Jan 2023 14:11:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 910ab906-2956-4a71-9be5-45797a4a40ae
+      - 5e9c44b4-831c-45cd-b262-e05101193073
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -489,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:05 GMT
+      - Mon, 02 Jan 2023 14:11:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd2be8be-642a-494c-9510-4b4d263e4604
+      - 0345cc6d-e266-4505-9add-e4f5082fb1d8
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -522,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:10 GMT
+      - Mon, 02 Jan 2023 14:11:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70236b54-b2ab-4ad5-be53-9c2c5a1a9358
+      - c1d1be50-6e34-49ba-b5af-b630a30db212
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -555,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:16 GMT
+      - Mon, 02 Jan 2023 14:11:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9df45136-2542-40f5-a873-a5210ca23298
+      - fad0b991-7daf-457a-9373-c58f0b7f2cdf
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -588,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:21 GMT
+      - Mon, 02 Jan 2023 14:11:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a54e899a-66db-4223-aa4a-1342623b20a0
+      - a57b0dc7-2319-4603-bb57-46603df3ec14
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -621,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:26 GMT
+      - Mon, 02 Jan 2023 14:11:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73378ec8-f810-4bb4-b8a7-b35e44650b13
+      - 525cd48f-7e8a-4e9d-8298-e1b5e9f9554d
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -654,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:32 GMT
+      - Mon, 02 Jan 2023 14:11:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0a08418-d8e4-4cb4-8426-f574c425b07d
+      - 2126fb35-4251-4264-af9a-cb73a567d26a
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -687,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:37 GMT
+      - Mon, 02 Jan 2023 14:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d449054a-847b-4315-89bd-58f35245f0c0
+      - 3cb100ce-3264-48d1-b069-0fc4ad1f85d7
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -720,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:43 GMT
+      - Mon, 02 Jan 2023 14:11:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1b46a35-2740-4a81-a5d3-266b2164fe66
+      - b402fd3e-8b09-42ad-b879-770389b99e4b
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -753,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:48 GMT
+      - Mon, 02 Jan 2023 14:11:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfa46925-1059-40c1-adba-5c98c9020e44
+      - 18953b68-30c4-4f3d-90ec-466b2b597789
     status: 200 OK
     code: 200
     duration: ""
@@ -772,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -786,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:53 GMT
+      - Mon, 02 Jan 2023 14:11:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2eba0f07-caae-4c61-ae2f-244d22e13e22
+      - 40f963bb-5d28-4603-af4d-379554c099cf
     status: 200 OK
     code: 200
     duration: ""
@@ -805,12 +806,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -819,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:59 GMT
+      - Mon, 02 Jan 2023 14:12:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e80365aa-8b39-424c-808f-bb9ea1b84af2
+      - 4ee18c4f-cf6f-4e8f-88b4-cd378e25a656
     status: 200 OK
     code: 200
     duration: ""
@@ -838,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -852,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:04 GMT
+      - Mon, 02 Jan 2023 14:12:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9c91b27-db9f-4b55-95e7-88852c32de7f
+      - 896fe898-7f26-4566-84bb-6b004c6ae2c5
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -885,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:10 GMT
+      - Mon, 02 Jan 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63bee685-b375-415c-8ac7-f4f4c917ab5e
+      - 6532dda9-2296-4bf0-ba2a-b5bdd0eb645a
     status: 200 OK
     code: 200
     duration: ""
@@ -904,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -918,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:15 GMT
+      - Mon, 02 Jan 2023 14:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97555d72-1a83-4320-96c7-93939671443d
+      - 338d2122-fa93-4dc7-8872-452f1c89b139
     status: 200 OK
     code: 200
     duration: ""
@@ -937,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -951,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:21 GMT
+      - Mon, 02 Jan 2023 14:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86b7d440-b77a-4500-811a-ba7d2fabea08
+      - 4e74df5c-6a9b-4f36-b451-bcd45d516348
     status: 200 OK
     code: 200
     duration: ""
@@ -970,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -984,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:26 GMT
+      - Mon, 02 Jan 2023 14:12:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6158f59e-f9bb-4d42-bb27-6b7a3bd4882b
+      - 1ed9a6ad-ecd6-459e-95c9-cfb4d233c310
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1017,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:31 GMT
+      - Mon, 02 Jan 2023 14:12:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ddaf7ba0-095a-4e80-8851-e53e51e52972
+      - 5363e965-5834-466d-8839-7dab35ce4b4c
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1050,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:36 GMT
+      - Mon, 02 Jan 2023 14:12:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cfe0d89-b17f-4a88-88f5-5f227c9cd118
+      - ec74d3ee-6a4a-42f7-9433-66dd5efac0b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1083,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:42 GMT
+      - Mon, 02 Jan 2023 14:12:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df6914da-43b9-43e5-9199-a57b283674f4
+      - d5c85834-e441-443f-8aa4-d34e80c912dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1116,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:47 GMT
+      - Mon, 02 Jan 2023 14:12:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea4bb37d-d04e-4451-b0d5-99421d2c1fc8
+      - b7b08963-570e-435b-87a6-8c8eb2e23c73
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1149,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:53 GMT
+      - Mon, 02 Jan 2023 14:12:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a62863a-df93-42d7-bcc1-cfb7c49b4ac1
+      - 79cdcc8c-c697-4245-969f-1fe6fb864a84
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1182,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:58 GMT
+      - Mon, 02 Jan 2023 14:12:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 177164ee-999f-48ab-b40b-d393e65466c5
+      - 3002ae53-876b-4e3e-ac3f-9883db566dd7
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1202,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1215,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:03 GMT
+      - Mon, 02 Jan 2023 14:13:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1562ebe7-d6ba-4da5-9aee-30b921cab4f9
+      - 5a1f6e87-882d-4264-bd1c-741dbd45ba6a
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1235,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1248,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:08 GMT
+      - Mon, 02 Jan 2023 14:13:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 076c44a4-8f4b-48cc-ab7a-5ee5862f21bd
+      - ee41c8a9-b672-4523-b8f7-bb1d4912be86
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1268,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1281,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:13 GMT
+      - Mon, 02 Jan 2023 14:13:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1671891-9c0d-40f1-b731-9a54e37c5cd3
+      - 6580c9be-65a0-4a12-80ee-0906d7f29a7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1301,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1314,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:19 GMT
+      - Mon, 02 Jan 2023 14:13:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d49ce56-14da-43f2-bc9b-40530fe37c88
+      - 7b653f92-c228-456d-a48e-dd9d2b134379
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1347,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:24 GMT
+      - Mon, 02 Jan 2023 14:13:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb7df55a-abd0-4969-9d2b-cd0bc396bd85
+      - b652a87c-820c-48c5-9b20-c9394fc72d23
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1380,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:30 GMT
+      - Mon, 02 Jan 2023 14:13:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de76811f-adbb-46c7-a1a1-1096eaed0de2
+      - e2c96ffe-6a8a-4a35-bd05-22edd60f355d
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1413,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:35 GMT
+      - Mon, 02 Jan 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fd6f5a0-a356-4f15-bbfb-913deaf68b0d
+      - 49500bf6-bcee-4b10-9998-81f96ab8dbd2
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1446,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:41 GMT
+      - Mon, 02 Jan 2023 14:13:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaf5ef4f-ac00-481f-b693-0a8fff78e61a
+      - a630ae23-02af-49e6-9cbe-027124e2b083
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,12 +1466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1479,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:46 GMT
+      - Mon, 02 Jan 2023 14:13:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4070970-f39f-4d3c-9bb3-e1e9e5f31e49
+      - 28712dd2-8036-4cc5-8de9-91313aca36d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,12 +1499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1512,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:52 GMT
+      - Mon, 02 Jan 2023 14:13:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 395fbed9-f310-455f-b0ef-5698cc5d86d3
+      - 74f22dbe-0e15-40ee-a59e-f627b8d7b593
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,12 +1532,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1545,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:57 GMT
+      - Mon, 02 Jan 2023 14:13:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4993f6ea-fc7d-4ca6-a42e-922a70887b4f
+      - a003c9b6-b77c-4355-a396-fb8b6f9374ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,12 +1565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1578,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:02 GMT
+      - Mon, 02 Jan 2023 14:13:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b570a49-74cb-43ce-84ed-deee836aa9d4
+      - 40d75bc4-5216-48d9-a9d1-8f1e7da5543a
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,12 +1598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1611,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:07 GMT
+      - Mon, 02 Jan 2023 14:14:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ab1755c-7490-428d-b11a-722b02c0e1f4
+      - 0d29f2c2-e05a-461c-98c0-a70b5628a6f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,12 +1631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1644,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:12 GMT
+      - Mon, 02 Jan 2023 14:14:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9976808-4bd2-494e-b380-975afaa1f200
+      - 3f6e8c3d-ecd8-49d1-8b89-af96238cf472
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,12 +1664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1677,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:18 GMT
+      - Mon, 02 Jan 2023 14:14:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c3284b8-c019-46ff-bc33-8c1746a32a04
+      - 200a0127-d915-4e4c-bec4-c0d578d78ee8
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,12 +1697,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1710,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:23 GMT
+      - Mon, 02 Jan 2023 14:14:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61b5e0be-92d5-4eea-a174-ce2d9baeb4e4
+      - 0ae0f690-3d48-49dc-96e9-0290df3f261b
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1730,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:39:31.941606Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -1743,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:28 GMT
+      - Mon, 02 Jan 2023 14:14:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa963974-2fc7-4a47-beca-75279cb23176
+      - afb64da5-14d7-4a75-a504-adeba189ff0c
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,12 +1763,342 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:43:30.018291Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 13fc8504-95a0-4551-bafd-3173ca6cc80f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1186b7da-ed6e-4d09-8cdd-27ff42c61889
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 101a40a2-7565-4038-8d0c-b0859795ad77
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ea16761-9421-4de0-8922-5a4c1d3e6d37
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5e69f16-34cf-451f-9950-43ac331d36a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab8ba8de-a9d5-4b6c-8e81-978bb9e62e64
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 87ba588c-49b7-47b3-8caf-fc2c40537cba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 45644076-15dc-4ca5-970b-8ff0c9e6f97f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d18e418a-9639-486e-ac99-b78dec269bc8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:10:39.290259Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8da4b2c9-baae-41b3-9187-7e8cccb692c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:15:15.683014Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -1776,7 +2107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:33 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01ee0664-2e63-4946-a618-3ecc03ad0ecf
+      - b3d055f4-d3cb-437b-9791-9fc87b16d980
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,12 +2126,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -1809,7 +2140,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:33 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49ec25b9-8ba6-4055-b03f-d22a6a4b3dd4
+      - c1fc13d5-3fbc-4782-b087-ab3179a5c6b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,12 +2159,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:43:30.018291Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:15:15.683014Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -1842,7 +2173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:34 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 804905e0-9d1e-47f9-9867-44c869028435
+      - e0ecff10-fc25-4360-a11b-8e1aea2b9db2
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,12 +2192,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=bcbc9339-3763-4d56-816a-eb052a06040c&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2ebc7f6e-6d42-4acb-b662-cd9b74e40144","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:41:20.429334Z","updated_at":"2022-10-25T08:43:30.007817Z","pool_id":"bcbc9339-3763-4d56-816a-eb052a06040c","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-default-2ebc7f6e6d424","public_ip_v4":"51.15.224.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/508b86d9-ddda-4aa1-8ac1-59ce4434c678","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:29.403518Z","error_message":null,"id":"7a798b1a-b5a8-451d-a104-e66ceb8a78fb","name":"scw-k8spoolconfigminimal-default-7a798b1ab5a84","pool_id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","provider_id":"scaleway://instance/fr-par-1/6516546d-7a61-4303-846d-c3433582fc8d","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:15.671239Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "605"
@@ -1875,7 +2206,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:34 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 255f60db-5529-4984-80c5-e71fdf2c2332
+      - f70d624f-fcbb-4674-8261-ab2b4fa268ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,12 +2225,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -1908,7 +2239,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:34 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8ed0a23-b109-4ee0-849a-143c7e9e2f4a
+      - ae23cce7-ae92-4059-94e1-f533b0ba8da3
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,12 +2258,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:43:30.018291Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:15:15.683014Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -1941,7 +2272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:34 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1951,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5599f8de-5572-418c-a4e4-8050857831f4
+      - c3322b92-b7ff-401f-b243-75824d23d1a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1960,12 +2291,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -1974,7 +2305,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:35 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1984,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 387049eb-b09e-4c2a-8e75-c7fa57503b86
+      - b4c9f6fe-2349-4358-b1e5-b3a59db1e6bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1993,12 +2324,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQXJDazVtYkZSeWRFbE5OWE5wUzBsU2RYSkNTbU00YmxSMUswWlZaRWx1TURRNFIxRnFVRU4wUkdnM1l6RlZNMkp3TVd4RmRtaEVOWFpWUmxGaVZXaDNPVFlLU25sV1kxZGFiamRvWlRVMEt6VndURmQwVTNCRVZtODRZWGwyUzFsUldsVktOVXRFVTAxR05YWkdiV3RCWVdoVVR5OW9ORlJxVkU1Q1YxRXdMMkpxVmdwNE9FUndWalJ0WVZKaVNUVTRNVFJaUkVod1ZuRnBTM1ZTUTBaVFExRTFLME42ZGt0aWNIWkNNRGw0UmpSbFpsUk9Ua0UzT0RGUFpsbE5VRWc1Y0dkb0NsaExRVUpKVFVOMmN6Um1UM0J1ZW1aNlltbFhiVk5aZUVSWE1HTlZWa2RKWjBKWk1VSlJkMDVRVWs5VVZ5OUZVV1ZGUm5sV1IyRkNNRkozVjJwT2FYQUthVm8xVWxaWFdUQnJTa0phVTB0dUx5OUhhVEJ0YjNoS1F6ZE5jMUZFWTFkVk1uRlpSbVU1WlZKbmFVRmFhVTgxYW04dmJsUkhNamhFYkhSa1VXOVdSQXBUVVU1UVdXbEhOMHd3YjFkSGRITlZkaTg0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTBGMFkxcHJSbW95YWs5S1dUY3hlRnBTVFVsUFRtVmxXV1ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDV1VWNFpUQjRVbVpUZGpsNVZrTjVRamh6VEVSdEszWTVabUZvZWt0UksydzBWRWd3VlRSYVFXcG1jMFJFWVhFeVZ3b3hLMVozTjFseWMyeHJObkp1ZGxKaldFZHJiM0ZPWVdsQlVWbEROV1l3U1ZoalpHcG1aazFMZWtOTE1XOXNjVUZtWmpCSWVYaEVXWGh0TTFGUE1ra3ZDa1ExV0ZWMWJtcEtUalpUTjNKWlZYRnFkRzVLU0RsV2VYRXdkQzgyY2xZMk4wUTBaalk0TUdRNVkwMDVMMGRzTW5veWVYaHZhbGN6VTJGMVoxRmxhelFLU1dOV1JEQldXakpQZUZORlV6ZE9Ra3BKVjBkek0zSk5ZbXAwVlhSMmNVRjVjRVZPVW1KaFRuWnJTa2RzWm5aa1dtbGhSMGQ0WWt4Nk5YazNaamN3ZWdwdk1qTlZZVkJYZFM5NFVHdGtURkZJYkU1V2RrOWliMGhOYTBSTlNIQkRUaTlvV1RseGVHcFNXVmN4YldsNWRYUnhXVloxY1dKWmNHNUxiRkpUWldwaENraFVla3BqWWxONlExZFZhMFZGVFdVeFprVmlhRTFaVkc1aVRqUjNZVWhaVEZweWVRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wNjkzMDEwZS0zZTJkLTRkNWItOWZmNC1lMTY1NjdmM2VlN2IuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBaZ3dxRjAwT3N2UlFQVUoxREpNMW5vVUphN1NGRXhmZVdteEtXU2xrSHdsa2R0QVVDZ2hhdXFRRw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMyNHZDbVZpUld4amVrazFaVGx3WVRGWlRVVnFlbWxpVEVnMFpqWjBjM1ZYVUdGS1FrMHdTMGhYU2pOTlJGbE9OVk5wT0hCbmEwZ3ljM1Z6U1dKdlVrazBVMWNLUlM4MFdFWkNZMUpYWkhOUFNsQXZTMU5oWTJoTGRuVTBWbUpSVEZKcmVHSndTall2YzBSTFFsTkhaRmQyZVRSVmFsTnJaREl4VDFaSlRFWm1jVU16UXdwRVJ6UkdSVUp1ZW5aRlNsQkpkV1JXZEcxRE9HTklSWEJEYTJONGVYY3hSMVUyUm1GUFowRmtSakJsTjJKSU5ESnVOVTVCVVhreVZFaDBNMlE1YXl0Q0NrUjNNVXBZVEcwMVZqSktUbmhOVWpKRmRtSndNMjlEVVcweFJuQXZWV1pzZGtNck1uRmFPVzVXVVVKTE9IaHhSRnBaZGpGU1oyOWtabTVoWnpWTVRtOEtlVGgwWW1OdWVFcHFNMGxaVml0alFVY3JSWFp5Um5OTWVUTmlRVmh1VmpSSVFUWnhjVWs0WVVNNGRHNTZiekZ1T0RGWWRubzFOSFJ1U0N0U1lVaDNOd3BrVFZGcWIxSjVXSHBsTUM5eVZGWm1ZMjA0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZWtSalFqbHBZVWhhSzNSb04wTmFOSGs0ZFZOUVZVdHdNMWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCVGpWalp6SXhOemx4VGxneFdVUk5SbmxKWVRCV1NURkhXRVEyT0RSeWJGTnVOVlpEYW5WT1NVVjBPVEJzVW5SamNncFpWMk5yWlRNelF6SkVWVklyVGt4dGJteDRSMXB5VkhBeGJ6RktWbUZIVEdaWGREbHNVVGx0TDFkYVV6QXhWakpSTkhoSVpIcE1UbWRJVUdjeWRIWkxDamhJTkd4VVdrNURNSE5aTXl0M1ZFeE9Wa056UjNKcloxSTNVMlp2T0d4R1dtTmtLMWRzZFdScFZXWm1abTFKYmxSTEwyaGpXRFUyV0dzMGJuZFpSbk1LTTBNNVJrVk1hMHhLVDBobVVYUk1TRUZpTDJVNVFtbDNSWGMwWmtSc2MxRmFVekZaYlRkRFlVWkhlUzl2WWtsd1pUWlJkVEJLT0RKWlEzWm1UbUpxZFFveE5FSjBhSGxIYm1kUEt6TTVlRTVWTDBkMWRYQnJObGxCWTJwRVdrOTRVMUZDVjFvd2MwSjZiVWw1YjNvNVpURjZlRE5TTHpkb1YzVlJaMWd2ZHpndkNuaFFNRVZEY1ZsdlF6UlBZVGhZZGpGc05GZFhjRXhpWVRrck1HbHlaV1JOZEcxTVRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82YTg3ZDIyOS01YmYzLTQ3YWItYjk0My1iOTcyOTZkNzNkM2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYTnZhekVsbks5Nktxb3QxcXRBVXFjbWtTWnduQTVOMGM0STVNRUdLamI4Mng0VXdSUmZjdmtMZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -2007,7 +2338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:36 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2017,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff1e071e-39aa-4dac-92f6-3e20667aadab
+      - d6717a83-b625-47de-9cba-69ac85366710
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,12 +2357,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:43:30.018291Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:15:15.683014Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -2040,7 +2371,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:36 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2050,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20c106c6-3cbf-4d93-b542-515c61963cdb
+      - ba6ca624-1942-4d53-a619-460b987a2a15
     status: 200 OK
     code: 200
     duration: ""
@@ -2059,12 +2390,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=bcbc9339-3763-4d56-816a-eb052a06040c&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2ebc7f6e-6d42-4acb-b662-cd9b74e40144","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:41:20.429334Z","updated_at":"2022-10-25T08:43:30.007817Z","pool_id":"bcbc9339-3763-4d56-816a-eb052a06040c","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-default-2ebc7f6e6d424","public_ip_v4":"51.15.224.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/508b86d9-ddda-4aa1-8ac1-59ce4434c678","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:29.403518Z","error_message":null,"id":"7a798b1a-b5a8-451d-a104-e66ceb8a78fb","name":"scw-k8spoolconfigminimal-default-7a798b1ab5a84","pool_id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","provider_id":"scaleway://instance/fr-par-1/6516546d-7a61-4303-846d-c3433582fc8d","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:15.671239Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "605"
@@ -2073,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:36 GMT
+      - Mon, 02 Jan 2023 14:15:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2083,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2380469b-848d-4a0e-a389-c9bf300bac0f
+      - d1ba9e96-d4ce-470c-a21e-8e302a5b918b
     status: 200 OK
     code: 200
     duration: ""
@@ -2092,12 +2423,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -2106,7 +2437,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:37 GMT
+      - Mon, 02 Jan 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2116,7 +2447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b6bff72-7b5b-4579-b73e-48219d3f89e9
+      - 5245acde-ec9d-4013-ae8f-193aad9f5617
     status: 200 OK
     code: 200
     duration: ""
@@ -2125,12 +2456,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQXJDazVtYkZSeWRFbE5OWE5wUzBsU2RYSkNTbU00YmxSMUswWlZaRWx1TURRNFIxRnFVRU4wUkdnM1l6RlZNMkp3TVd4RmRtaEVOWFpWUmxGaVZXaDNPVFlLU25sV1kxZGFiamRvWlRVMEt6VndURmQwVTNCRVZtODRZWGwyUzFsUldsVktOVXRFVTAxR05YWkdiV3RCWVdoVVR5OW9ORlJxVkU1Q1YxRXdMMkpxVmdwNE9FUndWalJ0WVZKaVNUVTRNVFJaUkVod1ZuRnBTM1ZTUTBaVFExRTFLME42ZGt0aWNIWkNNRGw0UmpSbFpsUk9Ua0UzT0RGUFpsbE5VRWc1Y0dkb0NsaExRVUpKVFVOMmN6Um1UM0J1ZW1aNlltbFhiVk5aZUVSWE1HTlZWa2RKWjBKWk1VSlJkMDVRVWs5VVZ5OUZVV1ZGUm5sV1IyRkNNRkozVjJwT2FYQUthVm8xVWxaWFdUQnJTa0phVTB0dUx5OUhhVEJ0YjNoS1F6ZE5jMUZFWTFkVk1uRlpSbVU1WlZKbmFVRmFhVTgxYW04dmJsUkhNamhFYkhSa1VXOVdSQXBUVVU1UVdXbEhOMHd3YjFkSGRITlZkaTg0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTBGMFkxcHJSbW95YWs5S1dUY3hlRnBTVFVsUFRtVmxXV1ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDV1VWNFpUQjRVbVpUZGpsNVZrTjVRamh6VEVSdEszWTVabUZvZWt0UksydzBWRWd3VlRSYVFXcG1jMFJFWVhFeVZ3b3hLMVozTjFseWMyeHJObkp1ZGxKaldFZHJiM0ZPWVdsQlVWbEROV1l3U1ZoalpHcG1aazFMZWtOTE1XOXNjVUZtWmpCSWVYaEVXWGh0TTFGUE1ra3ZDa1ExV0ZWMWJtcEtUalpUTjNKWlZYRnFkRzVLU0RsV2VYRXdkQzgyY2xZMk4wUTBaalk0TUdRNVkwMDVMMGRzTW5veWVYaHZhbGN6VTJGMVoxRmxhelFLU1dOV1JEQldXakpQZUZORlV6ZE9Ra3BKVjBkek0zSk5ZbXAwVlhSMmNVRjVjRVZPVW1KaFRuWnJTa2RzWm5aa1dtbGhSMGQ0WWt4Nk5YazNaamN3ZWdwdk1qTlZZVkJYZFM5NFVHdGtURkZJYkU1V2RrOWliMGhOYTBSTlNIQkRUaTlvV1RseGVHcFNXVmN4YldsNWRYUnhXVloxY1dKWmNHNUxiRkpUWldwaENraFVla3BqWWxONlExZFZhMFZGVFdVeFprVmlhRTFaVkc1aVRqUjNZVWhaVEZweWVRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wNjkzMDEwZS0zZTJkLTRkNWItOWZmNC1lMTY1NjdmM2VlN2IuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBaZ3dxRjAwT3N2UlFQVUoxREpNMW5vVUphN1NGRXhmZVdteEtXU2xrSHdsa2R0QVVDZ2hhdXFRRw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMyNHZDbVZpUld4amVrazFaVGx3WVRGWlRVVnFlbWxpVEVnMFpqWjBjM1ZYVUdGS1FrMHdTMGhYU2pOTlJGbE9OVk5wT0hCbmEwZ3ljM1Z6U1dKdlVrazBVMWNLUlM4MFdFWkNZMUpYWkhOUFNsQXZTMU5oWTJoTGRuVTBWbUpSVEZKcmVHSndTall2YzBSTFFsTkhaRmQyZVRSVmFsTnJaREl4VDFaSlRFWm1jVU16UXdwRVJ6UkdSVUp1ZW5aRlNsQkpkV1JXZEcxRE9HTklSWEJEYTJONGVYY3hSMVUyUm1GUFowRmtSakJsTjJKSU5ESnVOVTVCVVhreVZFaDBNMlE1YXl0Q0NrUjNNVXBZVEcwMVZqSktUbmhOVWpKRmRtSndNMjlEVVcweFJuQXZWV1pzZGtNck1uRmFPVzVXVVVKTE9IaHhSRnBaZGpGU1oyOWtabTVoWnpWTVRtOEtlVGgwWW1OdWVFcHFNMGxaVml0alFVY3JSWFp5Um5OTWVUTmlRVmh1VmpSSVFUWnhjVWs0WVVNNGRHNTZiekZ1T0RGWWRubzFOSFJ1U0N0U1lVaDNOd3BrVFZGcWIxSjVXSHBsTUM5eVZGWm1ZMjA0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZWtSalFqbHBZVWhhSzNSb04wTmFOSGs0ZFZOUVZVdHdNMWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCVGpWalp6SXhOemx4VGxneFdVUk5SbmxKWVRCV1NURkhXRVEyT0RSeWJGTnVOVlpEYW5WT1NVVjBPVEJzVW5SamNncFpWMk5yWlRNelF6SkVWVklyVGt4dGJteDRSMXB5VkhBeGJ6RktWbUZIVEdaWGREbHNVVGx0TDFkYVV6QXhWakpSTkhoSVpIcE1UbWRJVUdjeWRIWkxDamhJTkd4VVdrNURNSE5aTXl0M1ZFeE9Wa056UjNKcloxSTNVMlp2T0d4R1dtTmtLMWRzZFdScFZXWm1abTFKYmxSTEwyaGpXRFUyV0dzMGJuZFpSbk1LTTBNNVJrVk1hMHhLVDBobVVYUk1TRUZpTDJVNVFtbDNSWGMwWmtSc2MxRmFVekZaYlRkRFlVWkhlUzl2WWtsd1pUWlJkVEJLT0RKWlEzWm1UbUpxZFFveE5FSjBhSGxIYm1kUEt6TTVlRTVWTDBkMWRYQnJObGxCWTJwRVdrOTRVMUZDVjFvd2MwSjZiVWw1YjNvNVpURjZlRE5TTHpkb1YzVlJaMWd2ZHpndkNuaFFNRVZEY1ZsdlF6UlBZVGhZZGpGc05GZFhjRXhpWVRrck1HbHlaV1JOZEcxTVRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82YTg3ZDIyOS01YmYzLTQ3YWItYjk0My1iOTcyOTZkNzNkM2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYTnZhekVsbks5Nktxb3QxcXRBVXFjbWtTWnduQTVOMGM0STVNRUdLamI4Mng0VXdSUmZjdmtMZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -2139,7 +2470,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:37 GMT
+      - Mon, 02 Jan 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9904592-d367-4dc2-8cc4-38c14218b107
+      - ac3b5988-e753-4d96-9d33-3577a60da713
     status: 200 OK
     code: 200
     duration: ""
@@ -2158,12 +2489,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:43:30.018291Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:15:15.683014Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -2172,7 +2503,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:38 GMT
+      - Mon, 02 Jan 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e39cb4cd-25a4-472e-9678-dd0cd36f340d
+      - 10a57a3e-c1ca-47aa-98e7-e38c14c4bf49
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,12 +2522,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=bcbc9339-3763-4d56-816a-eb052a06040c&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2ebc7f6e-6d42-4acb-b662-cd9b74e40144","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:41:20.429334Z","updated_at":"2022-10-25T08:43:30.007817Z","pool_id":"bcbc9339-3763-4d56-816a-eb052a06040c","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-default-2ebc7f6e6d424","public_ip_v4":"51.15.224.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/508b86d9-ddda-4aa1-8ac1-59ce4434c678","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:29.403518Z","error_message":null,"id":"7a798b1a-b5a8-451d-a104-e66ceb8a78fb","name":"scw-k8spoolconfigminimal-default-7a798b1ab5a84","pool_id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","provider_id":"scaleway://instance/fr-par-1/6516546d-7a61-4303-846d-c3433582fc8d","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:15.671239Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "605"
@@ -2205,7 +2536,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:38 GMT
+      - Mon, 02 Jan 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2215,7 +2546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1878dc83-8dea-4447-affe-e39300eafa7e
+      - abefaf4c-2339-4166-b57d-48363fead12c
     status: 200 OK
     code: 200
     duration: ""
@@ -2224,12 +2555,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -2238,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:38 GMT
+      - Mon, 02 Jan 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2248,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af37c1e7-978c-417e-9a61-78e5af5d3ac3
+      - 9c4ed203-81ed-4d22-8a08-146da1086259
     status: 200 OK
     code: 200
     duration: ""
@@ -2259,12 +2590,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002092881Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749368Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "619"
@@ -2273,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:40 GMT
+      - Mon, 02 Jan 2023 14:15:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2283,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd42eef7-3930-4dfa-bc95-ca928a90ba7d
+      - a51eb021-e48d-413b-8fde-9961b18c9d48
     status: 200 OK
     code: 200
     duration: ""
@@ -2292,12 +2623,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2306,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:40 GMT
+      - Mon, 02 Jan 2023 14:15:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2316,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 107f45dc-f76c-4c28-856c-ed502c1819a6
+      - 8138a397-79a3-4638-8145-ddc4b5bde276
     status: 200 OK
     code: 200
     duration: ""
@@ -2325,12 +2656,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2339,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:45 GMT
+      - Mon, 02 Jan 2023 14:15:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2349,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9463f835-d48b-4fe4-9bb5-2ed04426de38
+      - f8b1b091-bcf6-4b36-b7ea-54cac8e5f82f
     status: 200 OK
     code: 200
     duration: ""
@@ -2358,12 +2689,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2372,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:50 GMT
+      - Mon, 02 Jan 2023 14:15:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2382,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31d7d45b-9a8a-4039-8adc-74e12feb5d65
+      - ec669bc7-3591-436a-abb6-c7271c8927b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2391,12 +2722,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2405,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:56 GMT
+      - Mon, 02 Jan 2023 14:15:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2415,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1c5f4af-7b45-4640-8e0e-ddf9c64edb8b
+      - 481b5460-f947-478f-809b-362df91194f0
     status: 200 OK
     code: 200
     duration: ""
@@ -2424,12 +2755,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2438,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:01 GMT
+      - Mon, 02 Jan 2023 14:15:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2448,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25bc036f-3b3c-4490-84b1-b41d598ac2c5
+      - 3869039d-ad05-4a2f-9710-00eff81942b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2457,12 +2788,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2471,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:07 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2481,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edf1ec6b-6534-47f1-a4c4-4b6fec3a261c
+      - e38195dc-000f-4aef-8af2-3c0a09a3ec45
     status: 200 OK
     code: 200
     duration: ""
@@ -2490,12 +2821,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2504,7 +2835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:12 GMT
+      - Mon, 02 Jan 2023 14:15:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2514,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c13f06d-1129-48e7-b05a-62f3cb91dafa
+      - 45d3519a-8dc2-4317-b9ca-f2421c1fdf36
     status: 200 OK
     code: 200
     duration: ""
@@ -2523,12 +2854,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2537,7 +2868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:17 GMT
+      - Mon, 02 Jan 2023 14:15:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2547,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fe540f6-a792-427b-a8c5-41c2413b36f3
+      - 15dc7a07-a719-4ef5-85a0-4ecb326e9270
     status: 200 OK
     code: 200
     duration: ""
@@ -2556,12 +2887,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2570,7 +2901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:16:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2580,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 692de085-3ce7-45cc-a886-6f100358d1b9
+      - 2a7dee6e-0358-43b0-8595-8dd5daf75a3d
     status: 200 OK
     code: 200
     duration: ""
@@ -2589,12 +2920,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2603,7 +2934,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:28 GMT
+      - Mon, 02 Jan 2023 14:16:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2613,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 558c6b5d-4d2d-475f-8433-3bfe82b8d802
+      - cb6f6643-cf82-4cea-9100-2da4cbd458eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2622,12 +2953,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2636,7 +2967,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:33 GMT
+      - Mon, 02 Jan 2023 14:16:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2646,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dd355ab-f0b1-4f11-a676-94378f80879b
+      - 5c38ec68-f2e2-4ca0-a572-a81b7bb6a827
     status: 200 OK
     code: 200
     duration: ""
@@ -2655,12 +2986,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2669,7 +3000,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:39 GMT
+      - Mon, 02 Jan 2023 14:16:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2679,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e3a39a4-83b6-4fda-8417-5b2427dc3e91
+      - 4ee733e3-d498-42e8-bf66-ab6fb39b36cf
     status: 200 OK
     code: 200
     duration: ""
@@ -2688,12 +3019,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2702,7 +3033,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:45 GMT
+      - Mon, 02 Jan 2023 14:16:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2712,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5be8d87-c595-4291-9b25-04c87f596f20
+      - fd56b015-7855-4b10-b68b-9842404caf95
     status: 200 OK
     code: 200
     duration: ""
@@ -2721,12 +3052,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2735,7 +3066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:51 GMT
+      - Mon, 02 Jan 2023 14:16:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2745,7 +3076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ba5163f-c2da-4428-84a1-0217c0b2f474
+      - deaacf5c-3e74-4110-8f25-c9efc97793ff
     status: 200 OK
     code: 200
     duration: ""
@@ -2754,12 +3085,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2768,7 +3099,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:56 GMT
+      - Mon, 02 Jan 2023 14:16:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2778,7 +3109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b65bf656-0cca-4fa2-9065-4ee50828a039
+      - 89b34785-530b-43fe-a413-03e8fcdd996c
     status: 200 OK
     code: 200
     duration: ""
@@ -2787,12 +3118,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2801,7 +3132,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:02 GMT
+      - Mon, 02 Jan 2023 14:16:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2811,7 +3142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4a29881-6c6d-4779-86a8-c0bb851021bb
+      - c13b72b7-180e-4201-ab7f-2fe74450784f
     status: 200 OK
     code: 200
     duration: ""
@@ -2820,12 +3151,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2834,7 +3165,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:07 GMT
+      - Mon, 02 Jan 2023 14:16:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2844,7 +3175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 810a48e0-8b68-49db-9617-2c4e7017321a
+      - cd9e2b94-fade-4110-bc52-7e64dc7de1b7
     status: 200 OK
     code: 200
     duration: ""
@@ -2853,12 +3184,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2867,7 +3198,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:13 GMT
+      - Mon, 02 Jan 2023 14:16:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2877,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59d3776e-3cdc-4ce7-bc80-e7780f7124b6
+      - e968104e-be2a-40e8-8d40-690391310dfa
     status: 200 OK
     code: 200
     duration: ""
@@ -2886,12 +3217,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2900,7 +3231,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:18 GMT
+      - Mon, 02 Jan 2023 14:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2910,7 +3241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64da0661-d1ec-4ed6-be3c-fe12fc7d632e
+      - 7d786b29-b59f-4c86-801a-20821b098e01
     status: 200 OK
     code: 200
     duration: ""
@@ -2919,12 +3250,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2933,7 +3264,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:23 GMT
+      - Mon, 02 Jan 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2943,7 +3274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d473635d-409f-465e-8530-c55206fe7d4f
+      - 6903f9d6-e7af-4e3a-a1d9-6a3ec3fb8ba2
     status: 200 OK
     code: 200
     duration: ""
@@ -2952,12 +3283,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2966,7 +3297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:29 GMT
+      - Mon, 02 Jan 2023 14:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2976,7 +3307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3d4b465-873a-4118-b70f-ece64c9d5000
+      - 93ed19e6-e1a6-43c6-9901-faaaae558dd0
     status: 200 OK
     code: 200
     duration: ""
@@ -2985,12 +3316,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -2999,7 +3330,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:34 GMT
+      - Mon, 02 Jan 2023 14:17:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3009,7 +3340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbaf3908-7247-4cd6-95d4-d058f444df2d
+      - 4cb1fcdb-09d7-4f0d-a132-17dabcd340c9
     status: 200 OK
     code: 200
     duration: ""
@@ -3018,12 +3349,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3032,7 +3363,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:39 GMT
+      - Mon, 02 Jan 2023 14:17:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3042,7 +3373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e638efc3-3997-40d2-8c69-0414ec5ce77a
+      - 0bd223a3-32be-4a69-9a0c-56505e6e3b4c
     status: 200 OK
     code: 200
     duration: ""
@@ -3051,12 +3382,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3065,7 +3396,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:45 GMT
+      - Mon, 02 Jan 2023 14:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3075,7 +3406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a850d34-82b3-4c61-b1ef-5b62c84f8b66
+      - fe97a9c0-af30-4f6a-9b7c-aa7e44fe7f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -3084,12 +3415,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3098,7 +3429,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:50 GMT
+      - Mon, 02 Jan 2023 14:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3108,7 +3439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1c16d91-7f1b-4d4d-8c2b-d76a81651648
+      - c11d815b-4abb-4d18-bff6-b5678816f480
     status: 200 OK
     code: 200
     duration: ""
@@ -3117,12 +3448,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3131,7 +3462,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:55 GMT
+      - Mon, 02 Jan 2023 14:17:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3141,7 +3472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97891e9d-15fe-4e64-a7be-6d0186fac653
+      - 2655cf28-ed63-460e-ac91-9ef1aae11673
     status: 200 OK
     code: 200
     duration: ""
@@ -3150,12 +3481,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3164,7 +3495,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:00 GMT
+      - Mon, 02 Jan 2023 14:17:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3174,7 +3505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4c45dc0-2ec5-429f-a7f8-67b95eea4308
+      - 97d7f352-f438-40b6-9486-8f439e220fe9
     status: 200 OK
     code: 200
     duration: ""
@@ -3183,12 +3514,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3197,7 +3528,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:06 GMT
+      - Mon, 02 Jan 2023 14:17:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3207,7 +3538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8050038b-1d39-4668-9486-adad311d2f19
+      - 43eafefa-79ad-468f-a619-c5c756a49e8e
     status: 200 OK
     code: 200
     duration: ""
@@ -3216,12 +3547,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3230,7 +3561,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:11 GMT
+      - Mon, 02 Jan 2023 14:17:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3240,7 +3571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4463e65b-8a97-4def-85ed-ee3d4c0a110c
+      - cd527acb-9405-4af0-8daf-31e6bada8ea7
     status: 200 OK
     code: 200
     duration: ""
@@ -3249,12 +3580,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3263,7 +3594,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:16 GMT
+      - Mon, 02 Jan 2023 14:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3273,7 +3604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dffbf04-5c11-47ba-bb73-44e0f78c3cc8
+      - 3f3145d1-48d2-497a-bace-31e152f364ed
     status: 200 OK
     code: 200
     duration: ""
@@ -3282,12 +3613,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3296,7 +3627,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:21 GMT
+      - Mon, 02 Jan 2023 14:17:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3306,7 +3637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2a80e6e-b2ea-4997-bd02-a308e776cb74
+      - 120cde9b-92ad-4cce-af9a-0486e270565f
     status: 200 OK
     code: 200
     duration: ""
@@ -3315,12 +3646,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3329,7 +3660,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:27 GMT
+      - Mon, 02 Jan 2023 14:17:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3339,7 +3670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c56bc2ec-e141-4dc6-a415-534065a309f2
+      - ac75b923-e08a-49f7-9e19-234dec7bd418
     status: 200 OK
     code: 200
     duration: ""
@@ -3348,12 +3679,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3362,7 +3693,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:32 GMT
+      - Mon, 02 Jan 2023 14:18:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3372,7 +3703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6fbaff4-15ee-48b2-9e97-c2e51755a9ad
+      - 9e490c1f-909e-4d44-a0e4-7d626cebf0eb
     status: 200 OK
     code: 200
     duration: ""
@@ -3381,12 +3712,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:43:39.002093Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3395,7 +3726,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:37 GMT
+      - Mon, 02 Jan 2023 14:18:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3405,7 +3736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c047bd2c-ae87-4e4c-b296-038c32994999
+      - 7c51b59f-2137-4169-92ca-187b809f75c5
     status: 200 OK
     code: 200
     duration: ""
@@ -3414,12 +3745,144 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:46:40.487481Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc091b8a-66d3-4e3f-bde2-40202f8f0982
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab96cb09-5669-4ed0-9c07-4320a09d4c49
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd7e9bc5-0be7-49b8-927d-de0925801c82
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:15:21.473749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9204294e-5c71-47dc-b7f7-b9d1e739097e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:18:33.595453Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -3428,7 +3891,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:43 GMT
+      - Mon, 02 Jan 2023 14:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3438,7 +3901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7c96af5-2758-44e5-8414-19cad2e18e5d
+      - 361e78c8-1632-4257-b3ae-e29fbfd1b508
     status: 200 OK
     code: 200
     duration: ""
@@ -3447,12 +3910,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:46:40.487481Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:18:33.595453Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -3461,7 +3924,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:43 GMT
+      - Mon, 02 Jan 2023 14:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3471,7 +3934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96dadbdf-1429-4fa0-b5b9-22b683bf78f8
+      - 3aa8c38d-95b2-477a-b2c4-af41033cac2d
     status: 200 OK
     code: 200
     duration: ""
@@ -3480,21 +3943,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=0ad0655e-7382-44fb-96c1-c19fb2d74bfd&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4a05adc5-400b-4a0c-8de0-35a5c986462b&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"92846c91-7502-428c-9304-c3cf247166e6","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:41.173910Z","updated_at":"2022-10-25T08:46:40.471925Z","pool_id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-minimal-92846c9175024","public_ip_v4":"163.172.175.88","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/fadd4615-d3c9-476e-9abe-203c54d3f6ea","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:15:23.132983Z","error_message":null,"id":"b8195374-d07a-464e-a09b-75fe015f2061","name":"scw-k8spoolconfigminimal-minimal-b8195374d07a4","pool_id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","provider_id":"scaleway://instance/fr-par-1/c8d55ffb-2123-443a-9fdc-49d89788abef","public_ip_v4":"51.158.75.237","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:18:33.539802Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:43 GMT
+      - Mon, 02 Jan 2023 14:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3504,7 +3967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a6bc9fa-2e03-4a21-81e3-ded2232d3fae
+      - 51727f10-eff9-4748-9633-69ad115391ed
     status: 200 OK
     code: 200
     duration: ""
@@ -3513,12 +3976,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -3527,7 +3990,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:44 GMT
+      - Mon, 02 Jan 2023 14:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3537,7 +4000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2babf209-3cb4-4f5e-919f-c3a9c71cb872
+      - 706974a1-7576-4364-8ffa-01474f1c8f8d
     status: 200 OK
     code: 200
     duration: ""
@@ -3546,12 +4009,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:46:40.487481Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:18:33.595453Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -3560,7 +4023,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:44 GMT
+      - Mon, 02 Jan 2023 14:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3570,7 +4033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b82cbab-7cb8-4be1-9914-76fd43b0bfed
+      - 723695dc-e783-4207-b762-7438b4aa36b7
     status: 200 OK
     code: 200
     duration: ""
@@ -3579,12 +4042,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -3593,7 +4056,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:45 GMT
+      - Mon, 02 Jan 2023 14:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3603,7 +4066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf3b6727-752b-49c3-94b7-4668775a4ee2
+      - 85413dba-7ef9-4c9e-bfe3-381d749c2421
     status: 200 OK
     code: 200
     duration: ""
@@ -3612,12 +4075,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQXJDazVtYkZSeWRFbE5OWE5wUzBsU2RYSkNTbU00YmxSMUswWlZaRWx1TURRNFIxRnFVRU4wUkdnM1l6RlZNMkp3TVd4RmRtaEVOWFpWUmxGaVZXaDNPVFlLU25sV1kxZGFiamRvWlRVMEt6VndURmQwVTNCRVZtODRZWGwyUzFsUldsVktOVXRFVTAxR05YWkdiV3RCWVdoVVR5OW9ORlJxVkU1Q1YxRXdMMkpxVmdwNE9FUndWalJ0WVZKaVNUVTRNVFJaUkVod1ZuRnBTM1ZTUTBaVFExRTFLME42ZGt0aWNIWkNNRGw0UmpSbFpsUk9Ua0UzT0RGUFpsbE5VRWc1Y0dkb0NsaExRVUpKVFVOMmN6Um1UM0J1ZW1aNlltbFhiVk5aZUVSWE1HTlZWa2RKWjBKWk1VSlJkMDVRVWs5VVZ5OUZVV1ZGUm5sV1IyRkNNRkozVjJwT2FYQUthVm8xVWxaWFdUQnJTa0phVTB0dUx5OUhhVEJ0YjNoS1F6ZE5jMUZFWTFkVk1uRlpSbVU1WlZKbmFVRmFhVTgxYW04dmJsUkhNamhFYkhSa1VXOVdSQXBUVVU1UVdXbEhOMHd3YjFkSGRITlZkaTg0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTBGMFkxcHJSbW95YWs5S1dUY3hlRnBTVFVsUFRtVmxXV1ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDV1VWNFpUQjRVbVpUZGpsNVZrTjVRamh6VEVSdEszWTVabUZvZWt0UksydzBWRWd3VlRSYVFXcG1jMFJFWVhFeVZ3b3hLMVozTjFseWMyeHJObkp1ZGxKaldFZHJiM0ZPWVdsQlVWbEROV1l3U1ZoalpHcG1aazFMZWtOTE1XOXNjVUZtWmpCSWVYaEVXWGh0TTFGUE1ra3ZDa1ExV0ZWMWJtcEtUalpUTjNKWlZYRnFkRzVLU0RsV2VYRXdkQzgyY2xZMk4wUTBaalk0TUdRNVkwMDVMMGRzTW5veWVYaHZhbGN6VTJGMVoxRmxhelFLU1dOV1JEQldXakpQZUZORlV6ZE9Ra3BKVjBkek0zSk5ZbXAwVlhSMmNVRjVjRVZPVW1KaFRuWnJTa2RzWm5aa1dtbGhSMGQ0WWt4Nk5YazNaamN3ZWdwdk1qTlZZVkJYZFM5NFVHdGtURkZJYkU1V2RrOWliMGhOYTBSTlNIQkRUaTlvV1RseGVHcFNXVmN4YldsNWRYUnhXVloxY1dKWmNHNUxiRkpUWldwaENraFVla3BqWWxONlExZFZhMFZGVFdVeFprVmlhRTFaVkc1aVRqUjNZVWhaVEZweWVRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wNjkzMDEwZS0zZTJkLTRkNWItOWZmNC1lMTY1NjdmM2VlN2IuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBaZ3dxRjAwT3N2UlFQVUoxREpNMW5vVUphN1NGRXhmZVdteEtXU2xrSHdsa2R0QVVDZ2hhdXFRRw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMyNHZDbVZpUld4amVrazFaVGx3WVRGWlRVVnFlbWxpVEVnMFpqWjBjM1ZYVUdGS1FrMHdTMGhYU2pOTlJGbE9OVk5wT0hCbmEwZ3ljM1Z6U1dKdlVrazBVMWNLUlM4MFdFWkNZMUpYWkhOUFNsQXZTMU5oWTJoTGRuVTBWbUpSVEZKcmVHSndTall2YzBSTFFsTkhaRmQyZVRSVmFsTnJaREl4VDFaSlRFWm1jVU16UXdwRVJ6UkdSVUp1ZW5aRlNsQkpkV1JXZEcxRE9HTklSWEJEYTJONGVYY3hSMVUyUm1GUFowRmtSakJsTjJKSU5ESnVOVTVCVVhreVZFaDBNMlE1YXl0Q0NrUjNNVXBZVEcwMVZqSktUbmhOVWpKRmRtSndNMjlEVVcweFJuQXZWV1pzZGtNck1uRmFPVzVXVVVKTE9IaHhSRnBaZGpGU1oyOWtabTVoWnpWTVRtOEtlVGgwWW1OdWVFcHFNMGxaVml0alFVY3JSWFp5Um5OTWVUTmlRVmh1VmpSSVFUWnhjVWs0WVVNNGRHNTZiekZ1T0RGWWRubzFOSFJ1U0N0U1lVaDNOd3BrVFZGcWIxSjVXSHBsTUM5eVZGWm1ZMjA0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZWtSalFqbHBZVWhhSzNSb04wTmFOSGs0ZFZOUVZVdHdNMWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCVGpWalp6SXhOemx4VGxneFdVUk5SbmxKWVRCV1NURkhXRVEyT0RSeWJGTnVOVlpEYW5WT1NVVjBPVEJzVW5SamNncFpWMk5yWlRNelF6SkVWVklyVGt4dGJteDRSMXB5VkhBeGJ6RktWbUZIVEdaWGREbHNVVGx0TDFkYVV6QXhWakpSTkhoSVpIcE1UbWRJVUdjeWRIWkxDamhJTkd4VVdrNURNSE5aTXl0M1ZFeE9Wa056UjNKcloxSTNVMlp2T0d4R1dtTmtLMWRzZFdScFZXWm1abTFKYmxSTEwyaGpXRFUyV0dzMGJuZFpSbk1LTTBNNVJrVk1hMHhLVDBobVVYUk1TRUZpTDJVNVFtbDNSWGMwWmtSc2MxRmFVekZaYlRkRFlVWkhlUzl2WWtsd1pUWlJkVEJLT0RKWlEzWm1UbUpxZFFveE5FSjBhSGxIYm1kUEt6TTVlRTVWTDBkMWRYQnJObGxCWTJwRVdrOTRVMUZDVjFvd2MwSjZiVWw1YjNvNVpURjZlRE5TTHpkb1YzVlJaMWd2ZHpndkNuaFFNRVZEY1ZsdlF6UlBZVGhZZGpGc05GZFhjRXhpWVRrck1HbHlaV1JOZEcxTVRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82YTg3ZDIyOS01YmYzLTQ3YWItYjk0My1iOTcyOTZkNzNkM2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYTnZhekVsbks5Nktxb3QxcXRBVXFjbWtTWnduQTVOMGM0STVNRUdLamI4Mng0VXdSUmZjdmtMZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -3626,7 +4089,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:46 GMT
+      - Mon, 02 Jan 2023 14:18:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3636,7 +4099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc5eb92f-1d8c-439e-a080-c31c3e37d6de
+      - 8eef3d25-7f10-4c9e-b06b-f98abf9e0e24
     status: 200 OK
     code: 200
     duration: ""
@@ -3645,12 +4108,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:43:30.018291Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:18:33.595453Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -3659,7 +4122,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:46 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3669,7 +4132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb0dea01-4351-427b-a698-44c4081a545d
+      - 1ca044cb-464a-474f-b1de-eae229ca2c16
     status: 200 OK
     code: 200
     duration: ""
@@ -3678,12 +4141,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:46:40.487481Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:15:15.683014Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -3692,7 +4155,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:46 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3702,7 +4165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6c9c382-ba87-488e-a499-48731c980c6c
+      - f6bc3921-70e1-4f27-95ea-23aca592a4d3
     status: 200 OK
     code: 200
     duration: ""
@@ -3711,12 +4174,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=bcbc9339-3763-4d56-816a-eb052a06040c&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2ebc7f6e-6d42-4acb-b662-cd9b74e40144","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:41:20.429334Z","updated_at":"2022-10-25T08:46:40.511941Z","pool_id":"bcbc9339-3763-4d56-816a-eb052a06040c","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-default-2ebc7f6e6d424","public_ip_v4":"51.15.224.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/508b86d9-ddda-4aa1-8ac1-59ce4434c678","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:29.403518Z","error_message":null,"id":"7a798b1a-b5a8-451d-a104-e66ceb8a78fb","name":"scw-k8spoolconfigminimal-default-7a798b1ab5a84","pool_id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","provider_id":"scaleway://instance/fr-par-1/6516546d-7a61-4303-846d-c3433582fc8d","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:18:33.624739Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "688"
@@ -3725,7 +4188,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:46 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3735,7 +4198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24b6b1d4-82e2-4102-b222-7b8faff9ba2e
+      - 40e36830-a08d-469b-8f5b-298067942aff
     status: 200 OK
     code: 200
     duration: ""
@@ -3744,21 +4207,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=0ad0655e-7382-44fb-96c1-c19fb2d74bfd&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4a05adc5-400b-4a0c-8de0-35a5c986462b&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"92846c91-7502-428c-9304-c3cf247166e6","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:41.173910Z","updated_at":"2022-10-25T08:46:40.471925Z","pool_id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-minimal-92846c9175024","public_ip_v4":"163.172.175.88","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/fadd4615-d3c9-476e-9abe-203c54d3f6ea","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:15:23.132983Z","error_message":null,"id":"b8195374-d07a-464e-a09b-75fe015f2061","name":"scw-k8spoolconfigminimal-minimal-b8195374d07a4","pool_id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","provider_id":"scaleway://instance/fr-par-1/c8d55ffb-2123-443a-9fdc-49d89788abef","public_ip_v4":"51.158.75.237","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:18:33.539802Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:46 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3768,7 +4231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63b9a925-e200-4998-906c-3c06e3c44686
+      - 892b58a6-33b1-4b97-93a6-136315dc1a41
     status: 200 OK
     code: 200
     duration: ""
@@ -3777,12 +4240,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -3791,7 +4254,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:47 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3801,7 +4264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96b9314c-3d90-4018-8374-9d19d7ba77c9
+      - 12bffeeb-f781-4a7e-92ff-acfdfd7922f1
     status: 200 OK
     code: 200
     duration: ""
@@ -3810,12 +4273,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:46:40.487481Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:18:33.595453Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -3824,7 +4287,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:47 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3834,7 +4297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39bf1746-6c27-43b3-a26c-49ccbe33bcd6
+      - 956e1b69-8106-463a-bda0-30f0666334b1
     status: 200 OK
     code: 200
     duration: ""
@@ -3843,21 +4306,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=0ad0655e-7382-44fb-96c1-c19fb2d74bfd&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4a05adc5-400b-4a0c-8de0-35a5c986462b&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"92846c91-7502-428c-9304-c3cf247166e6","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:41.173910Z","updated_at":"2022-10-25T08:46:40.471925Z","pool_id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-minimal-92846c9175024","public_ip_v4":"163.172.175.88","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/fadd4615-d3c9-476e-9abe-203c54d3f6ea","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:15:23.132983Z","error_message":null,"id":"b8195374-d07a-464e-a09b-75fe015f2061","name":"scw-k8spoolconfigminimal-minimal-b8195374d07a4","pool_id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","provider_id":"scaleway://instance/fr-par-1/c8d55ffb-2123-443a-9fdc-49d89788abef","public_ip_v4":"51.158.75.237","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:18:33.539802Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "606"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:47 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3867,7 +4330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 535239c9-5499-4036-b6ae-9f27596e60a9
+      - 8c1e72e7-0f4d-424f-bd7c-99bbbb399b35
     status: 200 OK
     code: 200
     duration: ""
@@ -3876,12 +4339,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQXJDazVtYkZSeWRFbE5OWE5wUzBsU2RYSkNTbU00YmxSMUswWlZaRWx1TURRNFIxRnFVRU4wUkdnM1l6RlZNMkp3TVd4RmRtaEVOWFpWUmxGaVZXaDNPVFlLU25sV1kxZGFiamRvWlRVMEt6VndURmQwVTNCRVZtODRZWGwyUzFsUldsVktOVXRFVTAxR05YWkdiV3RCWVdoVVR5OW9ORlJxVkU1Q1YxRXdMMkpxVmdwNE9FUndWalJ0WVZKaVNUVTRNVFJaUkVod1ZuRnBTM1ZTUTBaVFExRTFLME42ZGt0aWNIWkNNRGw0UmpSbFpsUk9Ua0UzT0RGUFpsbE5VRWc1Y0dkb0NsaExRVUpKVFVOMmN6Um1UM0J1ZW1aNlltbFhiVk5aZUVSWE1HTlZWa2RKWjBKWk1VSlJkMDVRVWs5VVZ5OUZVV1ZGUm5sV1IyRkNNRkozVjJwT2FYQUthVm8xVWxaWFdUQnJTa0phVTB0dUx5OUhhVEJ0YjNoS1F6ZE5jMUZFWTFkVk1uRlpSbVU1WlZKbmFVRmFhVTgxYW04dmJsUkhNamhFYkhSa1VXOVdSQXBUVVU1UVdXbEhOMHd3YjFkSGRITlZkaTg0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTBGMFkxcHJSbW95YWs5S1dUY3hlRnBTVFVsUFRtVmxXV1ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDV1VWNFpUQjRVbVpUZGpsNVZrTjVRamh6VEVSdEszWTVabUZvZWt0UksydzBWRWd3VlRSYVFXcG1jMFJFWVhFeVZ3b3hLMVozTjFseWMyeHJObkp1ZGxKaldFZHJiM0ZPWVdsQlVWbEROV1l3U1ZoalpHcG1aazFMZWtOTE1XOXNjVUZtWmpCSWVYaEVXWGh0TTFGUE1ra3ZDa1ExV0ZWMWJtcEtUalpUTjNKWlZYRnFkRzVLU0RsV2VYRXdkQzgyY2xZMk4wUTBaalk0TUdRNVkwMDVMMGRzTW5veWVYaHZhbGN6VTJGMVoxRmxhelFLU1dOV1JEQldXakpQZUZORlV6ZE9Ra3BKVjBkek0zSk5ZbXAwVlhSMmNVRjVjRVZPVW1KaFRuWnJTa2RzWm5aa1dtbGhSMGQ0WWt4Nk5YazNaamN3ZWdwdk1qTlZZVkJYZFM5NFVHdGtURkZJYkU1V2RrOWliMGhOYTBSTlNIQkRUaTlvV1RseGVHcFNXVmN4YldsNWRYUnhXVloxY1dKWmNHNUxiRkpUWldwaENraFVla3BqWWxONlExZFZhMFZGVFdVeFprVmlhRTFaVkc1aVRqUjNZVWhaVEZweWVRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wNjkzMDEwZS0zZTJkLTRkNWItOWZmNC1lMTY1NjdmM2VlN2IuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBaZ3dxRjAwT3N2UlFQVUoxREpNMW5vVUphN1NGRXhmZVdteEtXU2xrSHdsa2R0QVVDZ2hhdXFRRw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMyNHZDbVZpUld4amVrazFaVGx3WVRGWlRVVnFlbWxpVEVnMFpqWjBjM1ZYVUdGS1FrMHdTMGhYU2pOTlJGbE9OVk5wT0hCbmEwZ3ljM1Z6U1dKdlVrazBVMWNLUlM4MFdFWkNZMUpYWkhOUFNsQXZTMU5oWTJoTGRuVTBWbUpSVEZKcmVHSndTall2YzBSTFFsTkhaRmQyZVRSVmFsTnJaREl4VDFaSlRFWm1jVU16UXdwRVJ6UkdSVUp1ZW5aRlNsQkpkV1JXZEcxRE9HTklSWEJEYTJONGVYY3hSMVUyUm1GUFowRmtSakJsTjJKSU5ESnVOVTVCVVhreVZFaDBNMlE1YXl0Q0NrUjNNVXBZVEcwMVZqSktUbmhOVWpKRmRtSndNMjlEVVcweFJuQXZWV1pzZGtNck1uRmFPVzVXVVVKTE9IaHhSRnBaZGpGU1oyOWtabTVoWnpWTVRtOEtlVGgwWW1OdWVFcHFNMGxaVml0alFVY3JSWFp5Um5OTWVUTmlRVmh1VmpSSVFUWnhjVWs0WVVNNGRHNTZiekZ1T0RGWWRubzFOSFJ1U0N0U1lVaDNOd3BrVFZGcWIxSjVXSHBsTUM5eVZGWm1ZMjA0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZWtSalFqbHBZVWhhSzNSb04wTmFOSGs0ZFZOUVZVdHdNMWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCVGpWalp6SXhOemx4VGxneFdVUk5SbmxKWVRCV1NURkhXRVEyT0RSeWJGTnVOVlpEYW5WT1NVVjBPVEJzVW5SamNncFpWMk5yWlRNelF6SkVWVklyVGt4dGJteDRSMXB5VkhBeGJ6RktWbUZIVEdaWGREbHNVVGx0TDFkYVV6QXhWakpSTkhoSVpIcE1UbWRJVUdjeWRIWkxDamhJTkd4VVdrNURNSE5aTXl0M1ZFeE9Wa056UjNKcloxSTNVMlp2T0d4R1dtTmtLMWRzZFdScFZXWm1abTFKYmxSTEwyaGpXRFUyV0dzMGJuZFpSbk1LTTBNNVJrVk1hMHhLVDBobVVYUk1TRUZpTDJVNVFtbDNSWGMwWmtSc2MxRmFVekZaYlRkRFlVWkhlUzl2WWtsd1pUWlJkVEJLT0RKWlEzWm1UbUpxZFFveE5FSjBhSGxIYm1kUEt6TTVlRTVWTDBkMWRYQnJObGxCWTJwRVdrOTRVMUZDVjFvd2MwSjZiVWw1YjNvNVpURjZlRE5TTHpkb1YzVlJaMWd2ZHpndkNuaFFNRVZEY1ZsdlF6UlBZVGhZZGpGc05GZFhjRXhpWVRrck1HbHlaV1JOZEcxTVRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82YTg3ZDIyOS01YmYzLTQ3YWItYjk0My1iOTcyOTZkNzNkM2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYTnZhekVsbks5Nktxb3QxcXRBVXFjbWtTWnduQTVOMGM0STVNRUdLamI4Mng0VXdSUmZjdmtMZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -3890,7 +4353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:47 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3900,7 +4363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f5d882f-43b6-42ef-9ea8-7d219463dcfd
+      - cddcadc0-d66b-4f50-99af-1bd826392436
     status: 200 OK
     code: 200
     duration: ""
@@ -3909,12 +4372,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:43:30.018291Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:15:15.683014Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -3923,7 +4386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:48 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3933,7 +4396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 245cd568-3539-4247-aca8-2f49581108d7
+      - 496c5c65-63ae-44a6-87da-e76b5238d4d9
     status: 200 OK
     code: 200
     duration: ""
@@ -3942,12 +4405,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=bcbc9339-3763-4d56-816a-eb052a06040c&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2ebc7f6e-6d42-4acb-b662-cd9b74e40144","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:41:20.429334Z","updated_at":"2022-10-25T08:46:40.511941Z","pool_id":"bcbc9339-3763-4d56-816a-eb052a06040c","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-default-2ebc7f6e6d424","public_ip_v4":"51.15.224.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/508b86d9-ddda-4aa1-8ac1-59ce4434c678","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:29.403518Z","error_message":null,"id":"7a798b1a-b5a8-451d-a104-e66ceb8a78fb","name":"scw-k8spoolconfigminimal-default-7a798b1ab5a84","pool_id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","provider_id":"scaleway://instance/fr-par-1/6516546d-7a61-4303-846d-c3433582fc8d","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:18:33.624739Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "688"
@@ -3956,7 +4419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:48 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3966,7 +4429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29ee3494-c092-4b42-8538-78569247ce51
+      - 6cd8656a-db6e-4074-a680-6f0ac6fa6e1e
     status: 200 OK
     code: 200
     duration: ""
@@ -3975,12 +4438,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0ad0655e-7382-44fb-96c1-c19fb2d74bfd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a05adc5-400b-4a0c-8de0-35a5c986462b
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"0ad0655e-7382-44fb-96c1-c19fb2d74bfd","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:43:38.994003Z","updated_at":"2022-10-25T08:46:49.054972432Z","name":"minimal","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:15:21.468381Z","id":"4a05adc5-400b-4a0c-8de0-35a5c986462b","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-01-02T14:18:35.688071550Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "620"
@@ -3989,7 +4452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:49 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3999,7 +4462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5519b8d2-11f3-456f-a965-1bda9949964f
+      - e729754d-94de-459a-9ff6-413be6a7810c
     status: 200 OK
     code: 200
     duration: ""
@@ -4008,12 +4471,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -4022,7 +4485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:49 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4032,7 +4495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 594de484-a5c7-4e65-9ee0-8587f0560f83
+      - 175f82e3-4e88-4af8-bf69-5bd956dbc54c
     status: 200 OK
     code: 200
     duration: ""
@@ -4041,12 +4504,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:41:15.077157Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:14:02.552867Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -4055,7 +4518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:50 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4065,7 +4528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 394cba1b-03c1-473f-bcea-99a3fb373895
+      - 0db91bbc-0f34-4b9b-ba1b-f0c7dc130e88
     status: 200 OK
     code: 200
     duration: ""
@@ -4074,12 +4537,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQXJDazVtYkZSeWRFbE5OWE5wUzBsU2RYSkNTbU00YmxSMUswWlZaRWx1TURRNFIxRnFVRU4wUkdnM1l6RlZNMkp3TVd4RmRtaEVOWFpWUmxGaVZXaDNPVFlLU25sV1kxZGFiamRvWlRVMEt6VndURmQwVTNCRVZtODRZWGwyUzFsUldsVktOVXRFVTAxR05YWkdiV3RCWVdoVVR5OW9ORlJxVkU1Q1YxRXdMMkpxVmdwNE9FUndWalJ0WVZKaVNUVTRNVFJaUkVod1ZuRnBTM1ZTUTBaVFExRTFLME42ZGt0aWNIWkNNRGw0UmpSbFpsUk9Ua0UzT0RGUFpsbE5VRWc1Y0dkb0NsaExRVUpKVFVOMmN6Um1UM0J1ZW1aNlltbFhiVk5aZUVSWE1HTlZWa2RKWjBKWk1VSlJkMDVRVWs5VVZ5OUZVV1ZGUm5sV1IyRkNNRkozVjJwT2FYQUthVm8xVWxaWFdUQnJTa0phVTB0dUx5OUhhVEJ0YjNoS1F6ZE5jMUZFWTFkVk1uRlpSbVU1WlZKbmFVRmFhVTgxYW04dmJsUkhNamhFYkhSa1VXOVdSQXBUVVU1UVdXbEhOMHd3YjFkSGRITlZkaTg0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTBGMFkxcHJSbW95YWs5S1dUY3hlRnBTVFVsUFRtVmxXV1ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDV1VWNFpUQjRVbVpUZGpsNVZrTjVRamh6VEVSdEszWTVabUZvZWt0UksydzBWRWd3VlRSYVFXcG1jMFJFWVhFeVZ3b3hLMVozTjFseWMyeHJObkp1ZGxKaldFZHJiM0ZPWVdsQlVWbEROV1l3U1ZoalpHcG1aazFMZWtOTE1XOXNjVUZtWmpCSWVYaEVXWGh0TTFGUE1ra3ZDa1ExV0ZWMWJtcEtUalpUTjNKWlZYRnFkRzVLU0RsV2VYRXdkQzgyY2xZMk4wUTBaalk0TUdRNVkwMDVMMGRzTW5veWVYaHZhbGN6VTJGMVoxRmxhelFLU1dOV1JEQldXakpQZUZORlV6ZE9Ra3BKVjBkek0zSk5ZbXAwVlhSMmNVRjVjRVZPVW1KaFRuWnJTa2RzWm5aa1dtbGhSMGQ0WWt4Nk5YazNaamN3ZWdwdk1qTlZZVkJYZFM5NFVHdGtURkZJYkU1V2RrOWliMGhOYTBSTlNIQkRUaTlvV1RseGVHcFNXVmN4YldsNWRYUnhXVloxY1dKWmNHNUxiRkpUWldwaENraFVla3BqWWxONlExZFZhMFZGVFdVeFprVmlhRTFaVkc1aVRqUjNZVWhaVEZweWVRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wNjkzMDEwZS0zZTJkLTRkNWItOWZmNC1lMTY1NjdmM2VlN2IuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBaZ3dxRjAwT3N2UlFQVUoxREpNMW5vVUphN1NGRXhmZVdteEtXU2xrSHdsa2R0QVVDZ2hhdXFRRw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMyNHZDbVZpUld4amVrazFaVGx3WVRGWlRVVnFlbWxpVEVnMFpqWjBjM1ZYVUdGS1FrMHdTMGhYU2pOTlJGbE9OVk5wT0hCbmEwZ3ljM1Z6U1dKdlVrazBVMWNLUlM4MFdFWkNZMUpYWkhOUFNsQXZTMU5oWTJoTGRuVTBWbUpSVEZKcmVHSndTall2YzBSTFFsTkhaRmQyZVRSVmFsTnJaREl4VDFaSlRFWm1jVU16UXdwRVJ6UkdSVUp1ZW5aRlNsQkpkV1JXZEcxRE9HTklSWEJEYTJONGVYY3hSMVUyUm1GUFowRmtSakJsTjJKSU5ESnVOVTVCVVhreVZFaDBNMlE1YXl0Q0NrUjNNVXBZVEcwMVZqSktUbmhOVWpKRmRtSndNMjlEVVcweFJuQXZWV1pzZGtNck1uRmFPVzVXVVVKTE9IaHhSRnBaZGpGU1oyOWtabTVoWnpWTVRtOEtlVGgwWW1OdWVFcHFNMGxaVml0alFVY3JSWFp5Um5OTWVUTmlRVmh1VmpSSVFUWnhjVWs0WVVNNGRHNTZiekZ1T0RGWWRubzFOSFJ1U0N0U1lVaDNOd3BrVFZGcWIxSjVXSHBsTUM5eVZGWm1ZMjA0UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZWtSalFqbHBZVWhhSzNSb04wTmFOSGs0ZFZOUVZVdHdNMWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCVGpWalp6SXhOemx4VGxneFdVUk5SbmxKWVRCV1NURkhXRVEyT0RSeWJGTnVOVlpEYW5WT1NVVjBPVEJzVW5SamNncFpWMk5yWlRNelF6SkVWVklyVGt4dGJteDRSMXB5VkhBeGJ6RktWbUZIVEdaWGREbHNVVGx0TDFkYVV6QXhWakpSTkhoSVpIcE1UbWRJVUdjeWRIWkxDamhJTkd4VVdrNURNSE5aTXl0M1ZFeE9Wa056UjNKcloxSTNVMlp2T0d4R1dtTmtLMWRzZFdScFZXWm1abTFKYmxSTEwyaGpXRFUyV0dzMGJuZFpSbk1LTTBNNVJrVk1hMHhLVDBobVVYUk1TRUZpTDJVNVFtbDNSWGMwWmtSc2MxRmFVekZaYlRkRFlVWkhlUzl2WWtsd1pUWlJkVEJLT0RKWlEzWm1UbUpxZFFveE5FSjBhSGxIYm1kUEt6TTVlRTVWTDBkMWRYQnJObGxCWTJwRVdrOTRVMUZDVjFvd2MwSjZiVWw1YjNvNVpURjZlRE5TTHpkb1YzVlJaMWd2ZHpndkNuaFFNRVZEY1ZsdlF6UlBZVGhZZGpGc05GZFhjRXhpWVRrck1HbHlaV1JOZEcxTVRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82YTg3ZDIyOS01YmYzLTQ3YWItYjk0My1iOTcyOTZkNzNkM2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ21pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWdtaW5pbWFsIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ21pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWdtaW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYTnZhekVsbks5Nktxb3QxcXRBVXFjbWtTWnduQTVOMGM0STVNRUdLamI4Mng0VXdSUmZjdmtMZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2652"
@@ -4088,7 +4551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:50 GMT
+      - Mon, 02 Jan 2023 14:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4098,7 +4561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52ba06ed-7d9f-4449-82a6-df0f3668111c
+      - d2826a00-95eb-4b03-af16-17c11cf0ba76
     status: 200 OK
     code: 200
     duration: ""
@@ -4107,12 +4570,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:43:30.018291Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:15:15.683014Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -4121,7 +4584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:50 GMT
+      - Mon, 02 Jan 2023 14:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4131,7 +4594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5b66132-65a3-47a0-80eb-9cd0407b1b3b
+      - 1dbea099-e0fe-48c0-9b1b-ae40b380248c
     status: 200 OK
     code: 200
     duration: ""
@@ -4140,12 +4603,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b/nodes?order_by=created_at_asc&page=1&pool_id=bcbc9339-3763-4d56-816a-eb052a06040c&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e/nodes?order_by=created_at_asc&page=1&pool_id=4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2ebc7f6e-6d42-4acb-b662-cd9b74e40144","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:41:20.429334Z","updated_at":"2022-10-25T08:46:50.013169Z","pool_id":"bcbc9339-3763-4d56-816a-eb052a06040c","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-k8spoolconfigminimal-default-2ebc7f6e6d424","public_ip_v4":"51.15.224.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/508b86d9-ddda-4aa1-8ac1-59ce4434c678","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:29.403518Z","error_message":null,"id":"7a798b1a-b5a8-451d-a104-e66ceb8a78fb","name":"scw-k8spoolconfigminimal-default-7a798b1ab5a84","pool_id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","provider_id":"scaleway://instance/fr-par-1/6516546d-7a61-4303-846d-c3433582fc8d","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:18:33.624739Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "688"
@@ -4154,7 +4617,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:50 GMT
+      - Mon, 02 Jan 2023 14:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4164,7 +4627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 578ba269-d006-4952-a189-18c9ead91a36
+      - 3a1bd6ae-8cd2-4b49-ac6b-832cc08fdae1
     status: 200 OK
     code: 200
     duration: ""
@@ -4173,12 +4636,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bcbc9339-3763-4d56-816a-eb052a06040c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"bcbc9339-3763-4d56-816a-eb052a06040c","cluster_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","created_at":"2022-10-25T08:39:31.933049Z","updated_at":"2022-10-25T08:46:51.515363939Z","name":"default","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.267816Z","id":"4c3fe1da-dff4-4594-8656-b5fa0f0f9a1f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-01-02T14:18:36.378953204Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "620"
@@ -4187,7 +4650,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:51 GMT
+      - Mon, 02 Jan 2023 14:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4197,7 +4660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f31166b-6026-4d2f-a836-bee61381d729
+      - f338962a-f56a-417f-8fc7-3c291d1f1cdd
     status: 200 OK
     code: 200
     duration: ""
@@ -4206,12 +4669,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:46:51.823589231Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:18:36.469442290Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -4220,7 +4683,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:51 GMT
+      - Mon, 02 Jan 2023 14:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4230,7 +4693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37355482-8616-4369-8f01-c9a911088272
+      - 78b1ba17-94bf-4d01-9d63-47c26ff1559c
     status: 200 OK
     code: 200
     duration: ""
@@ -4239,12 +4702,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:46:51.823589Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:18:36.469442Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -4253,7 +4716,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:52 GMT
+      - Mon, 02 Jan 2023 14:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4263,7 +4726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9415d76e-f326-4e0d-b472-29732f882ecd
+      - 7a432f51-0922-4d94-9cd0-a72bf4c0cc7a
     status: 200 OK
     code: 200
     duration: ""
@@ -4272,12 +4735,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:46:51.823589Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:18:36.469442Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -4286,7 +4749,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:58 GMT
+      - Mon, 02 Jan 2023 14:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4296,7 +4759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10e3347c-433e-4130-8fda-2504c6e827f6
+      - 469bf1ef-e9d8-4700-b426-b9010c4a8be6
     status: 200 OK
     code: 200
     duration: ""
@@ -4305,12 +4768,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:46:51.823589Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:18:36.469442Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -4319,7 +4782,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:03 GMT
+      - Mon, 02 Jan 2023 14:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4329,7 +4792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df71bb5c-714f-486b-85ed-8ff2b161dd33
+      - 27dc64a4-9900-4642-aa4a-6ba798cec0b1
     status: 200 OK
     code: 200
     duration: ""
@@ -4338,12 +4801,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"region":"fr-par","id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.477654Z","updated_at":"2022-10-25T08:46:51.823589Z","type":"kapsule","name":"K8SPoolConfigMinimal","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.0693010e-3e2d-4d5b-9ff4-e16567f3ee7b.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6a87d229-5bf3-47ab-b943-b97296d73d3e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.560410Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6a87d229-5bf3-47ab-b943-b97296d73d3e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","ingress":"none","name":"K8SPoolConfigMinimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:18:36.469442Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -4352,7 +4815,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:09 GMT
+      - Mon, 02 Jan 2023 14:18:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4362,7 +4825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29d727be-7ea5-4ea2-9655-e78f3f408599
+      - 85e108f5-05d9-4c6f-8bd5-40cfe2c7a65a
     status: 200 OK
     code: 200
     duration: ""
@@ -4371,12 +4834,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4385,7 +4848,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:14 GMT
+      - Mon, 02 Jan 2023 14:18:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4395,7 +4858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7650683a-9fa0-4c3d-b01d-218247f2bd7f
+      - 0f384396-185f-44b6-9b73-e7de4070577e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4404,12 +4867,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0693010e-3e2d-4d5b-9ff4-e16567f3ee7b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6a87d229-5bf3-47ab-b943-b97296d73d3e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0693010e-3e2d-4d5b-9ff4-e16567f3ee7b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6a87d229-5bf3-47ab-b943-b97296d73d3e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4418,7 +4881,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:14 GMT
+      - Mon, 02 Jan 2023 14:18:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4428,7 +4891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 952d5145-19dd-4796-bc70-2ef5cf93e26a
+      - 11f875a1-7923-4c9b-8680-7fcf2a02b1eb
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-kubelet-args.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-kubelet-args.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:24 GMT
+      - Mon, 02 Jan 2023 14:10:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c2186ab-9354-4558-9a9c-61df6fb292b0
+      - 7cfed6b2-3131-4b2e-951d-70cf41fb808d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"K8SPoolConfigKubeletArgs","description":"","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"version":"1.24.5","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"K8SPoolConfigKubeletArgs","description":"","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"version":"1.24.7","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382130Z","updated_at":"2022-10-25T08:39:25.437433019Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804471Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.534543823Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1344"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5e6012d-a2fe-4a72-8f1b-a4d5ef23fccf
+      - fb476fb9-5348-41f6-9a95-a8268fcfc1c6
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:39:25.437433Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.534544Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1338"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 321736bf-2800-426c-877c-85798a87be1d
+      - 2036e8ec-8a1d-4b7b-9d7e-a1c4794ea49d
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:39:28.852751Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.141041Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1343"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8db96faa-96bc-42e0-b5c6-c2ac4d46811a
+      - 46dc35f6-dd12-429b-bfff-0d2a5cc32b7f
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:39:28.852751Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.141041Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1343"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f67d23d-27d3-4cf0-aa72-9316c07b7a48
+      - 53d47b55-1762-4934-b2ec-be5c147fd30d
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdrdWJlbGV0YXJncyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTR4YjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVFJ3Q2tGMlJpczJSMjVKV2pob1UxSXZiblY1WkVWb1R6RnJXWFp2T0RSbVJ6ZzJRbkJYY214blZ6Um1NR1JwU2lzelZHbDJjRFJMVXpKWVJsYzJObGQ1ZEVNS1RFVTBMM2xTWXpOSE1teFlXVkJWWlRsQk1UTjBOR1ZZUVRsNVdXSkJTM1ZaT1VWS2VsVTJNazV2TDBRdlJqUjRXVzlwZW5wUFJqUXZZM1ZwVlhBM013cFBhSEZPWVd0dllYSmpNRmxDVWpJMVlTdExWbkZKV1cxMVltMHdWbWhYU1N0UGQyNTNjVmxoUjBFNFkzZFhhbXRHTkVKbVVFaFpTMFJCWmpFM1ZXdE9DbFVyZFZkWFFtOVVURWs1UW1WS1dGazVWRXRTTldGT2N6SXpkR1pKUkhkcGRXVTViMG96U3pGNVVsRXZVR3RUY2xwVlZrNUxLM0ZQU1RNM1EybGtObmtLVTJob2JIRkVWbGxuTWxaQ2QydGhNMWR3TlVnd1ZWRmljSE5TTVdWSFNVZHRVaTh5WkVOWVYyUndhbUpPVkdoTVJWaGlTalp6V25vNWMwZHRVVmRTT1FwMmJWSllkVGRPYVZoaU1WTTROMWRWYlhORlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVJUWXlVMlpQT0dkdlpESktRM2RXY1dGR1UwODVTVEV4U1U1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdUazJTRGhCVkd4aUt6ZzRVSEZhU0hocmVHNWxielpRZFdGTlRXeDVTR05KTkUxdFkxZHdjemxWVGs1TmRETmtRUXBCTUU1NGVIUXphV001ZVZwb2JEZ3JUV0pGZVRNeFRDdEJUR2xKUTBFeE5tazFTa3RRVkdwdmFtOXhVRFZ0UWxaUE9IZFhRM0V2ZUdoTU0zZ3pWQzk0Q2psV2NYQnpPV2hRY1dsalQyTm1iVGhGTW1wU2QxTXJZemxWUVdkb1pYVlVkbnByZEZObE1FRlNObEpzU0Vnd2MwRXlMMUZYTUhKNVNXTnRUelp6U0hBS056bDFVR3hsWW01c2RrZEViazlDV210dWVYazVORWM0Wm5KSWNFWnJjVkpUUkRKNlNIWTBLemhuWm5VclkwMDRlVU41ZEdGeVoydFZTbWswUlhVckt3cEhaeXRWWVV0R1VYbEZRVzFtUVdaR1NsTjRSRTFuWmpOM1VETnBNUzlRWkV0b1pFZENWVlJNYW5sc01ub3pValE0YUROT2FGVmFWVVpoVlZkdVNVUmtDbEJrTVZwV1dWSkVkRVF6YmxaSE4zRlpUSGRUYlVGUWJtVXZRMEpOVERsSE1sTjFiUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDA3YTBmOGYtNjA2NC00ZDU3LWI3OWMtYTJhODZmZGZjOWNlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4c3Bvb2xjb25maWdrdWJlbGV0YXJncwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzcjRWRldrZVFLaGllTzBXZFVRM2FyYUQwTWxwUHZpMlV6ZjFPUXA4NnJWVUNXVUJRNDBTaHRYQw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdrdWJlbGV0YXJncyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUkJlazVHYjFoRVZFMTZUVVJGZDAxVVJUQk5WRUY2VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTVpQ20xUFkwbHhXRWQzT1ZOV1dUZEJPRWRSTDBOaVlVbE9NMDlYVTAxUkszWmtjVU5TU21STFJETnFORUpXYkRoRmFsSjVTVXgwS3k5SWF6aEhWa2w2VURFS2NHVnJXRzhyVEV4V1RWTkVXVTR5Y1hCT1J5OXhhSFkxZVRKNVFYWjZhbTlwWmxNclJUSXhRWGw2VVhWVGN6TXJaQ3Q1ZVhCRk5TdDZNV3ByUTFGbU5BcG5ZVGwyYzNGRlZVVnBOVlJSTjBSTVRtVjNUR1ZpTmk5V1VEVlJZekpxYW1VclRGVlZMM0p3VUVkQmJrOUxSV05JUTJFNVRHZFVZekJJU0dSWmJYcFZDbTh4U1VadUt6RXJjbVUxV1RZNFpIWm1MeXM0YW1sS2RpOXJRMVJZVFRreVdXWjJaM1pqYkVaTmMxZGFhMWgwT1VGdGVVRnVNRFY1WVd4NmFrNVRObXNLTW1FNE9FWkVhaTgwU1dwdU9HMHpiSEpSU1ZKWFoxTk1OM05DVEVremRucERXWGhRTTBkVlFYYzJTR1l4ZUZKTU9FTk1TVkZYZURad2JEVTBXbGN2TVFwb05uWlhUMmM0UkZSSE9UaE5OWFJIWW01alEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVV6SnJhMUl4Y25GeE5IQnhhVmgzWmpBMFdVWTJhRUpzYUhOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2FYRlZSMlZ3YTJaWWNGTktObmhGTkhkWk5GWnBSM2hRUlZwWlV6WlJVa04wUlhKQ1VYcHBWbFpHVUhWeWFtOHhkZ3BSY25kb01EUTNkWFZNVmpFeVNFeHpLMjlZVFRWR1Qxb3pUbkl3WldWcGNYQmtVVFJMT1dwTFJXMXNTVTVhZUc4NVIwVkdlRWd4UTBSeU9XSmFNRmhNQ25oMU4wSXlUQzgwVTBkM1drRllZekptYkdWaVVIaE9WRmx6TnpsblJEVkJaV3BLYlRRMk1IVkZSa2gwU1hCeVNYaHNRVE5aZVVvdlEzcFViRGM1VkZNS1ZIWTNheTlvU2twMWNsUktSbk5UTkhGbFVqbHlObTlxVVRsWlV6RmhaR3AwVkdaSmNUVkNkRFpoVVRJNVUxSTBPVEZyYW5FMVRGWkVia2xKTjBKNGJBcEtjM0JFYlV0eWJYVnNVMmhuU0dSMFpFUlJNMVJVUTBSV1IzRmFTelkzYUZReE1YVmllbmxUVnpFeVNXMXFTRTQ1Ym1aMVNYUldaMnMyTkhWSmFVTk5Dbmh3V0ZNMFptWXZhSFIwYldVclptODRhREEyUWtOSlJXZFJORzFqZDJ3M2QwMXhWQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGY5MzM0ZWMtNGJhNS00NzU2LWFiZDItMWJjZDBjZDU3YmY5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4c3Bvb2xjb25maWdrdWJlbGV0YXJncwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnZHg0SEtobVdTMVk2S2VTSTdzTWpWOTN6ZTNBalhIZVE0QjdNclVsVWRFcnJXUG5sc2k2TjVDSA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2684"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3d2cd2e-f8b2-4c40-bc60-87bd7e48b04a
+      - 8261feaf-99e8-48fa-9333-9cf7ad6173db
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:39:28.852751Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.141041Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1343"
@@ -223,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74b186b1-d950-4c91-9cce-9db465b95cf5
+      - de6bf14f-f2f5-4350-8b41-ec87f202de29
     status: 200 OK
     code: 200
     duration: ""
@@ -244,12 +245,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275900968Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930287503Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "640"
@@ -258,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 14:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -268,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65e80932-274b-48bf-b659-faf2dec750c5
+      - 79745540-380a-4947-824c-623508993524
     status: 200 OK
     code: 200
     duration: ""
@@ -277,12 +278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -291,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 14:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -301,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d7da6ac-b336-4842-9216-e062307419f0
+      - 32702d40-aa51-4392-bacc-0288f677130b
     status: 200 OK
     code: 200
     duration: ""
@@ -310,12 +311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -324,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:38 GMT
+      - Mon, 02 Jan 2023 14:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -334,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7cd2deb-7c9d-4cf8-9783-7d1c1e54dd68
+      - f7cb67e4-db1d-4440-90fe-b8f8143e09a6
     status: 200 OK
     code: 200
     duration: ""
@@ -343,12 +344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -357,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:44 GMT
+      - Mon, 02 Jan 2023 14:10:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -367,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da0baacb-a1a6-484c-bdb5-ec0dd77c789c
+      - 06df9f16-522e-4ec0-9d1d-9f7edf8e372a
     status: 200 OK
     code: 200
     duration: ""
@@ -376,12 +377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -390,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:50 GMT
+      - Mon, 02 Jan 2023 14:10:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbe26be5-6ca4-4a99-a1fb-60de67466f57
+      - 866777a9-3f31-4a1e-806b-662c49e49a98
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -423,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:55 GMT
+      - Mon, 02 Jan 2023 14:11:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d24cc814-5511-4c27-8cdb-c50618085421
+      - 23620927-bfe2-419f-96cb-b5d7ed8040d5
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -456,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:01 GMT
+      - Mon, 02 Jan 2023 14:11:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f48fc3ed-55fb-4190-bb01-cd25b0176928
+      - c4824a6f-14ab-455f-a19b-05f758b2cd7e
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -489,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:06 GMT
+      - Mon, 02 Jan 2023 14:11:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76fd3160-481a-48f1-8dbf-8e62fb40bb4e
+      - 5e9d6d2f-faa1-49e3-9937-0335a08b9626
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -522,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:11 GMT
+      - Mon, 02 Jan 2023 14:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0b57c38-71ed-4c99-9c7b-01a8405a5e34
+      - 85c71019-f1f5-4a9e-bb86-a2378dc969dc
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -555,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:16 GMT
+      - Mon, 02 Jan 2023 14:11:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 334d7874-175a-4f4d-beda-02960191d2b8
+      - 7723284d-667a-4e49-9d34-b57e007031dd
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -588,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:21 GMT
+      - Mon, 02 Jan 2023 14:11:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad7245df-d420-4845-a559-53caa8e7912d
+      - 9d951e1b-89af-433d-b9a6-f93273c933a4
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -621,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:27 GMT
+      - Mon, 02 Jan 2023 14:11:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b126d0a-a123-4a61-ad54-d58427136b61
+      - f38ab055-fc84-402a-ba20-cb8777aab9d3
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -654,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:32 GMT
+      - Mon, 02 Jan 2023 14:11:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b70d17d-7f32-462c-a518-61286874dcea
+      - 53fa7a7b-d06d-4d0b-9f30-d2f5bb23e3e5
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -687,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:37 GMT
+      - Mon, 02 Jan 2023 14:11:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c03ffa6-d0ac-4743-957e-eea0af4d429d
+      - 90bd5185-2dbc-488d-aa41-61201fa09132
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -720,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:43 GMT
+      - Mon, 02 Jan 2023 14:11:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7e508e5-6da8-40b7-9279-265b0f300615
+      - e8ba12a3-44d1-4b6a-81dd-3c3adac7dddb
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -753,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:48 GMT
+      - Mon, 02 Jan 2023 14:11:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63dcf072-077b-4dc9-9b16-a490a7462f69
+      - e919ac59-4cc3-4a5a-a600-aa7b697f85ad
     status: 200 OK
     code: 200
     duration: ""
@@ -772,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -786,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:53 GMT
+      - Mon, 02 Jan 2023 14:11:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d855cb3b-a8a0-4d60-abcc-1223eeba377f
+      - 6bb3e267-6a76-4099-879d-0e737cd0ebed
     status: 200 OK
     code: 200
     duration: ""
@@ -805,12 +806,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -819,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:59 GMT
+      - Mon, 02 Jan 2023 14:12:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eae54d60-fe8e-4195-b235-aee5d889d4f9
+      - 7d9e01dc-0f0d-4485-a2b6-bbba2850f3a3
     status: 200 OK
     code: 200
     duration: ""
@@ -838,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -852,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:04 GMT
+      - Mon, 02 Jan 2023 14:12:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecc9f4fb-e240-427b-abb7-34ef98f0cacb
+      - b551581e-fa92-4321-97b2-4d9181264f1f
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -885,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:09 GMT
+      - Mon, 02 Jan 2023 14:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89fc2518-2f94-41c4-9766-eb09c3025de8
+      - b53d9c95-4209-42f5-b99f-1316ac2c34bc
     status: 200 OK
     code: 200
     duration: ""
@@ -904,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -918,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:15 GMT
+      - Mon, 02 Jan 2023 14:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6572bd3e-86ce-4c26-8d95-0727700f2fb6
+      - 25c1d881-5f84-4460-aab5-c66c8c88f220
     status: 200 OK
     code: 200
     duration: ""
@@ -937,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -951,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:20 GMT
+      - Mon, 02 Jan 2023 14:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83088cfe-ffe3-45ed-9c76-bef8a02752f4
+      - 8b66c48d-a4ba-4814-8051-ba2de7961954
     status: 200 OK
     code: 200
     duration: ""
@@ -970,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -984,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:26 GMT
+      - Mon, 02 Jan 2023 14:12:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ee2896a-54fa-4a91-a042-edad82f71eeb
+      - e97d59b3-3c84-48ec-846d-856ea5ca4a69
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1017,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:31 GMT
+      - Mon, 02 Jan 2023 14:12:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4f6cad0-a726-48e2-89b0-320e08539cce
+      - 2af215b4-1e68-4003-9e52-5a48d760e429
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1050,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:36 GMT
+      - Mon, 02 Jan 2023 14:12:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d0036f9-aa89-4c30-bc8d-ae6df951c1ab
+      - 6e567b0e-13ba-44f9-9578-37254be0d6e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1083,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:42 GMT
+      - Mon, 02 Jan 2023 14:12:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5cef861-68c1-4746-ab1c-364c1ee5acc7
+      - 66cc6d36-62d8-4458-9d18-f3f6ed972cc0
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1116,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:47 GMT
+      - Mon, 02 Jan 2023 14:12:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cd338cc-3921-4fe2-a87b-c9bc5fc40ec8
+      - 78e1b145-c35c-4dcd-9bf7-c15f6da22f8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1149,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:53 GMT
+      - Mon, 02 Jan 2023 14:12:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73e7f91c-3dc6-4823-a433-f10bc6dcf6f5
+      - f27264e1-1b6c-4895-be40-d5536fa4f243
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1182,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:58 GMT
+      - Mon, 02 Jan 2023 14:12:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 502210dc-12c5-4bcd-9616-4e721215d475
+      - 81bd6d10-2e31-43dc-91d3-aeefbe3f8cf4
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1202,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1215,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:03 GMT
+      - Mon, 02 Jan 2023 14:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60c92914-a254-4f3b-825d-2754b47d6b84
+      - 4d78667d-1e7a-4470-b549-2197fb34478a
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1235,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1248,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:08 GMT
+      - Mon, 02 Jan 2023 14:13:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe79f311-721f-40a4-9f6a-89a993dfe1df
+      - e770f1a2-ff4f-4c55-a481-517a4d7fd4ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1268,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1281,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:13 GMT
+      - Mon, 02 Jan 2023 14:13:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7986a233-513a-4148-8010-15847c86b3ce
+      - 503e4f5c-a689-491b-adc4-14ce4b7575c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1301,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1314,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:19 GMT
+      - Mon, 02 Jan 2023 14:13:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e698b750-dd00-4b37-9028-c42e87bc4257
+      - 5371ec1b-56f4-45a3-b3ae-a5c585ba883f
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1347,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:24 GMT
+      - Mon, 02 Jan 2023 14:13:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa3cc82a-c2f8-4fb7-ae6d-688cbd61f1eb
+      - e4fbcc45-0f8c-43bd-a903-1c88e0456041
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1380,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:30 GMT
+      - Mon, 02 Jan 2023 14:13:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6be05746-2064-467f-a2b9-7a0648a88cea
+      - 54c3913e-4635-403b-b46b-8a9ef3ccccb3
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1413,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:35 GMT
+      - Mon, 02 Jan 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0064d58f-b6d5-4b75-9b41-e6d5257fcb9b
+      - 1edaae08-63a7-4686-ba56-3b71a8301047
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1446,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:41 GMT
+      - Mon, 02 Jan 2023 14:13:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c73d7cd1-48b1-4867-b57f-71ef98c5ae5b
+      - 2ff3fba1-8636-4a02-91ec-30fe52c1e121
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,12 +1466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1479,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:46 GMT
+      - Mon, 02 Jan 2023 14:13:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 793214c4-6757-48ab-9770-06ef13292249
+      - 13dd3377-fbf9-471e-8561-2a7b9c75e699
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,12 +1499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1512,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:52 GMT
+      - Mon, 02 Jan 2023 14:13:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28d73cf5-598c-4ffe-9a09-7705830d4fdc
+      - 2b2e640c-db0a-48a8-96f8-c8b91284717c
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,12 +1532,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1545,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:57 GMT
+      - Mon, 02 Jan 2023 14:13:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbb9cf5c-adbd-47d3-ba9b-2f899720b4c0
+      - f4dfbeea-5e93-40fc-a0c9-838cf0ae3ab0
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,12 +1565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1578,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:02 GMT
+      - Mon, 02 Jan 2023 14:13:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d31fbe2-27f4-4b48-a0dc-c45b1f821ae5
+      - d1fd73c0-2078-4219-8c15-ba6b14ccbf22
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,12 +1598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1611,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:08 GMT
+      - Mon, 02 Jan 2023 14:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06034135-1712-4dd0-b200-69e2e6eb668a
+      - ba7481be-aa28-42f3-b923-3a749144f109
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,12 +1631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1644,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:13 GMT
+      - Mon, 02 Jan 2023 14:14:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8b256a2-36a3-4bed-9454-7b63291896b0
+      - 99e45f66-9d34-4de1-b06f-a3428f13a61c
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,12 +1664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1677,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:19 GMT
+      - Mon, 02 Jan 2023 14:14:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1723b9e8-d102-427e-8b6a-3f964527252f
+      - 2fba7519-9c16-4d47-9ef3-4651af1160ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,12 +1697,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1710,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:24 GMT
+      - Mon, 02 Jan 2023 14:14:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a01b4c81-7c46-4492-8adb-a2d37faab832
+      - de076baf-8340-4ea8-88b5-e86daa2c5a34
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1730,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1743,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:29 GMT
+      - Mon, 02 Jan 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43c07a5d-a762-47e6-8bdb-f8d7c2cf7dac
+      - d209d64d-5f9e-4816-b57d-bf3a78d9779d
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,12 +1763,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1776,7 +1777,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:34 GMT
+      - Mon, 02 Jan 2023 14:14:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe6515d4-1d0a-4e46-bc36-3bbffc166cba
+      - d84c727d-b053-4dd2-a8e4-c35241a95add
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,12 +1796,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1809,7 +1810,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:40 GMT
+      - Mon, 02 Jan 2023 14:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8efa00cb-4748-413d-80c9-3699a927591f
+      - 3a081b67-4d80-4447-840a-25f4343c1782
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,12 +1829,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:39:32.275901Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "637"
@@ -1842,7 +1843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:45 GMT
+      - Mon, 02 Jan 2023 14:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d55b83e-fc7e-4330-9b0b-143fbe9afb45
+      - 6cf8d337-9751-44cf-9fa6-8871f928b4e1
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,12 +1862,111 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:49.096751Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "637"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c39f6c98-edec-4d17-9891-87dd24a21400
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "637"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 05dc1187-6278-4db6-bb72-215f28ba89ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:10:38.930288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "637"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 925077f2-fb22-4cb0-a24a-8dc0d9fa6d1b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:14:57.579914Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "635"
@@ -1875,7 +1975,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:51 GMT
+      - Mon, 02 Jan 2023 14:14:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +1985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78265187-e5f5-4eb8-b04c-0f52c8cf15fa
+      - 9cd6ef6d-6b9f-4ba2-8070-7b256bc49ecc
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,12 +1994,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:41:43.566306Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:11:37.417740Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1335"
@@ -1908,7 +2008,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:51 GMT
+      - Mon, 02 Jan 2023 14:14:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +2018,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57b0e7a7-2832-4763-8195-f360199e8857
+      - e79c0864-e5f2-435a-a0d0-e2d3ae297800
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,12 +2027,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:49.096751Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:14:57.579914Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "635"
@@ -1941,7 +2041,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:51 GMT
+      - Mon, 02 Jan 2023 14:14:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1951,7 +2051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1c0304f-279d-4250-a0ca-8eeaaa95de0f
+      - c963f7a3-e440-4ed6-b8e9-115417a1ba1b
     status: 200 OK
     code: 200
     duration: ""
@@ -1960,21 +2060,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/nodes?order_by=created_at_asc&page=1&pool_id=55121294-6733-420d-883d-dade37e88938&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/nodes?order_by=created_at_asc&page=1&pool_id=0382e71c-708e-4fce-a6c8-2eee1b48b720&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"03546773-886a-476a-b02e-7de7b95c7d96","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:40:55.843312Z","updated_at":"2022-10-25T08:43:49.079145Z","pool_id":"55121294-6733-420d-883d-dade37e88938","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigkubeletargs-default-035467738","public_ip_v4":"51.15.214.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/5434ba03-93d2-4644-bd51-52d4cc8868a0","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:11:52.655712Z","error_message":null,"id":"2a2b57c9-c535-49a7-a957-441ae91a5d5f","name":"scw-k8spoolconfigkubeletargs-default-2a2b57c9c","pool_id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","provider_id":"scaleway://instance/fr-par-1/88aef1f1-e3c2-4a85-94a6-7909703e39f6","public_ip_v4":"51.158.77.29","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:57.566538Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:52 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1984,7 +2084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 812ea8cf-59db-40df-9d05-cabdecd7a9ad
+      - 699f6d07-a5a2-4647-981f-8924e88b5f31
     status: 200 OK
     code: 200
     duration: ""
@@ -1993,12 +2093,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:41:43.566306Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:11:37.417740Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1335"
@@ -2007,7 +2107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:52 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2017,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 914c18cb-9f3b-4c1b-b7cb-631237a30f46
+      - f28eae60-836a-452a-89e8-eb13cf99f951
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,12 +2126,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:49.096751Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:14:57.579914Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "635"
@@ -2040,7 +2140,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:52 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2050,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 265e8d54-9de2-460c-857b-88c6a387db73
+      - d00af64a-865c-4334-b37b-9753eaa82916
     status: 200 OK
     code: 200
     duration: ""
@@ -2059,12 +2159,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:41:43.566306Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:11:37.417740Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1335"
@@ -2073,7 +2173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:53 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2083,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37f6d640-0725-468a-8d74-1a2062bf9b8b
+      - 566723e0-5da9-476f-aee1-01bbc33b869b
     status: 200 OK
     code: 200
     duration: ""
@@ -2092,12 +2192,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdrdWJlbGV0YXJncyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTR4YjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVFJ3Q2tGMlJpczJSMjVKV2pob1UxSXZiblY1WkVWb1R6RnJXWFp2T0RSbVJ6ZzJRbkJYY214blZ6Um1NR1JwU2lzelZHbDJjRFJMVXpKWVJsYzJObGQ1ZEVNS1RFVTBMM2xTWXpOSE1teFlXVkJWWlRsQk1UTjBOR1ZZUVRsNVdXSkJTM1ZaT1VWS2VsVTJNazV2TDBRdlJqUjRXVzlwZW5wUFJqUXZZM1ZwVlhBM013cFBhSEZPWVd0dllYSmpNRmxDVWpJMVlTdExWbkZKV1cxMVltMHdWbWhYU1N0UGQyNTNjVmxoUjBFNFkzZFhhbXRHTkVKbVVFaFpTMFJCWmpFM1ZXdE9DbFVyZFZkWFFtOVVURWs1UW1WS1dGazVWRXRTTldGT2N6SXpkR1pKUkhkcGRXVTViMG96U3pGNVVsRXZVR3RUY2xwVlZrNUxLM0ZQU1RNM1EybGtObmtLVTJob2JIRkVWbGxuTWxaQ2QydGhNMWR3TlVnd1ZWRmljSE5TTVdWSFNVZHRVaTh5WkVOWVYyUndhbUpPVkdoTVJWaGlTalp6V25vNWMwZHRVVmRTT1FwMmJWSllkVGRPYVZoaU1WTTROMWRWYlhORlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVJUWXlVMlpQT0dkdlpESktRM2RXY1dGR1UwODVTVEV4U1U1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdUazJTRGhCVkd4aUt6ZzRVSEZhU0hocmVHNWxielpRZFdGTlRXeDVTR05KTkUxdFkxZHdjemxWVGs1TmRETmtRUXBCTUU1NGVIUXphV001ZVZwb2JEZ3JUV0pGZVRNeFRDdEJUR2xKUTBFeE5tazFTa3RRVkdwdmFtOXhVRFZ0UWxaUE9IZFhRM0V2ZUdoTU0zZ3pWQzk0Q2psV2NYQnpPV2hRY1dsalQyTm1iVGhGTW1wU2QxTXJZemxWUVdkb1pYVlVkbnByZEZObE1FRlNObEpzU0Vnd2MwRXlMMUZYTUhKNVNXTnRUelp6U0hBS056bDFVR3hsWW01c2RrZEViazlDV210dWVYazVORWM0Wm5KSWNFWnJjVkpUUkRKNlNIWTBLemhuWm5VclkwMDRlVU41ZEdGeVoydFZTbWswUlhVckt3cEhaeXRWWVV0R1VYbEZRVzFtUVdaR1NsTjRSRTFuWmpOM1VETnBNUzlRWkV0b1pFZENWVlJNYW5sc01ub3pValE0YUROT2FGVmFWVVpoVlZkdVNVUmtDbEJrTVZwV1dWSkVkRVF6YmxaSE4zRlpUSGRUYlVGUWJtVXZRMEpOVERsSE1sTjFiUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDA3YTBmOGYtNjA2NC00ZDU3LWI3OWMtYTJhODZmZGZjOWNlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4c3Bvb2xjb25maWdrdWJlbGV0YXJncwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzcjRWRldrZVFLaGllTzBXZFVRM2FyYUQwTWxwUHZpMlV6ZjFPUXA4NnJWVUNXVUJRNDBTaHRYQw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdrdWJlbGV0YXJncyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUkJlazVHYjFoRVZFMTZUVVJGZDAxVVJUQk5WRUY2VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTVpQ20xUFkwbHhXRWQzT1ZOV1dUZEJPRWRSTDBOaVlVbE9NMDlYVTAxUkszWmtjVU5TU21STFJETnFORUpXYkRoRmFsSjVTVXgwS3k5SWF6aEhWa2w2VURFS2NHVnJXRzhyVEV4V1RWTkVXVTR5Y1hCT1J5OXhhSFkxZVRKNVFYWjZhbTlwWmxNclJUSXhRWGw2VVhWVGN6TXJaQ3Q1ZVhCRk5TdDZNV3ByUTFGbU5BcG5ZVGwyYzNGRlZVVnBOVlJSTjBSTVRtVjNUR1ZpTmk5V1VEVlJZekpxYW1VclRGVlZMM0p3VUVkQmJrOUxSV05JUTJFNVRHZFVZekJJU0dSWmJYcFZDbTh4U1VadUt6RXJjbVUxV1RZNFpIWm1MeXM0YW1sS2RpOXJRMVJZVFRreVdXWjJaM1pqYkVaTmMxZGFhMWgwT1VGdGVVRnVNRFY1WVd4NmFrNVRObXNLTW1FNE9FWkVhaTgwU1dwdU9HMHpiSEpSU1ZKWFoxTk1OM05DVEVremRucERXWGhRTTBkVlFYYzJTR1l4ZUZKTU9FTk1TVkZYZURad2JEVTBXbGN2TVFwb05uWlhUMmM0UkZSSE9UaE5OWFJIWW01alEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVV6SnJhMUl4Y25GeE5IQnhhVmgzWmpBMFdVWTJhRUpzYUhOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2FYRlZSMlZ3YTJaWWNGTktObmhGTkhkWk5GWnBSM2hRUlZwWlV6WlJVa04wUlhKQ1VYcHBWbFpHVUhWeWFtOHhkZ3BSY25kb01EUTNkWFZNVmpFeVNFeHpLMjlZVFRWR1Qxb3pUbkl3WldWcGNYQmtVVFJMT1dwTFJXMXNTVTVhZUc4NVIwVkdlRWd4UTBSeU9XSmFNRmhNQ25oMU4wSXlUQzgwVTBkM1drRllZekptYkdWaVVIaE9WRmx6TnpsblJEVkJaV3BLYlRRMk1IVkZSa2gwU1hCeVNYaHNRVE5aZVVvdlEzcFViRGM1VkZNS1ZIWTNheTlvU2twMWNsUktSbk5UTkhGbFVqbHlObTlxVVRsWlV6RmhaR3AwVkdaSmNUVkNkRFpoVVRJNVUxSTBPVEZyYW5FMVRGWkVia2xKTjBKNGJBcEtjM0JFYlV0eWJYVnNVMmhuU0dSMFpFUlJNMVJVUTBSV1IzRmFTelkzYUZReE1YVmllbmxUVnpFeVNXMXFTRTQ1Ym1aMVNYUldaMnMyTkhWSmFVTk5Dbmh3V0ZNMFptWXZhSFIwYldVclptODRhREEyUWtOSlJXZFJORzFqZDJ3M2QwMXhWQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGY5MzM0ZWMtNGJhNS00NzU2LWFiZDItMWJjZDBjZDU3YmY5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4c3Bvb2xjb25maWdrdWJlbGV0YXJncwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnZHg0SEtobVdTMVk2S2VTSTdzTWpWOTN6ZTNBalhIZVE0QjdNclVsVWRFcnJXUG5sc2k2TjVDSA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2684"
@@ -2106,7 +2206,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:53 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2116,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28d77bc3-6807-4eb0-9c45-77bb919de4f6
+      - 7d41009e-f522-41c0-ab98-d067884664f0
     status: 200 OK
     code: 200
     duration: ""
@@ -2125,12 +2225,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:49.096751Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:14:57.579914Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "635"
@@ -2139,7 +2239,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:53 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 486e5cd3-d718-47b2-925d-be907bbf6cf1
+      - e94ad8be-360b-4dff-8cf8-9150567eb744
     status: 200 OK
     code: 200
     duration: ""
@@ -2158,21 +2258,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/nodes?order_by=created_at_asc&page=1&pool_id=55121294-6733-420d-883d-dade37e88938&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/nodes?order_by=created_at_asc&page=1&pool_id=0382e71c-708e-4fce-a6c8-2eee1b48b720&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"03546773-886a-476a-b02e-7de7b95c7d96","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:40:55.843312Z","updated_at":"2022-10-25T08:43:49.079145Z","pool_id":"55121294-6733-420d-883d-dade37e88938","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigkubeletargs-default-035467738","public_ip_v4":"51.15.214.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/5434ba03-93d2-4644-bd51-52d4cc8868a0","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:11:52.655712Z","error_message":null,"id":"2a2b57c9-c535-49a7-a957-441ae91a5d5f","name":"scw-k8spoolconfigkubeletargs-default-2a2b57c9c","pool_id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","provider_id":"scaleway://instance/fr-par-1/88aef1f1-e3c2-4a85-94a6-7909703e39f6","public_ip_v4":"51.158.77.29","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:57.566538Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:54 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d26b048-0d50-44af-a8bb-5cf0022a2680
+      - 47b5786a-be0a-4047-b4ed-e8eab258a1ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,12 +2291,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:41:43.566306Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:11:37.417740Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1335"
@@ -2205,7 +2305,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:54 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2215,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abb3e013-8db2-4263-a5d3-3679bd352cf3
+      - 914dc7e4-33dc-42bb-bb4c-f015ba39675e
     status: 200 OK
     code: 200
     duration: ""
@@ -2224,12 +2324,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdrdWJlbGV0YXJncyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTR4YjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVFJ3Q2tGMlJpczJSMjVKV2pob1UxSXZiblY1WkVWb1R6RnJXWFp2T0RSbVJ6ZzJRbkJYY214blZ6Um1NR1JwU2lzelZHbDJjRFJMVXpKWVJsYzJObGQ1ZEVNS1RFVTBMM2xTWXpOSE1teFlXVkJWWlRsQk1UTjBOR1ZZUVRsNVdXSkJTM1ZaT1VWS2VsVTJNazV2TDBRdlJqUjRXVzlwZW5wUFJqUXZZM1ZwVlhBM013cFBhSEZPWVd0dllYSmpNRmxDVWpJMVlTdExWbkZKV1cxMVltMHdWbWhYU1N0UGQyNTNjVmxoUjBFNFkzZFhhbXRHTkVKbVVFaFpTMFJCWmpFM1ZXdE9DbFVyZFZkWFFtOVVURWs1UW1WS1dGazVWRXRTTldGT2N6SXpkR1pKUkhkcGRXVTViMG96U3pGNVVsRXZVR3RUY2xwVlZrNUxLM0ZQU1RNM1EybGtObmtLVTJob2JIRkVWbGxuTWxaQ2QydGhNMWR3TlVnd1ZWRmljSE5TTVdWSFNVZHRVaTh5WkVOWVYyUndhbUpPVkdoTVJWaGlTalp6V25vNWMwZHRVVmRTT1FwMmJWSllkVGRPYVZoaU1WTTROMWRWYlhORlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVJUWXlVMlpQT0dkdlpESktRM2RXY1dGR1UwODVTVEV4U1U1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdUazJTRGhCVkd4aUt6ZzRVSEZhU0hocmVHNWxielpRZFdGTlRXeDVTR05KTkUxdFkxZHdjemxWVGs1TmRETmtRUXBCTUU1NGVIUXphV001ZVZwb2JEZ3JUV0pGZVRNeFRDdEJUR2xKUTBFeE5tazFTa3RRVkdwdmFtOXhVRFZ0UWxaUE9IZFhRM0V2ZUdoTU0zZ3pWQzk0Q2psV2NYQnpPV2hRY1dsalQyTm1iVGhGTW1wU2QxTXJZemxWUVdkb1pYVlVkbnByZEZObE1FRlNObEpzU0Vnd2MwRXlMMUZYTUhKNVNXTnRUelp6U0hBS056bDFVR3hsWW01c2RrZEViazlDV210dWVYazVORWM0Wm5KSWNFWnJjVkpUUkRKNlNIWTBLemhuWm5VclkwMDRlVU41ZEdGeVoydFZTbWswUlhVckt3cEhaeXRWWVV0R1VYbEZRVzFtUVdaR1NsTjRSRTFuWmpOM1VETnBNUzlRWkV0b1pFZENWVlJNYW5sc01ub3pValE0YUROT2FGVmFWVVpoVlZkdVNVUmtDbEJrTVZwV1dWSkVkRVF6YmxaSE4zRlpUSGRUYlVGUWJtVXZRMEpOVERsSE1sTjFiUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDA3YTBmOGYtNjA2NC00ZDU3LWI3OWMtYTJhODZmZGZjOWNlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4c3Bvb2xjb25maWdrdWJlbGV0YXJncwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzcjRWRldrZVFLaGllTzBXZFVRM2FyYUQwTWxwUHZpMlV6ZjFPUXA4NnJWVUNXVUJRNDBTaHRYQw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdrdWJlbGV0YXJncyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUkJlazVHYjFoRVZFMTZUVVJGZDAxVVJUQk5WRUY2VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTVpQ20xUFkwbHhXRWQzT1ZOV1dUZEJPRWRSTDBOaVlVbE9NMDlYVTAxUkszWmtjVU5TU21STFJETnFORUpXYkRoRmFsSjVTVXgwS3k5SWF6aEhWa2w2VURFS2NHVnJXRzhyVEV4V1RWTkVXVTR5Y1hCT1J5OXhhSFkxZVRKNVFYWjZhbTlwWmxNclJUSXhRWGw2VVhWVGN6TXJaQ3Q1ZVhCRk5TdDZNV3ByUTFGbU5BcG5ZVGwyYzNGRlZVVnBOVlJSTjBSTVRtVjNUR1ZpTmk5V1VEVlJZekpxYW1VclRGVlZMM0p3VUVkQmJrOUxSV05JUTJFNVRHZFVZekJJU0dSWmJYcFZDbTh4U1VadUt6RXJjbVUxV1RZNFpIWm1MeXM0YW1sS2RpOXJRMVJZVFRreVdXWjJaM1pqYkVaTmMxZGFhMWgwT1VGdGVVRnVNRFY1WVd4NmFrNVRObXNLTW1FNE9FWkVhaTgwU1dwdU9HMHpiSEpSU1ZKWFoxTk1OM05DVEVremRucERXWGhRTTBkVlFYYzJTR1l4ZUZKTU9FTk1TVkZYZURad2JEVTBXbGN2TVFwb05uWlhUMmM0UkZSSE9UaE5OWFJIWW01alEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVV6SnJhMUl4Y25GeE5IQnhhVmgzWmpBMFdVWTJhRUpzYUhOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2FYRlZSMlZ3YTJaWWNGTktObmhGTkhkWk5GWnBSM2hRUlZwWlV6WlJVa04wUlhKQ1VYcHBWbFpHVUhWeWFtOHhkZ3BSY25kb01EUTNkWFZNVmpFeVNFeHpLMjlZVFRWR1Qxb3pUbkl3WldWcGNYQmtVVFJMT1dwTFJXMXNTVTVhZUc4NVIwVkdlRWd4UTBSeU9XSmFNRmhNQ25oMU4wSXlUQzgwVTBkM1drRllZekptYkdWaVVIaE9WRmx6TnpsblJEVkJaV3BLYlRRMk1IVkZSa2gwU1hCeVNYaHNRVE5aZVVvdlEzcFViRGM1VkZNS1ZIWTNheTlvU2twMWNsUktSbk5UTkhGbFVqbHlObTlxVVRsWlV6RmhaR3AwVkdaSmNUVkNkRFpoVVRJNVUxSTBPVEZyYW5FMVRGWkVia2xKTjBKNGJBcEtjM0JFYlV0eWJYVnNVMmhuU0dSMFpFUlJNMVJVUTBSV1IzRmFTelkzYUZReE1YVmllbmxUVnpFeVNXMXFTRTQ1Ym1aMVNYUldaMnMyTkhWSmFVTk5Dbmh3V0ZNMFptWXZhSFIwYldVclptODRhREEyUWtOSlJXZFJORzFqZDJ3M2QwMXhWQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGY5MzM0ZWMtNGJhNS00NzU2LWFiZDItMWJjZDBjZDU3YmY5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4c3Bvb2xjb25maWdrdWJlbGV0YXJncwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnZHg0SEtobVdTMVk2S2VTSTdzTWpWOTN6ZTNBalhIZVE0QjdNclVsVWRFcnJXUG5sc2k2TjVDSA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2684"
@@ -2238,7 +2338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:54 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2248,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e32f021d-85fe-46e9-89de-83fe276c6f71
+      - e0f8b909-691b-462b-8178-d8474460b38f
     status: 200 OK
     code: 200
     duration: ""
@@ -2257,12 +2357,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:49.096751Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"1337"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:14:57.579914Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "635"
@@ -2271,7 +2371,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:55 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2281,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbac6769-f4fd-4c06-9ee8-dbbb1da0d1b8
+      - db244a87-99e9-4412-a4ca-b70a8e2fbf1f
     status: 200 OK
     code: 200
     duration: ""
@@ -2290,21 +2390,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/nodes?order_by=created_at_asc&page=1&pool_id=55121294-6733-420d-883d-dade37e88938&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/nodes?order_by=created_at_asc&page=1&pool_id=0382e71c-708e-4fce-a6c8-2eee1b48b720&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"03546773-886a-476a-b02e-7de7b95c7d96","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:40:55.843312Z","updated_at":"2022-10-25T08:43:49.079145Z","pool_id":"55121294-6733-420d-883d-dade37e88938","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigkubeletargs-default-035467738","public_ip_v4":"51.15.214.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/5434ba03-93d2-4644-bd51-52d4cc8868a0","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:11:52.655712Z","error_message":null,"id":"2a2b57c9-c535-49a7-a957-441ae91a5d5f","name":"scw-k8spoolconfigkubeletargs-default-2a2b57c9c","pool_id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","provider_id":"scaleway://instance/fr-par-1/88aef1f1-e3c2-4a85-94a6-7909703e39f6","public_ip_v4":"51.158.77.29","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:57.566538Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:55 GMT
+      - Mon, 02 Jan 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 620be0d4-da6b-4be8-95f9-1d505813dc05
+      - 13db8908-3e35-413e-94f3-4b6063e555d8
     status: 200 OK
     code: 200
     duration: ""
@@ -2325,12 +2425,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:56.094601481Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"50"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:15:00.052889164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "636"
@@ -2339,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:57 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2349,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1aefdfa-4618-4eb5-8edd-b6c516e35cb3
+      - dd9e12b8-06a1-4453-87d9-e08b64d851be
     status: 200 OK
     code: 200
     duration: ""
@@ -2358,12 +2458,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:56.094601Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"50"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:15:00.052889Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "633"
@@ -2372,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:57 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2382,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7016b7e-6e31-47fb-93f5-e457df6a93e0
+      - 1f544f33-6f5b-4581-af07-ab8620b0100b
     status: 200 OK
     code: 200
     duration: ""
@@ -2391,12 +2491,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:56.094601Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"50"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:15:00.052889Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "633"
@@ -2405,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:57 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2415,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ebbcc84-96b3-453b-80db-2713dedc0f8c
+      - 71b53d36-bf10-4e81-8ff5-2e39f22b2446
     status: 200 OK
     code: 200
     duration: ""
@@ -2424,21 +2524,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/nodes?order_by=created_at_asc&page=1&pool_id=55121294-6733-420d-883d-dade37e88938&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/nodes?order_by=created_at_asc&page=1&pool_id=0382e71c-708e-4fce-a6c8-2eee1b48b720&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"03546773-886a-476a-b02e-7de7b95c7d96","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:40:55.843312Z","updated_at":"2022-10-25T08:43:49.079145Z","pool_id":"55121294-6733-420d-883d-dade37e88938","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigkubeletargs-default-035467738","public_ip_v4":"51.15.214.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/5434ba03-93d2-4644-bd51-52d4cc8868a0","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:11:52.655712Z","error_message":null,"id":"2a2b57c9-c535-49a7-a957-441ae91a5d5f","name":"scw-k8spoolconfigkubeletargs-default-2a2b57c9c","pool_id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","provider_id":"scaleway://instance/fr-par-1/88aef1f1-e3c2-4a85-94a6-7909703e39f6","public_ip_v4":"51.158.77.29","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:57.566538Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:57 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2448,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ce97c62-9d56-48d6-b0c0-55f0185b6b95
+      - 4d152a94-1b15-4e27-863f-12fe272fe9f4
     status: 200 OK
     code: 200
     duration: ""
@@ -2457,12 +2557,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:41:43.566306Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:11:37.417740Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1335"
@@ -2471,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:58 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2481,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13d3268b-7924-40d7-943d-004163493e85
+      - 040b9993-161f-432e-b706-3f1e6c9d1cbb
     status: 200 OK
     code: 200
     duration: ""
@@ -2490,12 +2590,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:56.094601Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"50"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:15:00.052889Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "633"
@@ -2504,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:58 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2514,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0612510d-7c15-4eaf-8398-9c5bd5d2b865
+      - f9aafe45-1dfb-4b3a-b61e-ffa729b89848
     status: 200 OK
     code: 200
     duration: ""
@@ -2523,12 +2623,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:41:43.566306Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:11:37.417740Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1335"
@@ -2537,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:00 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2547,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e33f3698-dd5f-4921-8de1-83fe5c802b10
+      - 0e34fc86-256f-41fb-b162-3064bc416fd6
     status: 200 OK
     code: 200
     duration: ""
@@ -2556,12 +2656,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdrdWJlbGV0YXJncyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGxPUkVFMFRYcHJlVTR4YjFoRVZFMTVUVlJCZVU1RVFUUk5lbXQ1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVFJ3Q2tGMlJpczJSMjVKV2pob1UxSXZiblY1WkVWb1R6RnJXWFp2T0RSbVJ6ZzJRbkJYY214blZ6Um1NR1JwU2lzelZHbDJjRFJMVXpKWVJsYzJObGQ1ZEVNS1RFVTBMM2xTWXpOSE1teFlXVkJWWlRsQk1UTjBOR1ZZUVRsNVdXSkJTM1ZaT1VWS2VsVTJNazV2TDBRdlJqUjRXVzlwZW5wUFJqUXZZM1ZwVlhBM013cFBhSEZPWVd0dllYSmpNRmxDVWpJMVlTdExWbkZKV1cxMVltMHdWbWhYU1N0UGQyNTNjVmxoUjBFNFkzZFhhbXRHTkVKbVVFaFpTMFJCWmpFM1ZXdE9DbFVyZFZkWFFtOVVURWs1UW1WS1dGazVWRXRTTldGT2N6SXpkR1pKUkhkcGRXVTViMG96U3pGNVVsRXZVR3RUY2xwVlZrNUxLM0ZQU1RNM1EybGtObmtLVTJob2JIRkVWbGxuTWxaQ2QydGhNMWR3TlVnd1ZWRmljSE5TTVdWSFNVZHRVaTh5WkVOWVYyUndhbUpPVkdoTVJWaGlTalp6V25vNWMwZHRVVmRTT1FwMmJWSllkVGRPYVZoaU1WTTROMWRWYlhORlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVJUWXlVMlpQT0dkdlpESktRM2RXY1dGR1UwODVTVEV4U1U1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFdUazJTRGhCVkd4aUt6ZzRVSEZhU0hocmVHNWxielpRZFdGTlRXeDVTR05KTkUxdFkxZHdjemxWVGs1TmRETmtRUXBCTUU1NGVIUXphV001ZVZwb2JEZ3JUV0pGZVRNeFRDdEJUR2xKUTBFeE5tazFTa3RRVkdwdmFtOXhVRFZ0UWxaUE9IZFhRM0V2ZUdoTU0zZ3pWQzk0Q2psV2NYQnpPV2hRY1dsalQyTm1iVGhGTW1wU2QxTXJZemxWUVdkb1pYVlVkbnByZEZObE1FRlNObEpzU0Vnd2MwRXlMMUZYTUhKNVNXTnRUelp6U0hBS056bDFVR3hsWW01c2RrZEViazlDV210dWVYazVORWM0Wm5KSWNFWnJjVkpUUkRKNlNIWTBLemhuWm5VclkwMDRlVU41ZEdGeVoydFZTbWswUlhVckt3cEhaeXRWWVV0R1VYbEZRVzFtUVdaR1NsTjRSRTFuWmpOM1VETnBNUzlRWkV0b1pFZENWVlJNYW5sc01ub3pValE0YUROT2FGVmFWVVpoVlZkdVNVUmtDbEJrTVZwV1dWSkVkRVF6YmxaSE4zRlpUSGRUYlVGUWJtVXZRMEpOVERsSE1sTjFiUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDA3YTBmOGYtNjA2NC00ZDU3LWI3OWMtYTJhODZmZGZjOWNlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4c3Bvb2xjb25maWdrdWJlbGV0YXJncwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzcjRWRldrZVFLaGllTzBXZFVRM2FyYUQwTWxwUHZpMlV6ZjFPUXA4NnJWVUNXVUJRNDBTaHRYQw=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWdrdWJlbGV0YXJncyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUkJlazVHYjFoRVZFMTZUVVJGZDAxVVJUQk5WRUY2VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTVpQ20xUFkwbHhXRWQzT1ZOV1dUZEJPRWRSTDBOaVlVbE9NMDlYVTAxUkszWmtjVU5TU21STFJETnFORUpXYkRoRmFsSjVTVXgwS3k5SWF6aEhWa2w2VURFS2NHVnJXRzhyVEV4V1RWTkVXVTR5Y1hCT1J5OXhhSFkxZVRKNVFYWjZhbTlwWmxNclJUSXhRWGw2VVhWVGN6TXJaQ3Q1ZVhCRk5TdDZNV3ByUTFGbU5BcG5ZVGwyYzNGRlZVVnBOVlJSTjBSTVRtVjNUR1ZpTmk5V1VEVlJZekpxYW1VclRGVlZMM0p3VUVkQmJrOUxSV05JUTJFNVRHZFVZekJJU0dSWmJYcFZDbTh4U1VadUt6RXJjbVUxV1RZNFpIWm1MeXM0YW1sS2RpOXJRMVJZVFRreVdXWjJaM1pqYkVaTmMxZGFhMWgwT1VGdGVVRnVNRFY1WVd4NmFrNVRObXNLTW1FNE9FWkVhaTgwU1dwdU9HMHpiSEpSU1ZKWFoxTk1OM05DVEVremRucERXWGhRTTBkVlFYYzJTR1l4ZUZKTU9FTk1TVkZYZURad2JEVTBXbGN2TVFwb05uWlhUMmM0UkZSSE9UaE5OWFJIWW01alEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVV6SnJhMUl4Y25GeE5IQnhhVmgzWmpBMFdVWTJhRUpzYUhOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2FYRlZSMlZ3YTJaWWNGTktObmhGTkhkWk5GWnBSM2hRUlZwWlV6WlJVa04wUlhKQ1VYcHBWbFpHVUhWeWFtOHhkZ3BSY25kb01EUTNkWFZNVmpFeVNFeHpLMjlZVFRWR1Qxb3pUbkl3WldWcGNYQmtVVFJMT1dwTFJXMXNTVTVhZUc4NVIwVkdlRWd4UTBSeU9XSmFNRmhNQ25oMU4wSXlUQzgwVTBkM1drRllZekptYkdWaVVIaE9WRmx6TnpsblJEVkJaV3BLYlRRMk1IVkZSa2gwU1hCeVNYaHNRVE5aZVVvdlEzcFViRGM1VkZNS1ZIWTNheTlvU2twMWNsUktSbk5UTkhGbFVqbHlObTlxVVRsWlV6RmhaR3AwVkdaSmNUVkNkRFpoVVRJNVUxSTBPVEZyYW5FMVRGWkVia2xKTjBKNGJBcEtjM0JFYlV0eWJYVnNVMmhuU0dSMFpFUlJNMVJVUTBSV1IzRmFTelkzYUZReE1YVmllbmxUVnpFeVNXMXFTRTQ1Ym1aMVNYUldaMnMyTkhWSmFVTk5Dbmh3V0ZNMFptWXZhSFIwYldVclptODRhREEyUWtOSlJXZFJORzFqZDJ3M2QwMXhWQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGY5MzM0ZWMtNGJhNS00NzU2LWFiZDItMWJjZDBjZDU3YmY5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4c3Bvb2xjb25maWdrdWJlbGV0YXJncwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzcG9vbGNvbmZpZ2t1YmVsZXRhcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnZHg0SEtobVdTMVk2S2VTSTdzTWpWOTN6ZTNBalhIZVE0QjdNclVsVWRFcnJXUG5sc2k2TjVDSA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2684"
@@ -2570,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:00 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2580,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 263f2544-6ddd-49ad-a0c4-0fed33637e22
+      - ece95e3f-9a81-40fe-a609-4d61753982c8
     status: 200 OK
     code: 200
     duration: ""
@@ -2589,12 +2689,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: GET
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:43:56.094601Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"50"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:15:00.052889Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "633"
@@ -2603,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:00 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2613,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e7aba14-bab9-45a2-95fe-8346da703322
+      - 5dc96d0c-7168-47a8-8f41-4b1f9086d7db
     status: 200 OK
     code: 200
     duration: ""
@@ -2622,21 +2722,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce/nodes?order_by=created_at_asc&page=1&pool_id=55121294-6733-420d-883d-dade37e88938&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9/nodes?order_by=created_at_asc&page=1&pool_id=0382e71c-708e-4fce-a6c8-2eee1b48b720&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"03546773-886a-476a-b02e-7de7b95c7d96","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:40:55.843312Z","updated_at":"2022-10-25T08:43:57.696598Z","pool_id":"55121294-6733-420d-883d-dade37e88938","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigkubeletargs-default-035467738","public_ip_v4":"51.15.214.148","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/5434ba03-93d2-4644-bd51-52d4cc8868a0","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:11:52.655712Z","error_message":null,"id":"2a2b57c9-c535-49a7-a957-441ae91a5d5f","name":"scw-k8spoolconfigkubeletargs-default-2a2b57c9c","pool_id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","provider_id":"scaleway://instance/fr-par-1/88aef1f1-e3c2-4a85-94a6-7909703e39f6","public_ip_v4":"51.158.77.29","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:01.825985Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:01 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2646,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf4d4621-360b-4078-9cb5-80a4b22659a6
+      - 3dd15e04-a7d2-4ed7-b14a-4c3240434d97
     status: 200 OK
     code: 200
     duration: ""
@@ -2655,12 +2755,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/55121294-6733-420d-883d-dade37e88938
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0382e71c-708e-4fce-a6c8-2eee1b48b720
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"55121294-6733-420d-883d-dade37e88938","cluster_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","created_at":"2022-10-25T08:39:32.263357Z","updated_at":"2022-10-25T08:44:01.936847307Z","name":"default","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"placement_group_id":null,"kubelet_args":{"maxPods":"50"},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922334Z","id":"0382e71c-708e-4fce-a6c8-2eee1b48b720","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-01-02T14:15:02.119391253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "639"
@@ -2669,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:01 GMT
+      - Mon, 02 Jan 2023 14:15:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2679,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8617473-abbc-4d94-ae51-ce7200dcfc01
+      - d349cd48-019f-4517-ac39-f5f9a8bf9eb5
     status: 200 OK
     code: 200
     duration: ""
@@ -2688,12 +2788,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:44:02.270310460Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:15:02.183779963Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1341"
@@ -2702,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:02 GMT
+      - Mon, 02 Jan 2023 14:15:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2712,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83ae409d-9c6d-482f-912e-c2155350eebe
+      - be85f443-1365-454b-a772-4e6f96bfe671
     status: 200 OK
     code: 200
     duration: ""
@@ -2721,12 +2821,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:44:02.270310Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:15:02.183780Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1338"
@@ -2735,7 +2835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:02 GMT
+      - Mon, 02 Jan 2023 14:15:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2745,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e684653c-8c89-4498-913c-f4fd07c1b40c
+      - b67ca323-9625-47eb-be15-a59e239bc042
     status: 200 OK
     code: 200
     duration: ""
@@ -2754,12 +2854,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:44:02.270310Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:15:02.183780Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1338"
@@ -2768,7 +2868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:07 GMT
+      - Mon, 02 Jan 2023 14:15:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2778,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21c41651-6b16-45bd-b09f-7eed12567f46
+      - 37cf7a19-862d-4e3e-951c-1eb9f408f437
     status: 200 OK
     code: 200
     duration: ""
@@ -2787,12 +2887,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"region":"fr-par","id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.424382Z","updated_at":"2022-10-25T08:44:02.270310Z","type":"kapsule","name":"K8SPoolConfigKubeletArgs","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"cluster_url":"https://407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.407a0f8f-6064-4d57-b79c-a2a86fdfc9ce.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:15:02.183780Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1338"
@@ -2801,7 +2901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:13 GMT
+      - Mon, 02 Jan 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2811,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af96564d-b296-4694-8ee7-8f7a40cc5ef2
+      - a6252de4-22e1-4e0e-9dbb-8cdc775d47ed
     status: 200 OK
     code: 200
     duration: ""
@@ -2820,12 +2920,78 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:15:02.183780Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1338"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bc6f4382-162c-4f20-8bd5-e522cf4b347e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.526804Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","ingress":"none","name":"K8SPoolConfigKubeletArgs","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-01-02T14:15:02.183780Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1338"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6b735009-06ed-47cf-b338-8b645b2e13b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2834,7 +3000,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:19 GMT
+      - Mon, 02 Jan 2023 14:15:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2844,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9ab3d6b-6c43-45de-bd93-96d6910f3639
+      - 64f3c1da-d1ca-4e8f-92f1-6f0672d04e67
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2853,12 +3019,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/407a0f8f-6064-4d57-b79c-a2a86fdfc9ce
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"407a0f8f-6064-4d57-b79c-a2a86fdfc9ce","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8f9334ec-4ba5-4756-abd2-1bcd0cd57bf9","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2867,7 +3033,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:19 GMT
+      - Mon, 02 Jan 2023 14:15:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2877,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2e70143-6f5b-425f-9d70-982cbab5c635
+      - a7cc94b9-ca8b-4ada-84b0-4790e50609d9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-placement-group.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-placement-group.cassette.yaml
@@ -6,25 +6,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.20.15","label":"Kubernetes
-      1.20.15","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders","GenericEphemeralVolume"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
-      - "3963"
+      - "3135"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:17:54 GMT
+      - Mon, 02 Jan 2023 14:10:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,27 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ba9d13d-d81e-46e6-8a4a-1795e698b5b9
+      - d479caaf-ee7f-4f67-b351-74cc1f7f4720
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group": {"id": "90fe4f8e-b4cf-4ad4-b027-55be686a04ae", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "fr-par-1"}}'
+    body: '{"placement_group":{"id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "326"
@@ -63,9 +59,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:17:55 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/90fe4f8e-b4cf-4ad4-b027-55be686a04ae
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/45d307dd-6f3a-472e-8877-76d3d5ee0929
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -75,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49f96164-1f1a-42b6-abb0-728ae494eeeb
+      - f360503b-1ba2-4dff-a524-e771364ab301
     status: 201 Created
     code: 201
     duration: ""
@@ -84,16 +80,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/90fe4f8e-b4cf-4ad4-b027-55be686a04ae
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/45d307dd-6f3a-472e-8877-76d3d5ee0929
     method: GET
   response:
-    body: '{"placement_group": {"id": "90fe4f8e-b4cf-4ad4-b027-55be686a04ae", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "fr-par-1"}}'
+    body: '{"placement_group":{"id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "326"
@@ -102,7 +94,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:17:56 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -112,23 +104,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ac6fae5-c100-4d7a-95ad-ebefc8aeb793
+      - d46209b5-bbe7-4a88-8723-aa2a3692c20b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"placement_group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.24.5","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"placement_group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.24.7","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990181Z","updated_at":"2022-10-06T12:17:56.594973388Z","type":"kapsule","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248436Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.538934154Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1338"
@@ -137,7 +129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:17:56 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -147,7 +139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bcb099b-6ef4-4edc-bee2-24671a0fa18e
+      - 750bfec1-3711-4678-9ced-afd75554737e
     status: 200 OK
     code: 200
     duration: ""
@@ -156,12 +148,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:17:56.594973Z","type":"kapsule","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.538934Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -170,7 +162,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:17:57 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -180,7 +172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eba68a1a-61ee-4f5f-902f-be861c9cd1f7
+      - 09690692-0d97-4a30-a4f5-f2105546622d
     status: 200 OK
     code: 200
     duration: ""
@@ -189,12 +181,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:18:00.773229Z","type":"kapsule","name":"placement_group","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:10:38.312808Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1337"
@@ -203,7 +195,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:04 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -213,7 +205,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8200372d-e550-4ce8-97bb-a6267f84dbe7
+      - 85b24621-f14d-4c09-aa9a-86850d891d13
     status: 200 OK
     code: 200
     duration: ""
@@ -222,12 +214,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:18:00.773229Z","type":"kapsule","name":"placement_group","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:10:38.312808Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1337"
@@ -236,7 +228,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:04 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -246,7 +238,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ca9b24-62d1-40d3-b7bf-bbddaefa8452
+      - 0d6a2688-823e-4859-b5b7-32f93fdc571c
     status: 200 OK
     code: 200
     duration: ""
@@ -255,12 +247,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGRPVkVWNVRWUmpNVTlXYjFoRVZFMTVUVlJCZDA1VVJYbE5WR014VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV3h0Q2pOUVozVTBVRzloY1U5dk0ybGxVV1JyTTBWalpURTFNU3RWTVhCMU5VVXpjSGxzT1M5UmJGRlRPR2RGZVZBNFRFTkhXalptU21aTGFVMW5TMWxvY0dnS1pFMWFWVVpyZWpJMWFsSnNZWGh2TlRsNlNXMDBjRTVqY21oR2VIbFdibkZKU2t0dlJHTkxXV0ZJZVdKcWMySTRla0Y0VkVVMmNXeGhjR2hJTnk4dkx3cE9aek5CVTBoSGRuZzBPVXh4VUVrNFJqSlVUWEkwVmpsbmJVaHhVMmxLUm1GQ01VeFdRbEY1Wm01dFpYVm9kV3R1YlZad1VqTjNZbkZrVDBoaFFVbHpDamxTV1ZKREszWXJURk51TUZJNE5raDJZa2hKZVhSclYyNUtjbWMyTWtNMVlYZHlWbmRXVURaall6RnVOMEozTlVST2FEVndVWE14VkhrNVdsQTFVMFFLZFdzeFkzVXlOamszTXlzeWVpOVhkMnRzUTFoSE5VTnBNVUZMUlV0a1FYRlBjRWcwUTNCeFVFa3lWMUZZWXpoemQzVjROREZRVHpWR2EwcHFVVWR5ZFFwbVJEZHJOM2hLVHpneWRFRnJXR1ZSV0RCVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaR2NFOTZaV2s1UzJ4T2NFRjNXWGQyUlVGa1dXdE9hRU5RTVcxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJHMU5iVzkyV1dob2JpOWhVVGxGUVRFMGJtMXFaMVFyTldoVFduUlpSelF4Y21GU1dXNXdhMmgzU0dKb1VISk9Wd3BVZFRsdFQwdE9LekI2TjA5VUwxRkVVVUZWUWtoMU5GbEphREpDTDBWMVMyOXdjRkJRT0VaUmJWaDZXVWhrU21WSVkxQnlVMDh4UlZSR1ZWTkJOaXMwQ2pKSU1HaFpTbkJUZWxOalNHMVRabFZUYzFSUGRIUXlNWEJvTTIxRU4yWjNLM05ZT1hWcWVEaEpNbTFFYWtkbU1uVllOVVIyY2tocGQwSkhNMEpRV2xVS1FtZFFWV3AxV25wclMwTTBjalZqTldkcEt5dFZlQ3RSTDJ0UFJrOWFZbE5DUVdjelMzaFpTRTVhV1VwVVpUY3ZNbFZwYzA4clFYaENja29yTldNMFpncFRXRkZQUmtsRFJpdFJTRnB0UVRaVVEwNXJXRzQzVGpCdlpHeFRiamM0ZWtKT1l6bGhRbXRwTHlzMVFYaFZObU54V2xWdE9XVkZWWE12ZW5kM1prWXZDbTlYSzNsNVRuQm1kR2RzTXpBMlZVdFdUVEl3WVVoS1RVczRaVFJGZG05ek4zVjNWUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDc4NzIzZWUtNGU5Yi00YzRjLTg3MTgtYTgxZDJiNDYwMjdlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXWDdGNjFtMmJHOXFsQ2RsOFA2Z01EWGpCalBHbWc2TFVDZWU0d1dZeXJ3VDFpNTNGNW4xTDNLRA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUkJlazR4YjFoRVZFMTZUVVJGZDAxVVJUQk5WRUY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURXg2Q204dlpIUmxiMXB2YzBaTmJtUXJXbmQwVFZkWk5IcFFVMDg1UXpKU1UyUkxaek5qUzBGNGQzZDBNRlpoWkRKWE4wdGxZM0pTU2xBeWNERlJOamhyYld3S01pOWFjM1pKYVZRMWNURkxibkJpU1hvM1V6TllZeTltY1dSMlFtdEdUVVEyUmtaS1NpOWpRMDE1VjFORE5YUlNha2g0ZUM5c1JqRmhhVzl1VGxZMVZRcDRlbWxKUzNGQlZqTktWMVpRVGt3eGJqZEdSVkl3YzFWMlFURmpZMEZLVGxoRGFsRjVjV1V3WnpWeVNrSm9iVTV1WVhZMFVrTnNkbEoxVDBObWIwUkVDa1JUWVc5MVZFUnFabkJsVkVoUE1uQjBRVk4yY0dWclpVODFXazVxYjFwUVVHdE1heTlKV25WdE9YcEdLMWhuV0hjMlRYTmxVbE01YVRCVGFIRkhLM1VLYlRCWE9FVXJSa2wyTm1kR2VqVlpaVXAxZGxWaE0yVkdRbGhJYUhSM1VVTmxaWEV6TkZkQ1ExQm1aM0oxZENzNFZXUlhNa1owTURkdWRURjVjbEpvU1FwUFdYUTRXa05IV1RVeVIxRm1OVlJDTjNoclEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVRVSnFWMEp0V0hSQ1RWcGFUeXRFTURsdkwzb3hNMDFaTTNoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmVXTXdSREpIZVdobE9HaDRjSE12S3l0RlNGUldNV3d2UzNOdmRYZHZkSHBOZVVSak0yeFBOV3hLYVU0MlJtZEtlZ3BKWjJzck5HWjFlRTF1UzNOMFZqRnliRGhNYXpjMmFuTXJjaTlVVlRZMVUzUXdlamN4ZWxZeU5IQkJNVEZtV2psSmNVRlFORlZSZEd0SmExQjBhVzlUQ2xCdE5DdGxZVmhQV0dGc2F5dEpVak4xY25WMmJVRjFZMG81U0RoS1pVNW5WalJWZDA1dFFuUTRla3N6ZWs1R1ptcERkRlpPUm01RmFuQmtNRWR3YUVRS2VHZzFka015U21aU1YwMHdkR2g0WkZoVFdWSm9VRzByWm05RFNEVm1MMFZ2WW5OM1YxTkxWRUZWYnk5cFZUVlBRV3RTU2s1NWRIbGhVMHhFV2pWTFFnb3hTRzV0VTFKd2FsTlFRWGhtYW0xbk0zZFdXRzlsYVZsdlpqUTNMekZ5YW5CWE4wVXdTbVpZVkdWcVQzUlVlVzVYTUZaWksxWlNPV2hrWlUxWU9EaDBDbUZYT1ZCd1QyTnhUMnQyTmpsMlF6bE5lbmswYlZGNlVtaFBWRzVrZEc5R1ZUSm1TQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWZhZmE5MWEtYTFmZS00MTYxLTkyYmEtOWRkZjRhN2ExZWY3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5aHMyWDMydjRtMXkyRjJuV1R6RmpVaUkyNFRPZ1FSQ0s3ZGFkS25iWHhiVWpTazFEQWpxTWF2aA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -269,7 +261,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:05 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -279,7 +271,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52c3f158-74eb-48de-a3f4-61fcf6cb3bc2
+      - 1779bfd4-42b4-44c2-a0fb-cfa233b9c353
     status: 200 OK
     code: 200
     duration: ""
@@ -288,12 +280,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:18:00.773229Z","type":"kapsule","name":"placement_group","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:10:38.312808Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1337"
@@ -302,7 +294,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:06 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -312,23 +304,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2db666a2-3b94-4745-999b-b2795d3ac6a7
+      - 73711275-af27-4ea1-a822-7bbf8870ab68
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"placement_group","node_type":"gp1_xs","placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null}'
+    body: '{"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244369783Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407481906Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "614"
@@ -337,7 +329,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:10 GMT
+      - Mon, 02 Jan 2023 14:10:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -347,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 111070c9-e3ee-4612-ba2e-91cdff6edd1d
+      - c18a91db-3892-4fd2-af88-0ef81d9b9c0b
     status: 200 OK
     code: 200
     duration: ""
@@ -356,12 +348,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -370,7 +362,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:11 GMT
+      - Mon, 02 Jan 2023 14:10:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -380,7 +372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab09cb63-54f9-4820-a26e-0ee40a34cacc
+      - 59c91ff5-d48d-4c86-87a3-a4bb6146ced5
     status: 200 OK
     code: 200
     duration: ""
@@ -389,12 +381,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -403,7 +395,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:17 GMT
+      - Mon, 02 Jan 2023 14:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -413,7 +405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a05f8e03-282b-49e8-9205-5ef5655f1d50
+      - a77cfe6f-5a47-4d64-970f-8fedd2ef9dae
     status: 200 OK
     code: 200
     duration: ""
@@ -422,12 +414,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -436,7 +428,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:23 GMT
+      - Mon, 02 Jan 2023 14:10:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -446,7 +438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 506dc742-5ff5-44cc-a678-dfcf35aa9f44
+      - 6f5fcf79-8669-40e1-8a5e-56ea48c8ecbd
     status: 200 OK
     code: 200
     duration: ""
@@ -455,12 +447,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -469,7 +461,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:28 GMT
+      - Mon, 02 Jan 2023 14:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -479,7 +471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 215d10c7-42ca-4805-b89d-d63637d884bd
+      - 7772cffa-e3f7-4d84-b98f-d893d5d2f7d8
     status: 200 OK
     code: 200
     duration: ""
@@ -488,12 +480,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -502,7 +494,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:34 GMT
+      - Mon, 02 Jan 2023 14:11:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -512,7 +504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72c390c9-c248-454a-8599-d136875a19d5
+      - 3d619642-d182-417b-a596-c21e228ca078
     status: 200 OK
     code: 200
     duration: ""
@@ -521,12 +513,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -535,7 +527,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:41 GMT
+      - Mon, 02 Jan 2023 14:11:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -545,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab137ec4-fe08-43ff-b8a1-04f93d686268
+      - 76cc8502-6806-4321-bd80-62af34236c0d
     status: 200 OK
     code: 200
     duration: ""
@@ -554,12 +546,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -568,7 +560,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:47 GMT
+      - Mon, 02 Jan 2023 14:11:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -578,7 +570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e071b2fd-f8bd-4852-a7cf-f422bc7983c7
+      - b0f64a6c-c5a6-4bc9-ace9-a4d15d83d77b
     status: 200 OK
     code: 200
     duration: ""
@@ -587,12 +579,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -601,7 +593,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:52 GMT
+      - Mon, 02 Jan 2023 14:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -611,7 +603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72b5a648-e89b-4699-bcb0-39d98c7f93b8
+      - 779ba69f-e8b6-4702-89cf-29d64d733130
     status: 200 OK
     code: 200
     duration: ""
@@ -620,12 +612,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -634,7 +626,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:18:58 GMT
+      - Mon, 02 Jan 2023 14:11:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -644,7 +636,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a39b4039-55d4-4a8e-99bc-5f31c4f58b0f
+      - 84d6f1cc-c3ec-48b3-8908-ebad4e78e057
     status: 200 OK
     code: 200
     duration: ""
@@ -653,12 +645,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -667,7 +659,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:19:03 GMT
+      - Mon, 02 Jan 2023 14:11:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -677,7 +669,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1546a139-56a7-4eb2-a973-a521fb22982c
+      - 4bae644f-f801-4ddd-9e39-b4399435bc7f
     status: 200 OK
     code: 200
     duration: ""
@@ -686,12 +678,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -700,7 +692,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:19:12 GMT
+      - Mon, 02 Jan 2023 14:11:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -710,7 +702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eca7534c-9585-4a7e-84dd-f0f8b20701a8
+      - 1d4180a0-c10a-48cf-ad80-36553f6f7573
     status: 200 OK
     code: 200
     duration: ""
@@ -719,12 +711,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -733,7 +725,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:19:18 GMT
+      - Mon, 02 Jan 2023 14:11:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -743,7 +735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4ff6766-f8bb-46b2-8566-00add96fa8d5
+      - 1f7a8030-6b9b-4e12-ab0a-f93dd112a9da
     status: 200 OK
     code: 200
     duration: ""
@@ -752,12 +744,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -766,7 +758,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:19:44 GMT
+      - Mon, 02 Jan 2023 14:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -776,7 +768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4417a802-dd52-4ee7-bf8a-15f387dfda38
+      - 93027042-e09f-4235-9b1b-687dea45d739
     status: 200 OK
     code: 200
     duration: ""
@@ -785,12 +777,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -799,7 +791,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:19:49 GMT
+      - Mon, 02 Jan 2023 14:11:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -809,7 +801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c6ad621-e90b-4055-ad2e-1c099a496f3d
+      - 3aa9d415-5305-4038-a823-936d70318b6b
     status: 200 OK
     code: 200
     duration: ""
@@ -818,12 +810,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -832,7 +824,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:02 GMT
+      - Mon, 02 Jan 2023 14:11:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -842,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 095331a0-4575-479d-99a9-5a1b753f6d88
+      - 8ccbaac7-81dd-43ed-a782-c54533be8083
     status: 200 OK
     code: 200
     duration: ""
@@ -851,12 +843,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -865,7 +857,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:08 GMT
+      - Mon, 02 Jan 2023 14:11:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -875,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a67ec78-cb91-4cae-830c-392d8699b5a1
+      - a6654f61-f52f-452c-b193-b63b8682d47f
     status: 200 OK
     code: 200
     duration: ""
@@ -884,12 +876,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -898,7 +890,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:14 GMT
+      - Mon, 02 Jan 2023 14:12:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -908,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8b63a9f-0777-4676-8856-2f13bb3e0940
+      - 57f4ddf1-016f-45b0-83e1-7e0c6c7cf072
     status: 200 OK
     code: 200
     duration: ""
@@ -917,12 +909,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -931,7 +923,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:20 GMT
+      - Mon, 02 Jan 2023 14:12:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -941,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f222da17-c3e8-40ab-b99d-a6bb19da08eb
+      - 8ac19612-6e41-4181-86a5-099e84a1ea2e
     status: 200 OK
     code: 200
     duration: ""
@@ -950,12 +942,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -964,7 +956,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:25 GMT
+      - Mon, 02 Jan 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -974,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09bddb25-831a-4bd0-b93b-fb2cdd345524
+      - 32e318e9-8882-4aa3-b83f-74ade88c7c8d
     status: 200 OK
     code: 200
     duration: ""
@@ -983,12 +975,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -997,7 +989,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:30 GMT
+      - Mon, 02 Jan 2023 14:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1007,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 814f2dd8-4ae2-4775-8010-fc1531681cec
+      - 146e655e-e8f3-45d9-a636-859f3f09b73d
     status: 200 OK
     code: 200
     duration: ""
@@ -1016,12 +1008,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1030,7 +1022,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:37 GMT
+      - Mon, 02 Jan 2023 14:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1040,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1c23561-564b-44dd-bbda-445415335b44
+      - ed5894cd-a995-4a2c-a597-e9866977efb1
     status: 200 OK
     code: 200
     duration: ""
@@ -1049,12 +1041,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1063,7 +1055,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:43 GMT
+      - Mon, 02 Jan 2023 14:12:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1073,7 +1065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bafb488-9013-42df-a853-0d8964f37432
+      - 46d438b0-6de2-43f4-a822-e4c4c3fa8e78
     status: 200 OK
     code: 200
     duration: ""
@@ -1082,12 +1074,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1096,7 +1088,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:48 GMT
+      - Mon, 02 Jan 2023 14:12:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1106,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6cd56e3-a8da-4d1e-af8a-f7a858f3dd88
+      - dea07230-06c1-4239-a8c2-5ba837b921df
     status: 200 OK
     code: 200
     duration: ""
@@ -1115,12 +1107,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1129,7 +1121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:53 GMT
+      - Mon, 02 Jan 2023 14:12:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1139,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a08107f5-23c2-45f5-8876-be8d60ba9eed
+      - 1d0b1f2f-527d-4b47-8689-efd8fcc98156
     status: 200 OK
     code: 200
     duration: ""
@@ -1148,12 +1140,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1162,7 +1154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:20:59 GMT
+      - Mon, 02 Jan 2023 14:12:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1172,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5b0064d-8cce-4652-8018-34cf7de1201a
+      - c0dc25ac-ca85-4c70-aae1-fbf7dd5af94c
     status: 200 OK
     code: 200
     duration: ""
@@ -1181,12 +1173,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1195,7 +1187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:05 GMT
+      - Mon, 02 Jan 2023 14:12:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1205,7 +1197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff9737de-7b38-453b-87d4-1eecc640ee4f
+      - 8c59e4e3-40c6-4c97-825a-0a4f05d31e49
     status: 200 OK
     code: 200
     duration: ""
@@ -1214,12 +1206,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1228,7 +1220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:10 GMT
+      - Mon, 02 Jan 2023 14:12:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1238,7 +1230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f061928c-2aa4-4094-aadc-53d51054ec9c
+      - bf4cd426-19dc-4971-b2d9-03acfb8d732d
     status: 200 OK
     code: 200
     duration: ""
@@ -1247,12 +1239,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1261,7 +1253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:15 GMT
+      - Mon, 02 Jan 2023 14:12:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1271,7 +1263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c8714cd-3a10-46bb-a8bf-d8df03bb863f
+      - d528757f-2a63-4850-8f91-c93f79bd9bac
     status: 200 OK
     code: 200
     duration: ""
@@ -1280,12 +1272,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1294,7 +1286,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:21 GMT
+      - Mon, 02 Jan 2023 14:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1304,7 +1296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93d87a9c-90a3-4cdb-9d78-62865812a4bb
+      - e7895b24-9315-4879-b961-6d4686fb3a2b
     status: 200 OK
     code: 200
     duration: ""
@@ -1313,12 +1305,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1327,7 +1319,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:27 GMT
+      - Mon, 02 Jan 2023 14:13:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1337,7 +1329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ce1157d-79a1-4d1d-8cb3-d4ddbb065499
+      - c29f3f9b-3a3d-4189-8ca5-44874c379c4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1346,12 +1338,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1360,7 +1352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:38 GMT
+      - Mon, 02 Jan 2023 14:13:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1370,7 +1362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 736a7e1a-0a8a-4cb7-a024-71973936e75e
+      - 98be7cbb-dc19-4de9-92a8-a2c977bffff9
     status: 200 OK
     code: 200
     duration: ""
@@ -1379,12 +1371,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1393,7 +1385,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:43 GMT
+      - Mon, 02 Jan 2023 14:13:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1403,7 +1395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39a8a470-30ba-4785-ab4b-aedbba12974c
+      - 0f9da6d6-b69b-4119-acb1-c80dba2c3f1e
     status: 200 OK
     code: 200
     duration: ""
@@ -1412,12 +1404,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1426,7 +1418,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:49 GMT
+      - Mon, 02 Jan 2023 14:13:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1436,7 +1428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03b89da8-1d19-495d-a77b-3afd7449c818
+      - 7ddf23df-bd08-4426-bba9-054b54821ae2
     status: 200 OK
     code: 200
     duration: ""
@@ -1445,12 +1437,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1459,7 +1451,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:54 GMT
+      - Mon, 02 Jan 2023 14:13:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1469,7 +1461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3852f932-4490-418d-bff1-c1d8744a276b
+      - 60bc5229-2b95-4fba-b977-ec248185cbd1
     status: 200 OK
     code: 200
     duration: ""
@@ -1478,12 +1470,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1492,7 +1484,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:21:59 GMT
+      - Mon, 02 Jan 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1502,7 +1494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd34700c-dabc-4c1c-aa35-5302d15e1a7c
+      - 7ecf27c6-4c43-41b4-91a0-1fd4e04bea2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1511,12 +1503,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1525,7 +1517,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:05 GMT
+      - Mon, 02 Jan 2023 14:13:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1535,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b79b0410-5db4-47c4-8a50-9474bd6493cd
+      - 28a3d5b6-0df3-4d66-9717-2791e5ace9ee
     status: 200 OK
     code: 200
     duration: ""
@@ -1544,12 +1536,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1558,7 +1550,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:12 GMT
+      - Mon, 02 Jan 2023 14:13:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1568,7 +1560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d43628de-24e6-46a8-9c2a-5f241de45c51
+      - 5e34537b-7268-444c-90b4-1201087c9b84
     status: 200 OK
     code: 200
     duration: ""
@@ -1577,12 +1569,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1591,7 +1583,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:18 GMT
+      - Mon, 02 Jan 2023 14:13:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1601,7 +1593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5591370-eda2-4c07-9fc7-57da943ba0b3
+      - cfbaad95-14f2-4062-bcb3-c4caff33ca36
     status: 200 OK
     code: 200
     duration: ""
@@ -1610,12 +1602,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1624,7 +1616,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:23 GMT
+      - Mon, 02 Jan 2023 14:13:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1634,7 +1626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af8fabcd-e47c-4bac-91a5-b25ca191e090
+      - 53ca820c-0891-4f80-9e09-5bf16dd09f6c
     status: 200 OK
     code: 200
     duration: ""
@@ -1643,12 +1635,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1657,7 +1649,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:29 GMT
+      - Mon, 02 Jan 2023 14:13:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1667,7 +1659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1f3091b-388a-484a-b706-8fea2adc859b
+      - d1b3781e-ae93-41ee-852d-a9cdc703b595
     status: 200 OK
     code: 200
     duration: ""
@@ -1676,12 +1668,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1690,7 +1682,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:40 GMT
+      - Mon, 02 Jan 2023 14:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1700,7 +1692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83b34d5e-3e61-456a-b0a2-6f80aa1872a2
+      - c89e6ede-df29-440d-b424-8e92bd56518a
     status: 200 OK
     code: 200
     duration: ""
@@ -1709,12 +1701,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1723,7 +1715,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:46 GMT
+      - Mon, 02 Jan 2023 14:14:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1733,7 +1725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ba466f6-7431-43e1-8933-54136a503b33
+      - 78076456-941b-4078-a4b7-7cf7b905ee95
     status: 200 OK
     code: 200
     duration: ""
@@ -1742,12 +1734,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1756,7 +1748,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:52 GMT
+      - Mon, 02 Jan 2023 14:14:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1766,7 +1758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce621b96-ca7c-4f86-a290-60e195cc1a2e
+      - 7034a569-bbeb-4c38-be6b-edc863a741d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1775,12 +1767,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1789,7 +1781,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:22:58 GMT
+      - Mon, 02 Jan 2023 14:14:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1799,7 +1791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85c422ee-522b-44d5-847f-87cc6293f836
+      - 69c6ae1d-3f18-4281-9dc2-d47d5546eebc
     status: 200 OK
     code: 200
     duration: ""
@@ -1808,12 +1800,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1822,7 +1814,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:04 GMT
+      - Mon, 02 Jan 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1832,7 +1824,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99dc2375-ba01-4715-88d0-fcfec7dcc099
+      - 57099583-052d-44cb-9134-73e74a2d7cc8
     status: 200 OK
     code: 200
     duration: ""
@@ -1841,12 +1833,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1855,7 +1847,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:13 GMT
+      - Mon, 02 Jan 2023 14:14:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1865,7 +1857,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1628442c-9d18-47f7-bc91-d2aaba29faea
+      - b6287942-f42a-45df-b474-be03a5a1d1e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1874,12 +1866,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1888,7 +1880,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:19 GMT
+      - Mon, 02 Jan 2023 14:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1898,7 +1890,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4313efd9-d905-437a-b492-4c465c383fcc
+      - 6c820eff-d069-4e23-9372-ceb3867c1f5a
     status: 200 OK
     code: 200
     duration: ""
@@ -1907,12 +1899,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1921,7 +1913,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:24 GMT
+      - Mon, 02 Jan 2023 14:14:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1931,7 +1923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90917786-08ab-459a-8304-fab8cbde9ea8
+      - f15a1918-1126-4f97-b038-3bb679167dae
     status: 200 OK
     code: 200
     duration: ""
@@ -1940,12 +1932,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:39.407482Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "611"
@@ -1954,7 +1946,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:32 GMT
+      - Mon, 02 Jan 2023 14:14:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1964,7 +1956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 965508bf-dfca-495b-883d-bd3f4ca745c4
+      - 0882d699-0765-4974-a960-82125b0b14a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1973,45 +1965,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:18:07.244370Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:23:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 60b42980-1b86-47e6-a5ae-9ef9bb97a5b3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:23:37.775980Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:47.350778Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "609"
@@ -2020,7 +1979,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:43 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2030,7 +1989,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f40d9d8f-5c2b-42d0-a9ca-45ea6f6b792f
+      - 8e532f33-a90c-4b56-a556-2fc387c0248d
     status: 200 OK
     code: 200
     duration: ""
@@ -2039,12 +1998,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:19:16.561740Z","type":"kapsule","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:12:01.855362Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -2053,7 +2012,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:43 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2063,7 +2022,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a2cd19b-8596-4dfc-aefa-cbc041438a8c
+      - c5b4f95f-2ef3-4865-9022-fc49534149b7
     status: 200 OK
     code: 200
     duration: ""
@@ -2072,12 +2031,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:23:37.775980Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:47.350778Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "609"
@@ -2086,7 +2045,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:43 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2096,7 +2055,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa36731c-d199-4617-9c75-c2cf75ae6d9a
+      - f428103b-5916-468b-92b3-167c886f3f1f
     status: 200 OK
     code: 200
     duration: ""
@@ -2105,21 +2064,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e/nodes?order_by=created_at_asc&page=1&pool_id=294330e2-5005-4b7f-b1d8-e054daf3e721&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7/nodes?order_by=created_at_asc&page=1&pool_id=9228f3df-0110-4346-bbbc-2a14e197ba30&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"edef2a1d-6ce4-4751-ad0d-e8bbf61a2023","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:19:40.264429Z","updated_at":"2022-10-06T12:23:37.679819Z","pool_id":"294330e2-5005-4b7f-b1d8-e054daf3e721","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-placement-group-placement-group-edef2a1d6c","public_ip_v4":"212.47.247.29","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6ec793db-9c8e-4ec9-92ab-edbef5ae0370","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:13.710484Z","error_message":null,"id":"088342c7-f2a4-4e06-9fd5-c46c022fa0ed","name":"scw-placement-group-placement-group-088342c7f2","pool_id":"9228f3df-0110-4346-bbbc-2a14e197ba30","provider_id":"scaleway://instance/fr-par-1/fda23f67-89a1-4c16-ac8b-c02459ad96f7","public_ip_v4":"51.158.114.140","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:47.333250Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:44 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2129,7 +2088,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 554051ae-af72-45ea-bcc6-f1f96c1c0a47
+      - 93327814-732e-4309-bcc3-aad34b483df0
     status: 200 OK
     code: 200
     duration: ""
@@ -2138,12 +2097,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:19:16.561740Z","type":"kapsule","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:12:01.855362Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -2152,7 +2111,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:44 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2162,7 +2121,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6556ab9-9203-4d8f-b085-d51e7a2f8b0b
+      - 9fec83bc-fef3-47e7-9242-cbb3f02db9a0
     status: 200 OK
     code: 200
     duration: ""
@@ -2171,12 +2130,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:23:37.775980Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:47.350778Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "609"
@@ -2185,7 +2144,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:44 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2195,7 +2154,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56a535be-3b6d-4397-8a2f-02d6d2754f21
+      - 2335b573-77b8-4384-9d36-de331e49d47d
     status: 200 OK
     code: 200
     duration: ""
@@ -2204,12 +2163,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:19:16.561740Z","type":"kapsule","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:12:01.855362Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -2218,7 +2177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:45 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2228,7 +2187,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57b54212-55c0-45d6-a4b6-5bc59ddb152c
+      - bb590b18-2da2-4ecd-abf7-754c11f2775e
     status: 200 OK
     code: 200
     duration: ""
@@ -2237,16 +2196,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/90fe4f8e-b4cf-4ad4-b027-55be686a04ae
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/45d307dd-6f3a-472e-8877-76d3d5ee0929
     method: GET
   response:
-    body: '{"placement_group": {"id": "90fe4f8e-b4cf-4ad4-b027-55be686a04ae", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "fr-par-1"}}'
+    body: '{"placement_group":{"id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "326"
@@ -2255,7 +2210,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:45 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2265,7 +2220,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca961a19-e00d-4e7f-ab11-f7e3eff0c758
+      - 605cb2d1-39d6-4af3-9ec6-b8320609f06a
     status: 200 OK
     code: 200
     duration: ""
@@ -2274,12 +2229,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGRPVkVWNVRWUmpNVTlXYjFoRVZFMTVUVlJCZDA1VVJYbE5WR014VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV3h0Q2pOUVozVTBVRzloY1U5dk0ybGxVV1JyTTBWalpURTFNU3RWTVhCMU5VVXpjSGxzT1M5UmJGRlRPR2RGZVZBNFRFTkhXalptU21aTGFVMW5TMWxvY0dnS1pFMWFWVVpyZWpJMWFsSnNZWGh2TlRsNlNXMDBjRTVqY21oR2VIbFdibkZKU2t0dlJHTkxXV0ZJZVdKcWMySTRla0Y0VkVVMmNXeGhjR2hJTnk4dkx3cE9aek5CVTBoSGRuZzBPVXh4VUVrNFJqSlVUWEkwVmpsbmJVaHhVMmxLUm1GQ01VeFdRbEY1Wm01dFpYVm9kV3R1YlZad1VqTjNZbkZrVDBoaFFVbHpDamxTV1ZKREszWXJURk51TUZJNE5raDJZa2hKZVhSclYyNUtjbWMyTWtNMVlYZHlWbmRXVURaall6RnVOMEozTlVST2FEVndVWE14VkhrNVdsQTFVMFFLZFdzeFkzVXlOamszTXlzeWVpOVhkMnRzUTFoSE5VTnBNVUZMUlV0a1FYRlBjRWcwUTNCeFVFa3lWMUZZWXpoemQzVjROREZRVHpWR2EwcHFVVWR5ZFFwbVJEZHJOM2hLVHpneWRFRnJXR1ZSV0RCVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaR2NFOTZaV2s1UzJ4T2NFRjNXWGQyUlVGa1dXdE9hRU5RTVcxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJHMU5iVzkyV1dob2JpOWhVVGxGUVRFMGJtMXFaMVFyTldoVFduUlpSelF4Y21GU1dXNXdhMmgzU0dKb1VISk9Wd3BVZFRsdFQwdE9LekI2TjA5VUwxRkVVVUZWUWtoMU5GbEphREpDTDBWMVMyOXdjRkJRT0VaUmJWaDZXVWhrU21WSVkxQnlVMDh4UlZSR1ZWTkJOaXMwQ2pKSU1HaFpTbkJUZWxOalNHMVRabFZUYzFSUGRIUXlNWEJvTTIxRU4yWjNLM05ZT1hWcWVEaEpNbTFFYWtkbU1uVllOVVIyY2tocGQwSkhNMEpRV2xVS1FtZFFWV3AxV25wclMwTTBjalZqTldkcEt5dFZlQ3RSTDJ0UFJrOWFZbE5DUVdjelMzaFpTRTVhV1VwVVpUY3ZNbFZwYzA4clFYaENja29yTldNMFpncFRXRkZQUmtsRFJpdFJTRnB0UVRaVVEwNXJXRzQzVGpCdlpHeFRiamM0ZWtKT1l6bGhRbXRwTHlzMVFYaFZObU54V2xWdE9XVkZWWE12ZW5kM1prWXZDbTlYSzNsNVRuQm1kR2RzTXpBMlZVdFdUVEl3WVVoS1RVczRaVFJGZG05ek4zVjNWUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDc4NzIzZWUtNGU5Yi00YzRjLTg3MTgtYTgxZDJiNDYwMjdlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXWDdGNjFtMmJHOXFsQ2RsOFA2Z01EWGpCalBHbWc2TFVDZWU0d1dZeXJ3VDFpNTNGNW4xTDNLRA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUkJlazR4YjFoRVZFMTZUVVJGZDAxVVJUQk5WRUY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURXg2Q204dlpIUmxiMXB2YzBaTmJtUXJXbmQwVFZkWk5IcFFVMDg1UXpKU1UyUkxaek5qUzBGNGQzZDBNRlpoWkRKWE4wdGxZM0pTU2xBeWNERlJOamhyYld3S01pOWFjM1pKYVZRMWNURkxibkJpU1hvM1V6TllZeTltY1dSMlFtdEdUVVEyUmtaS1NpOWpRMDE1VjFORE5YUlNha2g0ZUM5c1JqRmhhVzl1VGxZMVZRcDRlbWxKUzNGQlZqTktWMVpRVGt3eGJqZEdSVkl3YzFWMlFURmpZMEZLVGxoRGFsRjVjV1V3WnpWeVNrSm9iVTV1WVhZMFVrTnNkbEoxVDBObWIwUkVDa1JUWVc5MVZFUnFabkJsVkVoUE1uQjBRVk4yY0dWclpVODFXazVxYjFwUVVHdE1heTlKV25WdE9YcEdLMWhuV0hjMlRYTmxVbE01YVRCVGFIRkhLM1VLYlRCWE9FVXJSa2wyTm1kR2VqVlpaVXAxZGxWaE0yVkdRbGhJYUhSM1VVTmxaWEV6TkZkQ1ExQm1aM0oxZENzNFZXUlhNa1owTURkdWRURjVjbEpvU1FwUFdYUTRXa05IV1RVeVIxRm1OVlJDTjNoclEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVRVSnFWMEp0V0hSQ1RWcGFUeXRFTURsdkwzb3hNMDFaTTNoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmVXTXdSREpIZVdobE9HaDRjSE12S3l0RlNGUldNV3d2UzNOdmRYZHZkSHBOZVVSak0yeFBOV3hLYVU0MlJtZEtlZ3BKWjJzck5HWjFlRTF1UzNOMFZqRnliRGhNYXpjMmFuTXJjaTlVVlRZMVUzUXdlamN4ZWxZeU5IQkJNVEZtV2psSmNVRlFORlZSZEd0SmExQjBhVzlUQ2xCdE5DdGxZVmhQV0dGc2F5dEpVak4xY25WMmJVRjFZMG81U0RoS1pVNW5WalJWZDA1dFFuUTRla3N6ZWs1R1ptcERkRlpPUm01RmFuQmtNRWR3YUVRS2VHZzFka015U21aU1YwMHdkR2g0WkZoVFdWSm9VRzByWm05RFNEVm1MMFZ2WW5OM1YxTkxWRUZWYnk5cFZUVlBRV3RTU2s1NWRIbGhVMHhFV2pWTFFnb3hTRzV0VTFKd2FsTlFRWGhtYW0xbk0zZFdXRzlsYVZsdlpqUTNMekZ5YW5CWE4wVXdTbVpZVkdWcVQzUlVlVzVYTUZaWksxWlNPV2hrWlUxWU9EaDBDbUZYT1ZCd1QyTnhUMnQyTmpsMlF6bE5lbmswYlZGNlVtaFBWRzVrZEc5R1ZUSm1TQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWZhZmE5MWEtYTFmZS00MTYxLTkyYmEtOWRkZjRhN2ExZWY3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5aHMyWDMydjRtMXkyRjJuV1R6RmpVaUkyNFRPZ1FSQ0s3ZGFkS25iWHhiVWpTazFEQWpxTWF2aA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2288,7 +2243,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:45 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2298,7 +2253,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4c23e93-164a-4c71-99d0-6ebed2d28cb2
+      - fba03199-53ad-4cff-a087-ab36666ae949
     status: 200 OK
     code: 200
     duration: ""
@@ -2307,12 +2262,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:23:37.775980Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:47.350778Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "609"
@@ -2321,7 +2276,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:46 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2331,7 +2286,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7abb48e-064f-4ba8-851a-fe9ac0d63ec4
+      - 7dd0bed1-a4ef-42c3-9117-6d144bb90ed7
     status: 200 OK
     code: 200
     duration: ""
@@ -2340,21 +2295,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e/nodes?order_by=created_at_asc&page=1&pool_id=294330e2-5005-4b7f-b1d8-e054daf3e721&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7/nodes?order_by=created_at_asc&page=1&pool_id=9228f3df-0110-4346-bbbc-2a14e197ba30&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"edef2a1d-6ce4-4751-ad0d-e8bbf61a2023","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:19:40.264429Z","updated_at":"2022-10-06T12:23:37.679819Z","pool_id":"294330e2-5005-4b7f-b1d8-e054daf3e721","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-placement-group-placement-group-edef2a1d6c","public_ip_v4":"212.47.247.29","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6ec793db-9c8e-4ec9-92ab-edbef5ae0370","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:13.710484Z","error_message":null,"id":"088342c7-f2a4-4e06-9fd5-c46c022fa0ed","name":"scw-placement-group-placement-group-088342c7f2","pool_id":"9228f3df-0110-4346-bbbc-2a14e197ba30","provider_id":"scaleway://instance/fr-par-1/fda23f67-89a1-4c16-ac8b-c02459ad96f7","public_ip_v4":"51.158.114.140","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:47.333250Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:47 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2364,7 +2319,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41ed825d-a855-4f5f-b9d3-373b6d3b562c
+      - 4fb0ca20-c3d4-4402-a2ff-20a9fa0b39c3
     status: 200 OK
     code: 200
     duration: ""
@@ -2373,49 +2328,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/90fe4f8e-b4cf-4ad4-b027-55be686a04ae
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"placement_group": {"id": "90fe4f8e-b4cf-4ad4-b027-55be686a04ae", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "326"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:23:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - df9e9b1e-e002-4526-a450-e29311190b9d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:19:16.561740Z","type":"kapsule","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:12:01.855362Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -2424,7 +2342,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:47 GMT
+      - Mon, 02 Jan 2023 14:14:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2434,7 +2352,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9f8f0a3-1c51-4525-843b-44e0c2179d0b
+      - 24760d36-e5cb-4192-8bd7-70b20f97ffd8
     status: 200 OK
     code: 200
     duration: ""
@@ -2443,12 +2361,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
     method: GET
   response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:23:37.775980Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:47.350778Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "609"
@@ -2457,7 +2375,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:47 GMT
+      - Mon, 02 Jan 2023 14:14:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2467,7 +2385,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7fff9f3-255c-477c-b6bb-193339ecb05b
+      - 028663c5-f56e-410e-b4f3-9df56a203f1b
     status: 200 OK
     code: 200
     duration: ""
@@ -2476,12 +2394,78 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e/kubeconfig
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/45d307dd-6f3a-472e-8877-76d3d5ee0929
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGRPVkVWNVRWUmpNVTlXYjFoRVZFMTVUVlJCZDA1VVJYbE5WR014VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV3h0Q2pOUVozVTBVRzloY1U5dk0ybGxVV1JyTTBWalpURTFNU3RWTVhCMU5VVXpjSGxzT1M5UmJGRlRPR2RGZVZBNFRFTkhXalptU21aTGFVMW5TMWxvY0dnS1pFMWFWVVpyZWpJMWFsSnNZWGh2TlRsNlNXMDBjRTVqY21oR2VIbFdibkZKU2t0dlJHTkxXV0ZJZVdKcWMySTRla0Y0VkVVMmNXeGhjR2hJTnk4dkx3cE9aek5CVTBoSGRuZzBPVXh4VUVrNFJqSlVUWEkwVmpsbmJVaHhVMmxLUm1GQ01VeFdRbEY1Wm01dFpYVm9kV3R1YlZad1VqTjNZbkZrVDBoaFFVbHpDamxTV1ZKREszWXJURk51TUZJNE5raDJZa2hKZVhSclYyNUtjbWMyTWtNMVlYZHlWbmRXVURaall6RnVOMEozTlVST2FEVndVWE14VkhrNVdsQTFVMFFLZFdzeFkzVXlOamszTXlzeWVpOVhkMnRzUTFoSE5VTnBNVUZMUlV0a1FYRlBjRWcwUTNCeFVFa3lWMUZZWXpoemQzVjROREZRVHpWR2EwcHFVVWR5ZFFwbVJEZHJOM2hLVHpneWRFRnJXR1ZSV0RCVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaR2NFOTZaV2s1UzJ4T2NFRjNXWGQyUlVGa1dXdE9hRU5RTVcxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJHMU5iVzkyV1dob2JpOWhVVGxGUVRFMGJtMXFaMVFyTldoVFduUlpSelF4Y21GU1dXNXdhMmgzU0dKb1VISk9Wd3BVZFRsdFQwdE9LekI2TjA5VUwxRkVVVUZWUWtoMU5GbEphREpDTDBWMVMyOXdjRkJRT0VaUmJWaDZXVWhrU21WSVkxQnlVMDh4UlZSR1ZWTkJOaXMwQ2pKSU1HaFpTbkJUZWxOalNHMVRabFZUYzFSUGRIUXlNWEJvTTIxRU4yWjNLM05ZT1hWcWVEaEpNbTFFYWtkbU1uVllOVVIyY2tocGQwSkhNMEpRV2xVS1FtZFFWV3AxV25wclMwTTBjalZqTldkcEt5dFZlQ3RSTDJ0UFJrOWFZbE5DUVdjelMzaFpTRTVhV1VwVVpUY3ZNbFZwYzA4clFYaENja29yTldNMFpncFRXRkZQUmtsRFJpdFJTRnB0UVRaVVEwNXJXRzQzVGpCdlpHeFRiamM0ZWtKT1l6bGhRbXRwTHlzMVFYaFZObU54V2xWdE9XVkZWWE12ZW5kM1prWXZDbTlYSzNsNVRuQm1kR2RzTXpBMlZVdFdUVEl3WVVoS1RVczRaVFJGZG05ek4zVjNWUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDc4NzIzZWUtNGU5Yi00YzRjLTg3MTgtYTgxZDJiNDYwMjdlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXWDdGNjFtMmJHOXFsQ2RsOFA2Z01EWGpCalBHbWc2TFVDZWU0d1dZeXJ3VDFpNTNGNW4xTDNLRA=="}'
+    body: '{"placement_group":{"id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "326"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6c38734c-9eef-4304-a4a6-24efeea35850
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7/nodes?order_by=created_at_asc&page=1&pool_id=9228f3df-0110-4346-bbbc-2a14e197ba30&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:13.710484Z","error_message":null,"id":"088342c7-f2a4-4e06-9fd5-c46c022fa0ed","name":"scw-placement-group-placement-group-088342c7f2","pool_id":"9228f3df-0110-4346-bbbc-2a14e197ba30","provider_id":"scaleway://instance/fr-par-1/fda23f67-89a1-4c16-ac8b-c02459ad96f7","public_ip_v4":"51.158.114.140","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:47.333250Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "606"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b2a231d7-5160-4b4a-80b0-f7c53b4ac3e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUkJlazR4YjFoRVZFMTZUVVJGZDAxVVJUQk5WRUY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURXg2Q204dlpIUmxiMXB2YzBaTmJtUXJXbmQwVFZkWk5IcFFVMDg1UXpKU1UyUkxaek5qUzBGNGQzZDBNRlpoWkRKWE4wdGxZM0pTU2xBeWNERlJOamhyYld3S01pOWFjM1pKYVZRMWNURkxibkJpU1hvM1V6TllZeTltY1dSMlFtdEdUVVEyUmtaS1NpOWpRMDE1VjFORE5YUlNha2g0ZUM5c1JqRmhhVzl1VGxZMVZRcDRlbWxKUzNGQlZqTktWMVpRVGt3eGJqZEdSVkl3YzFWMlFURmpZMEZLVGxoRGFsRjVjV1V3WnpWeVNrSm9iVTV1WVhZMFVrTnNkbEoxVDBObWIwUkVDa1JUWVc5MVZFUnFabkJsVkVoUE1uQjBRVk4yY0dWclpVODFXazVxYjFwUVVHdE1heTlKV25WdE9YcEdLMWhuV0hjMlRYTmxVbE01YVRCVGFIRkhLM1VLYlRCWE9FVXJSa2wyTm1kR2VqVlpaVXAxZGxWaE0yVkdRbGhJYUhSM1VVTmxaWEV6TkZkQ1ExQm1aM0oxZENzNFZXUlhNa1owTURkdWRURjVjbEpvU1FwUFdYUTRXa05IV1RVeVIxRm1OVlJDTjNoclEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVRVSnFWMEp0V0hSQ1RWcGFUeXRFTURsdkwzb3hNMDFaTTNoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmVXTXdSREpIZVdobE9HaDRjSE12S3l0RlNGUldNV3d2UzNOdmRYZHZkSHBOZVVSak0yeFBOV3hLYVU0MlJtZEtlZ3BKWjJzck5HWjFlRTF1UzNOMFZqRnliRGhNYXpjMmFuTXJjaTlVVlRZMVUzUXdlamN4ZWxZeU5IQkJNVEZtV2psSmNVRlFORlZSZEd0SmExQjBhVzlUQ2xCdE5DdGxZVmhQV0dGc2F5dEpVak4xY25WMmJVRjFZMG81U0RoS1pVNW5WalJWZDA1dFFuUTRla3N6ZWs1R1ptcERkRlpPUm01RmFuQmtNRWR3YUVRS2VHZzFka015U21aU1YwMHdkR2g0WkZoVFdWSm9VRzByWm05RFNEVm1MMFZ2WW5OM1YxTkxWRUZWYnk5cFZUVlBRV3RTU2s1NWRIbGhVMHhFV2pWTFFnb3hTRzV0VTFKd2FsTlFRWGhtYW0xbk0zZFdXRzlsYVZsdlpqUTNMekZ5YW5CWE4wVXdTbVpZVkdWcVQzUlVlVzVYTUZaWksxWlNPV2hrWlUxWU9EaDBDbUZYT1ZCd1QyTnhUMnQyTmpsMlF6bE5lbmswYlZGNlVtaFBWRzVrZEc5R1ZUSm1TQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWZhZmE5MWEtYTFmZS00MTYxLTkyYmEtOWRkZjRhN2ExZWY3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA5aHMyWDMydjRtMXkyRjJuV1R6RmpVaUkyNFRPZ1FSQ0s3ZGFkS25iWHhiVWpTazFEQWpxTWF2aA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2490,7 +2474,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:48 GMT
+      - Mon, 02 Jan 2023 14:14:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2500,7 +2484,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e89932cf-729b-400c-a42a-590c249fc822
+      - 24323864-3fab-402d-b380-7b2619455d58
     status: 200 OK
     code: 200
     duration: ""
@@ -2509,21 +2493,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e/nodes?order_by=created_at_asc&page=1&pool_id=294330e2-5005-4b7f-b1d8-e054daf3e721&status=unknown
-    method: GET
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9228f3df-0110-4346-bbbc-2a14e197ba30
+    method: DELETE
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"edef2a1d-6ce4-4751-ad0d-e8bbf61a2023","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:19:40.264429Z","updated_at":"2022-10-06T12:23:37.679819Z","pool_id":"294330e2-5005-4b7f-b1d8-e054daf3e721","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-placement-group-placement-group-edef2a1d6c","public_ip_v4":"212.47.247.29","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/6ec793db-9c8e-4ec9-92ab-edbef5ae0370","error_message":null}]}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.392386Z","id":"9228f3df-0110-4346-bbbc-2a14e197ba30","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"45d307dd-6f3a-472e-8877-76d3d5ee0929","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-01-02T14:14:50.406547084Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "605"
+      - "615"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:48 GMT
+      - Mon, 02 Jan 2023 14:14:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2533,23 +2517,118 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 168afbe2-8beb-4e88-8da5-a0863c5a263d
+      - 24e3d58d-7bc0-4418-b045-dcb470c317b9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"placement_group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.24.5","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/45d307dd-6f3a-472e-8877-76d3d5ee0929
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Mon, 02 Jan 2023 14:14:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5922d33-c90e-4d22-a1f5-09691962da50
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7?with_additional_resources=true
+    method: DELETE
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:50.477061531Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1335"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f7d202a1-bce8-47ef-9cd3-47f6c064bc6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:50.477062Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1332"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 989dcb01-7be4-4bf8-a796-e7338cef83ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"placement_group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.24.7","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters
     method: POST
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118316Z","updated_at":"2022-10-06T12:23:49.021840114Z","type":"kapsule","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471597528Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:50.480264840Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1338"
@@ -2558,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:49 GMT
+      - Mon, 02 Jan 2023 14:14:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2568,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b10e03c-d7fe-4ff5-a19d-a26caf516bbe
+      - afb8301d-f684-40ee-badb-893065688e8a
     status: 200 OK
     code: 200
     duration: ""
@@ -2577,12 +2656,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:23:49.021840Z","type":"kapsule","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:50.480265Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -2591,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:49 GMT
+      - Mon, 02 Jan 2023 14:14:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2601,89 +2680,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcf73ff4-a631-411c-bb6a-ba687d9a73a0
+      - ff17d28c-c2cf-457b-8d5d-bda3e3d5be67
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/294330e2-5005-4b7f-b1d8-e054daf3e721
-    method: DELETE
-  response:
-    body: '{"region":"fr-par","id":"294330e2-5005-4b7f-b1d8-e054daf3e721","cluster_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","created_at":"2022-10-06T12:18:07.015147Z","updated_at":"2022-10-06T12:23:49.311175875Z","name":"placement_group","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"90fe4f8e-b4cf-4ad4-b027-55be686a04ae","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:23:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ec377720-ec59-44d1-9046-0521f8b80c92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/90fe4f8e-b4cf-4ad4-b027-55be686a04ae
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Thu, 06 Oct 2022 12:23:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2edfba74-b7bd-4882-bd61-8c58c22a8817
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"name":"pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups
     method: POST
   response:
-    body: '{"placement_group": {"id": "de5a99d9-75aa-4247-98cd-d0386a847193", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "nl-ams-2"}}'
+    body: '{"placement_group":{"id":"91b0a766-6804-4986-92f5-6637c058042e","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "326"
@@ -2692,9 +2705,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:49 GMT
+      - Mon, 02 Jan 2023 14:14:50 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/de5a99d9-75aa-4247-98cd-d0386a847193
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/91b0a766-6804-4986-92f5-6637c058042e
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2704,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b7495cc-ba59-4e4b-9dcf-b4f19bf23fd5
+      - 409d31f1-7ce1-47a2-a692-3e3cac3c3f8c
     status: 201 Created
     code: 201
     duration: ""
@@ -2713,16 +2726,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/de5a99d9-75aa-4247-98cd-d0386a847193
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/91b0a766-6804-4986-92f5-6637c058042e
     method: GET
   response:
-    body: '{"placement_group": {"id": "de5a99d9-75aa-4247-98cd-d0386a847193", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "nl-ams-2"}}'
+    body: '{"placement_group":{"id":"91b0a766-6804-4986-92f5-6637c058042e","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "326"
@@ -2731,7 +2740,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:49 GMT
+      - Mon, 02 Jan 2023 14:14:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2741,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 938361a2-8ca7-4251-8860-49eae4e30a1b
+      - f714cb31-bbd9-4b91-bc13-8903b7cb8d20
     status: 200 OK
     code: 200
     duration: ""
@@ -2750,45 +2759,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e?with_additional_resources=false
-    method: DELETE
-  response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:23:50.261877294Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1335"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:23:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 96cabeb5-a787-41e6-98a1-83b6a662250a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:23:50.261877Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:50.477062Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -2797,7 +2773,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:50 GMT
+      - Mon, 02 Jan 2023 14:14:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2807,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b116650-9e87-47f1-92ad-cc81ce2253d8
+      - 1ad0d9e5-040a-4fc1-825d-6a787243240c
     status: 200 OK
     code: 200
     duration: ""
@@ -2816,12 +2792,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:23:51.126188Z","type":"kapsule","name":"placement_group","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:52.064752Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1337"
@@ -2830,7 +2806,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:54 GMT
+      - Mon, 02 Jan 2023 14:14:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2840,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21b0ae0a-fbf9-4786-bb6e-b9e140b14c43
+      - b7669af0-ddf4-4b4b-8a07-d4d13f51b1be
     status: 200 OK
     code: 200
     duration: ""
@@ -2849,12 +2825,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:23:51.126188Z","type":"kapsule","name":"placement_group","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:52.064752Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1337"
@@ -2863,7 +2839,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:54 GMT
+      - Mon, 02 Jan 2023 14:14:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2873,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f26eb493-af70-44c1-a985-858aaa03449c
+      - 047f6a0d-180b-40a8-a079-0b3390d92742
     status: 200 OK
     code: 200
     duration: ""
@@ -2882,12 +2858,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGRPVkVWNVRXcE5NVTFHYjFoRVZFMTVUVlJCZDA1VVJYbE5hazB4VFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVEZLQ21Jck5HbFFkbFprVVd4VGFqa3ZTRWgyVG1nM1EyMVNhV1prTlZKTlExUnZLMVZSUmpWV1ZYTkdSQzlNUjIxaWJIa3pXbU5HZDFScGF5dGFaVk5TYzNjS2FqazRjalZ5ZFZacWNEUnROM04xYnpGTmJsQndXV2Q2YkhoUlFYQmhibWhVYjJ0Vk9IY3lPQzluTlUxbWVsbGhPVUZLVkVKWUx6QlZhRTQ1TkhJd2JBcG5ZMjFxVkRWV2NsRklRWGR5YWpKNFpHVkpOM2hSWlV4V01Vb3JNblYyWXpnMVMyUlFRMVpuWjJFeVJucEZhWEY1WWtvNGIxbGxMekp0TVNzMGNGQXdDbUY2Y0daa01rOUdjRFp5TUVjMmVsQndSV3Q0VkUxWU1tbGFVREJYY1RsSlZUQlpXWHBCTmpSMFUzSklaR0pHVjA1d1JtUnBOM0pIVERWNVVVUnBWelFLVEV0WVREUTRkalpVV1cxdlN6RlJjR0ZZU0dwU05ISnBZVUZ4VTNaQ09HSjFUek5NZW1oM2JtTlZlaTk0VG0wd2RWZ3ZiVlJXWlc4NVVqUmxkRFJHTHdwWFozVjZORTVETVZFM2QzTlJSVzlCVHl0TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1RqZDBlWEZ1TWtSMFpFTkxkRUkzUVdadFNGbzFMM1o2WkVKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1ZIaE1URzFOY0VoRFpXOXRaMnM1YjJGdloxQmFVbTA1YWtveE9HVlVXakF2TmpodGJuVmtja3BLUjBKaFVrTlRSZ3B5V25sTlkzbzJiM3B3ZVhKM05IaFFZVXB2Vm5kd1NqbE1UamhzUlVWcFRTOVZVMFZCZWpOdGRFMVNSMHBSVW5obFZYSlJNbTg0Tnk4d2QybEJNR2R0Q2tWT1QwWkZlV1p6U21SMVMyWTFOMVphUzBjd1pFWXdjWE5DV0RWbmNXdFFaV1ZvYzAxa1dtbDVMMWN5T0RKd05IVTJjRXBwU1hCdVVFUjFRVGhOTlRNS1dpOW9SREJRVFZZdmJUY3djbWRoY1haMFVIRXJjRlp6V25saVZUUnhhWEZ6V2xKb1pWSXZhVWhDVUVaV2RVaHJjRTlMUjBwdFpuQmllWFJtT1dOdE5ncDNPVTlGYTNoRlZsWmpNR0pEY0RKMGEyc3ljbmRQUlhFck1UWnZaWGRqVTI1Vk1USXpVR1IzVFdSRGQyUlhhMjlzVmpSWmFVRlNWR1Z6VVVzNFQxSnlDbGxuZDJGR1VGRnpibVEzUXpNMFRHOVlaVTloVkV4U1NHNVZPV3hpTTBoeGEwUmlOUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTMxOWUyZmQtMWUwOC00NTQyLWIwYjYtNmNiZmFjNGZkYTY3LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6MFN3N01tVU1jZGR6WFFGZFBUT0t3ZFNxdUJpU0xEQ2I1WXBPeUY3SUN3Y3g4cmxNT1R6TVh6aQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUlJNVTFXYjFoRVZFMTZUVVJGZDAxVVJUQk5WRkV4VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEI0Q2xWQ04xZFFUemRZVW1VemNXNVZTMkUwTTJnNGMxTlhka053WjFremNUUnRibXRSZDJVemNFSjZTV3haUzJnMmVTOXRWa1V2ZVdSMmRUQTRXV05yT0M4S01rUkVlRXMzY0hkWFdISk9iSEV4VmtkVmFDOXBNMDVDU3l0RWRqUk9TRlZRZERsbldXUkxSMWhxU0V4eVNGTm1XbEJMVWsxRWJFNU5hR2hEVDJ4NGJBcDNXR0Z4UlhCc2NtZEthMmd5YVVsRlp6a3lZblVyUVc0MVZsSlNhSFZsZDB0MlpFSlVlRXBEYWxCb1NrSlFlazFIZEZaV05rNXlkMFZtYzBWWFMyZ3hDaTlJTmk5alZETjFWM1ZMYm5wMFUxSndha0V5VldkbVRtOTJPVm80VG14c1VGTnNNbkJaYjBwak5YaFFTMFFyWVhOUlRHRmhNRGR0TWtSdGFYUmtMMHNLYTJFM2FHWnBkbkF2Ylhob2VWRk5ia2xQZWtkQmJISjVNakpJTkVkNGN6Qk5NakprYWsxMlptdE5VMUUzWlVwQ1REaDZSMGhUVFU0elRsWXhaelpDU3dwbldGTllSWFJrVVV3d1VXSkVWVUY2TjBwelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTU16Sm1hRzFNVlVKVmNUbGpSMUJLWXpSSVFrcGxZa3hCTUdkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1IzRklaVmhxZEdObVVYVnVNMFZpYVV0bVNXaFplVGswYmtwSFowbGpTVGRhSzFoNVEwSTFZMXBGYW5wdVVXODBid3BZUXpoWlJVNVBWRWh1VVM5cGRWQlNaSFZHY0ZVNVNYWXZLMEppTDJzNFNIaG1lRVJEZFVkblZuSkdhRGg0WWpBeVVra3hhalExUTNFeWNqbEdUMmwzQ210cldITTNUbTlXY25CaFpHMWhVV3g2ZUZRNWFtVm1NM2hwUWxRd2MxVXhZV2hHUVdWcmIwMWxOMm94UVVsNVVrRlZZazFYV0RKVVJuVnlNREFyWmtJS1dHeHpWbkpSYm1OVWFEaHZNa1ZWWmpsck5reDFZa2xFYVZwT1MycFhOeTlFVkhkWmFGbElOa3B5YjJ0bFVHUmFURU5XYlVwWlVFbDZVWHBGTUU5VGN3cGxOSGg0VEhORWRXWnZOWEJVYURGcVdGbHdkbVpaVlhreVVUZG1NalZYZGpGd09HSkpRV2RCYkhwaFRFZENkbk5rV2xoQ1NqSkRWMVl6YmpBd2RHNXRDbFZtSzJGelFqVXpTVFJ0Vld4alExVlBhRE50WnpOWlNIRTVObUZDYTBOb00yTTNlUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZmZkYzk2ODUtMTM0Ni00Yzg3LWE0M2MtMjA0YzM2YzI5MDA0LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIWFFJSzFiNTBweHhlczRrY3Q0TzE2cURSd2FBMDhHQXlDM0I0SXJweHpjNVczREpqY0kxTURtag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2896,7 +2872,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:54 GMT
+      - Mon, 02 Jan 2023 14:14:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2906,7 +2882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92d29076-8fd7-465c-b67f-efccce1d27e4
+      - 6256d5b7-478c-4b9c-a5a7-eb29a62aa837
     status: 200 OK
     code: 200
     duration: ""
@@ -2915,12 +2891,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:23:51.126188Z","type":"kapsule","name":"placement_group","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:52.064752Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1337"
@@ -2929,7 +2905,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:54 GMT
+      - Mon, 02 Jan 2023 14:14:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2939,23 +2915,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6060b85d-30fd-49ef-a4e4-d2c7bde03e76
+      - c789141b-e571-4274-b18a-5bfd72d07344
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"placement_group","node_type":"gp1_xs","placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"nl-ams-2","root_volume_type":"default_volume_type","root_volume_size":null}'
+    body: '{"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"nl-ams-2","root_volume_type":"default_volume_type","root_volume_size":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67/pools
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004/pools
     method: POST
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677058933Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111522692Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "614"
@@ -2964,7 +2940,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:55 GMT
+      - Mon, 02 Jan 2023 14:14:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2974,7 +2950,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3b7467d-61e9-4d54-9916-c2f161451e30
+      - 3fbc4840-8c10-4160-be82-bca2170f9f6b
     status: 200 OK
     code: 200
     duration: ""
@@ -2983,12 +2959,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -2997,7 +2973,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:55 GMT
+      - Mon, 02 Jan 2023 14:14:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3007,7 +2983,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7c37da2-2e12-4ee2-8753-f3079337ccaf
+      - 48ce6797-cc80-4a59-ba35-1376bdcc0b8d
     status: 200 OK
     code: 200
     duration: ""
@@ -3016,12 +2992,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:23:50.261877Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.532248Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:14:50.477062Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -3030,7 +3006,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:23:57 GMT
+      - Mon, 02 Jan 2023 14:15:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3040,7 +3016,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee1c60dc-d0a1-495c-8ec9-f8f33baff67d
+      - 548b4665-de6a-4b9d-be82-bde898894512
     status: 200 OK
     code: 200
     duration: ""
@@ -3049,12 +3025,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3063,7 +3039,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:24:00 GMT
+      - Mon, 02 Jan 2023 14:15:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3073,7 +3049,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be82b4cc-68d6-4ba6-9e4d-3e8fcea7d483
+      - 043705f8-ce85-4a32-938f-3db32fb2a4a8
     status: 200 OK
     code: 200
     duration: ""
@@ -3082,276 +3058,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7
     method: GET
   response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:23:50.261877Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1332"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:24:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 905bd8d5-2f9d-4da1-b021-3c6ad3f7af9a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
-    method: GET
-  response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:24:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2d93f0b2-61d5-4923-9980-a62920619ffb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:23:50.261877Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1332"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:24:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 331c3093-c5a6-4666-b7be-73fdfca95d6a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
-    method: GET
-  response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:24:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9bd08baa-6302-4c5e-af60-28c4fbe0b8af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:23:50.261877Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1332"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:24:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 09d3ba5d-9323-44f0-8be7-5a0e887221f5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
-    method: GET
-  response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:24:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f01a7f26-dd43-4f3d-922d-c059bd2fd420
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:17:56.544990Z","updated_at":"2022-10-06T12:23:50.261877Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://478723ee-4e9b-4c4c-8718-a81d2b46027e.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.478723ee-4e9b-4c4c-8718-a81d2b46027e.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1332"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:24:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3b8e9cdc-3649-425e-9f85-e9ca1ed752f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
-    method: GET
-  response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:24:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bf484a77-ca5c-4c91-a2eb-c034ac5660df
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/478723ee-4e9b-4c4c-8718-a81d2b46027e
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"478723ee-4e9b-4c4c-8718-a81d2b46027e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"efafa91a-a1fe-4161-92ba-9ddf4a7a1ef7","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3360,7 +3072,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:24:24 GMT
+      - Mon, 02 Jan 2023 14:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3370,7 +3082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fb3827d-4a28-46e0-ad13-2b47b5599b09
+      - 1c18c0c5-90f5-4758-997c-a2c43e5715b4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3379,12 +3091,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3393,7 +3105,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:24:25 GMT
+      - Mon, 02 Jan 2023 14:15:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3403,7 +3115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ad57a24-cace-4771-a2ae-29298e5af04a
+      - 863ede6f-7297-417b-beec-1a46d7a79d37
     status: 200 OK
     code: 200
     duration: ""
@@ -3412,12 +3124,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3426,7 +3138,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:24:31 GMT
+      - Mon, 02 Jan 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3436,7 +3148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3a3ae73-cefe-421d-9049-fb844afe5262
+      - b78e1695-fb98-4ac3-8d2e-68d569cb56e2
     status: 200 OK
     code: 200
     duration: ""
@@ -3445,12 +3157,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3459,7 +3171,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:24:36 GMT
+      - Mon, 02 Jan 2023 14:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3469,7 +3181,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 516c03f3-7ad4-4e2c-94f0-dea01345afab
+      - 8250022b-2ef7-46da-abd2-03fd3f1d383e
     status: 200 OK
     code: 200
     duration: ""
@@ -3478,12 +3190,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3492,7 +3204,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:24:41 GMT
+      - Mon, 02 Jan 2023 14:15:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3502,7 +3214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d26e6dea-2f44-47ef-a2ab-5b266d2b7cd0
+      - 72ba5c9a-09a1-4c09-b06c-94312e458419
     status: 200 OK
     code: 200
     duration: ""
@@ -3511,12 +3223,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3525,7 +3237,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:24:51 GMT
+      - Mon, 02 Jan 2023 14:15:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3535,7 +3247,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4229523b-2a54-4f9d-a19b-564bdb5d230c
+      - ad182897-5be9-427b-88b4-dcc1e0177cb4
     status: 200 OK
     code: 200
     duration: ""
@@ -3544,12 +3256,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3558,7 +3270,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:24:56 GMT
+      - Mon, 02 Jan 2023 14:15:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3568,7 +3280,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d95266d-ba34-4366-9254-8c4aeaa5f2ab
+      - 49c3b2fd-4349-459b-a5e9-32fff9eadb8a
     status: 200 OK
     code: 200
     duration: ""
@@ -3577,12 +3289,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3591,7 +3303,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:01 GMT
+      - Mon, 02 Jan 2023 14:15:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3601,7 +3313,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfb5f015-96ab-40b4-9292-7cf9f6f87bb7
+      - 7fb2b13a-5907-42fc-bfb6-d2816525f592
     status: 200 OK
     code: 200
     duration: ""
@@ -3610,12 +3322,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3624,7 +3336,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:06 GMT
+      - Mon, 02 Jan 2023 14:15:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3634,7 +3346,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 093a9643-7b6f-4ca5-9f79-a63185374695
+      - 17fc4b37-aceb-4496-8e86-bcd9723df3a7
     status: 200 OK
     code: 200
     duration: ""
@@ -3643,12 +3355,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3657,7 +3369,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:11 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3667,7 +3379,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb574a88-3c52-43fc-a9d8-b0f5fb2316f3
+      - c665ab08-d262-42f2-a3e2-9f079fb57cfb
     status: 200 OK
     code: 200
     duration: ""
@@ -3676,12 +3388,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3690,7 +3402,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:17 GMT
+      - Mon, 02 Jan 2023 14:15:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3700,7 +3412,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99510883-9d4c-4925-bb45-3e2761d4076d
+      - 8a00a8bd-afea-46c0-b164-73ae40572521
     status: 200 OK
     code: 200
     duration: ""
@@ -3709,12 +3421,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3723,7 +3435,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:22 GMT
+      - Mon, 02 Jan 2023 14:15:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3733,7 +3445,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2619cb1-f5b0-44cb-94f3-9239e480b623
+      - d6b406c9-979e-4a59-a92f-94e2682aad16
     status: 200 OK
     code: 200
     duration: ""
@@ -3742,12 +3454,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3756,7 +3468,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:27 GMT
+      - Mon, 02 Jan 2023 14:16:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3766,7 +3478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1793edb8-143d-421c-8969-d56d4cac5f00
+      - e3ab24ea-384c-48a3-b522-5977687bee29
     status: 200 OK
     code: 200
     duration: ""
@@ -3775,12 +3487,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3789,7 +3501,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:32 GMT
+      - Mon, 02 Jan 2023 14:16:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3799,7 +3511,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f73c38d-a418-42c4-b57f-3eb6b4486a41
+      - 707256cd-52c4-426a-af54-a3605edeb78d
     status: 200 OK
     code: 200
     duration: ""
@@ -3808,12 +3520,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3822,7 +3534,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:37 GMT
+      - Mon, 02 Jan 2023 14:16:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3832,7 +3544,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 593bc5ec-4bc9-42ef-b4fc-5f17da43188c
+      - b098e8d9-0ff6-4684-986f-7e4e2e6a7b9d
     status: 200 OK
     code: 200
     duration: ""
@@ -3841,12 +3553,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3855,7 +3567,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:42 GMT
+      - Mon, 02 Jan 2023 14:16:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3865,7 +3577,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d9fd09e-75ab-4575-be4a-3c0ab7a30388
+      - 17783c99-b939-4f36-9a67-337714383c65
     status: 200 OK
     code: 200
     duration: ""
@@ -3874,12 +3586,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3888,7 +3600,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:47 GMT
+      - Mon, 02 Jan 2023 14:16:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3898,7 +3610,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfc679c8-03aa-4f32-b461-c4f7b086c1dd
+      - 41e10863-9acc-40e8-b081-88032d989aa1
     status: 200 OK
     code: 200
     duration: ""
@@ -3907,12 +3619,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3921,7 +3633,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:52 GMT
+      - Mon, 02 Jan 2023 14:16:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3931,7 +3643,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e20d8854-2e23-48ec-b6be-a8ee06ab688b
+      - 972c3594-ce2a-4647-b6f8-724bf934799b
     status: 200 OK
     code: 200
     duration: ""
@@ -3940,12 +3652,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3954,7 +3666,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:25:57 GMT
+      - Mon, 02 Jan 2023 14:16:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3964,7 +3676,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9b24523-be8f-4258-8a25-882312d9e2fa
+      - f887214e-9bd8-4012-be0d-e702781cc8b6
     status: 200 OK
     code: 200
     duration: ""
@@ -3973,12 +3685,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -3987,7 +3699,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:02 GMT
+      - Mon, 02 Jan 2023 14:16:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3997,7 +3709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b642eb1-f8a8-4b2d-b5f7-334d5355468c
+      - b91f56f8-4c83-4736-b0ca-11973c434bfa
     status: 200 OK
     code: 200
     duration: ""
@@ -4006,12 +3718,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4020,7 +3732,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:07 GMT
+      - Mon, 02 Jan 2023 14:16:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4030,7 +3742,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50fbcaaf-e13a-4126-8abf-55ec1f5cc75a
+      - c837b6ec-bcdc-40a8-b931-86dee93eb92e
     status: 200 OK
     code: 200
     duration: ""
@@ -4039,12 +3751,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4053,7 +3765,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:13 GMT
+      - Mon, 02 Jan 2023 14:16:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4063,7 +3775,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51982411-36d4-418d-a0f2-0445a5226db8
+      - cd8c29d4-d0cd-446e-944b-94997667ef4a
     status: 200 OK
     code: 200
     duration: ""
@@ -4072,12 +3784,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4086,7 +3798,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:18 GMT
+      - Mon, 02 Jan 2023 14:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4096,7 +3808,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3563607a-41e6-4ace-8df6-7623ae9f8f7c
+      - af48b5ec-6191-41f0-b1cd-a75277cdd145
     status: 200 OK
     code: 200
     duration: ""
@@ -4105,12 +3817,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4119,7 +3831,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:27 GMT
+      - Mon, 02 Jan 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4129,7 +3841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4df15d0-8c04-4f1b-ab81-467db1ad9b82
+      - 2386d433-72fb-4995-b4f4-d7df18179801
     status: 200 OK
     code: 200
     duration: ""
@@ -4138,12 +3850,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4152,7 +3864,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:32 GMT
+      - Mon, 02 Jan 2023 14:17:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4162,7 +3874,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08502a43-1aa5-45a7-9c1d-338aa4ad25e9
+      - 2a1ba560-08b3-45f3-9860-2196707e3186
     status: 200 OK
     code: 200
     duration: ""
@@ -4171,12 +3883,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4185,7 +3897,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:38 GMT
+      - Mon, 02 Jan 2023 14:17:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4195,7 +3907,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f4789eb-5e59-48e3-9417-15aac2eff822
+      - 26459f48-a767-449c-bc9a-3e4940e6bb85
     status: 200 OK
     code: 200
     duration: ""
@@ -4204,12 +3916,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4218,7 +3930,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:43 GMT
+      - Mon, 02 Jan 2023 14:17:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4228,7 +3940,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34a9c811-28cd-49a2-ab2b-e07839c97f5d
+      - 3487b848-11b9-40f2-ab35-99d59b3d246e
     status: 200 OK
     code: 200
     duration: ""
@@ -4237,12 +3949,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4251,7 +3963,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:48 GMT
+      - Mon, 02 Jan 2023 14:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4261,7 +3973,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b97957c9-c855-4265-8659-f3b8202db3b8
+      - 1a1c2cdf-18bc-45ad-88a9-6896541ba8a8
     status: 200 OK
     code: 200
     duration: ""
@@ -4270,12 +3982,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4284,7 +3996,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:54 GMT
+      - Mon, 02 Jan 2023 14:17:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4294,7 +4006,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8f78cda-b4d2-4643-8cc6-ed8ce8369606
+      - 8ee95b3f-5324-42a5-8b99-8fd586d1e768
     status: 200 OK
     code: 200
     duration: ""
@@ -4303,12 +4015,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4317,7 +4029,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:26:59 GMT
+      - Mon, 02 Jan 2023 14:17:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4327,7 +4039,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41b26a8d-3f5d-496a-b22b-4e91464574e0
+      - 4c8654df-763f-42e3-8fc5-c74db782d4ef
     status: 200 OK
     code: 200
     duration: ""
@@ -4336,12 +4048,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4350,7 +4062,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:04 GMT
+      - Mon, 02 Jan 2023 14:17:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4360,7 +4072,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 166f355e-6890-4835-acc3-bc8471aed9f1
+      - 1571340f-a7a6-4d7e-85c0-b418a1ef9e1f
     status: 200 OK
     code: 200
     duration: ""
@@ -4369,12 +4081,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4383,7 +4095,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:09 GMT
+      - Mon, 02 Jan 2023 14:17:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4393,7 +4105,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 669f8b04-5d2b-42ab-869f-51d80de771d9
+      - 6739fff9-efd8-4078-9689-2c4565c6f992
     status: 200 OK
     code: 200
     duration: ""
@@ -4402,12 +4114,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4416,7 +4128,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:14 GMT
+      - Mon, 02 Jan 2023 14:17:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4426,7 +4138,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e56dfd0-6fc8-4e0c-9427-e9e32ab7093f
+      - 40bd46fd-4f1e-454e-a5f5-301a4fdaf7fa
     status: 200 OK
     code: 200
     duration: ""
@@ -4435,12 +4147,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4449,7 +4161,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:19 GMT
+      - Mon, 02 Jan 2023 14:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4459,7 +4171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78d23c01-0df2-44f1-a85a-cd290b91c7ea
+      - 2e717a88-f708-44ea-9191-dba8175acac0
     status: 200 OK
     code: 200
     duration: ""
@@ -4468,12 +4180,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4482,7 +4194,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:24 GMT
+      - Mon, 02 Jan 2023 14:17:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4492,7 +4204,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ef05c77-9d0f-4316-b554-612090683704
+      - f1cc864a-dbd5-4816-871b-9d4927c04874
     status: 200 OK
     code: 200
     duration: ""
@@ -4501,12 +4213,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4515,7 +4227,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:29 GMT
+      - Mon, 02 Jan 2023 14:17:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4525,7 +4237,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ace7d8e3-d874-4cb7-b817-f08261fa150f
+      - a920ca6d-054e-48aa-9634-b84fd9b72b8c
     status: 200 OK
     code: 200
     duration: ""
@@ -4534,12 +4246,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4548,7 +4260,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:34 GMT
+      - Mon, 02 Jan 2023 14:18:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4558,7 +4270,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97b95f12-55cb-4e6f-ad0c-7b11344b3e41
+      - c5e9645e-f954-4604-b30b-ff7da327063c
     status: 200 OK
     code: 200
     duration: ""
@@ -4567,12 +4279,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4581,7 +4293,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:40 GMT
+      - Mon, 02 Jan 2023 14:18:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4591,7 +4303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e95da4d6-aeef-4872-be55-0ba3ab5b5229
+      - f492afb4-8c77-4dfb-a58f-ef0208b8e563
     status: 200 OK
     code: 200
     duration: ""
@@ -4600,12 +4312,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4614,7 +4326,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:45 GMT
+      - Mon, 02 Jan 2023 14:18:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4624,7 +4336,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2ff53aa-fd99-4c9e-88e7-7e5c802b353c
+      - 76667168-2d4e-4705-a837-e41843936dac
     status: 200 OK
     code: 200
     duration: ""
@@ -4633,12 +4345,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4647,7 +4359,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:50 GMT
+      - Mon, 02 Jan 2023 14:18:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4657,7 +4369,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae477186-7b1f-478e-ba28-47f2c6698640
+      - abea9f31-34e9-452f-983c-c2a975782463
     status: 200 OK
     code: 200
     duration: ""
@@ -4666,12 +4378,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4680,7 +4392,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:27:55 GMT
+      - Mon, 02 Jan 2023 14:18:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4690,7 +4402,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 858571a3-cff7-4e1a-b387-f34a4c5b9c06
+      - c1c5e423-3e1c-41f9-aa4a-f8dd73f7ec67
     status: 200 OK
     code: 200
     duration: ""
@@ -4699,12 +4411,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4713,7 +4425,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:04 GMT
+      - Mon, 02 Jan 2023 14:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4723,7 +4435,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63fb7f04-778a-4704-a245-b7f7d9ae0074
+      - c0b38f8e-51c4-43be-8d37-545c37acb981
     status: 200 OK
     code: 200
     duration: ""
@@ -4732,12 +4444,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4746,7 +4458,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:09 GMT
+      - Mon, 02 Jan 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4756,7 +4468,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fbb4c12-d891-48c2-9d58-cfd61d7250b7
+      - b12518c0-2cbc-4e12-92be-1a31d3a699ad
     status: 200 OK
     code: 200
     duration: ""
@@ -4765,12 +4477,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4779,7 +4491,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:14 GMT
+      - Mon, 02 Jan 2023 14:18:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4789,7 +4501,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0c066a5-e95b-458c-8f08-8e1ca68a3b49
+      - e14bfecd-98c4-4e23-b2bc-71f7da10b29d
     status: 200 OK
     code: 200
     duration: ""
@@ -4798,12 +4510,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4812,7 +4524,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:19 GMT
+      - Mon, 02 Jan 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4822,7 +4534,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13026edf-da47-4a34-ae60-9e5020a1009c
+      - 73d5d6e5-3f28-4054-8979-86ae71fc517a
     status: 200 OK
     code: 200
     duration: ""
@@ -4831,12 +4543,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:23:54.677059Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "611"
@@ -4845,7 +4557,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:24 GMT
+      - Mon, 02 Jan 2023 14:18:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4855,7 +4567,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bab9f308-c1d9-4a14-b9e8-d92e1eb3a4ed
+      - 3f5b5d48-cb5a-43d7-84d1-434f0f48c7ef
     status: 200 OK
     code: 200
     duration: ""
@@ -4864,12 +4576,309 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:28:29.913687Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5c967c1-a87c-4f19-87ab-6741e007cf31
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e18d2bb3-2edb-4fc1-a61e-55eb29ac4f5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d2ee32e2-7e20-4dce-9e65-f2c5cb2859d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 66f474d6-d3df-4c97-a000-3885c2579b8f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b94f2442-48ac-4973-804e-45f0900d9f05
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f90549a1-24db-4e5e-a4e7-804d4e93469e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - beaa9eda-9d5c-41ba-bb9f-c5d10083bcea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5e25c9e9-edbd-43c6-b628-fc25d4639b6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:56.111523Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "611"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 98ce4846-ed59-467c-a764-1b5487f1725c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:41.343092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "609"
@@ -4878,7 +4887,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:30 GMT
+      - Mon, 02 Jan 2023 14:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4888,7 +4897,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66c97da7-5d04-437b-a6e2-6893bb33e27e
+      - 0ede0a2e-ed8f-4fbf-b5df-7a05c5c6d941
     status: 200 OK
     code: 200
     duration: ""
@@ -4897,12 +4906,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:24:44.901470Z","type":"kapsule","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:16:05.429153Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -4911,7 +4920,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:30 GMT
+      - Mon, 02 Jan 2023 14:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4921,7 +4930,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e184d3a-9821-4132-878a-eb86403d94e0
+      - 8163aca5-7679-4cc7-90f9-c038ae6a05f4
     status: 200 OK
     code: 200
     duration: ""
@@ -4930,12 +4939,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:28:29.913687Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:41.343092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "609"
@@ -4944,7 +4953,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:30 GMT
+      - Mon, 02 Jan 2023 14:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4954,7 +4963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6952283-27dc-49df-aca6-85992a71560e
+      - 51759764-fe7c-40fa-b9fb-4b9d5dc7195b
     status: 200 OK
     code: 200
     duration: ""
@@ -4963,21 +4972,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67/nodes?order_by=created_at_asc&page=1&pool_id=0773a1b9-9fe6-41cf-9b5e-868decf70cae&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004/nodes?order_by=created_at_asc&page=1&pool_id=18ed8423-0530-4b8a-a270-923fc7557c2e&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"nl-ams","id":"5d7f59d1-54ec-4d07-8fd1-1032b7771ddf","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:24:59.884339Z","updated_at":"2022-10-06T12:28:29.889366Z","pool_id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-placement-group-placement-group-5d7f59d154","public_ip_v4":"51.158.236.40","public_ip_v6":null,"provider_id":"scaleway://instance/nl-ams-2/b3f96b65-3b64-4de4-ae5d-dd2b3bff44ab","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:16:54.867582Z","error_message":null,"id":"5e9a2717-f53b-4aa2-8cdf-d34566dfac0d","name":"scw-placement-group-placement-group-5e9a2717f5","pool_id":"18ed8423-0530-4b8a-a270-923fc7557c2e","provider_id":"scaleway://instance/nl-ams-2/c67bebb9-0dbb-4f1a-87a8-080ab689a99f","public_ip_v4":"51.158.243.1","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-01-02T14:19:41.320768Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:30 GMT
+      - Mon, 02 Jan 2023 14:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4987,7 +4996,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c75a5d49-1691-4cc2-8ade-74f3f14343ac
+      - b37789d2-4031-4e31-8216-fa5ef5635c2a
     status: 200 OK
     code: 200
     duration: ""
@@ -4996,12 +5005,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:24:44.901470Z","type":"kapsule","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:16:05.429153Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -5010,7 +5019,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:30 GMT
+      - Mon, 02 Jan 2023 14:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5020,7 +5029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1526040e-e613-405c-b7af-82e19a6cc3b6
+      - c27da7b1-454c-4d47-af76-118cfe3fd9e8
     status: 200 OK
     code: 200
     duration: ""
@@ -5029,12 +5038,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:28:29.913687Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:41.343092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "609"
@@ -5043,7 +5052,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:30 GMT
+      - Mon, 02 Jan 2023 14:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5053,7 +5062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10a89204-7093-4a10-8579-14e8e6f5369f
+      - ca2e8ce8-19ec-414c-a2e3-60bc92991b36
     status: 200 OK
     code: 200
     duration: ""
@@ -5062,12 +5071,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:24:44.901470Z","type":"kapsule","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:16:05.429153Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -5076,7 +5085,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5086,7 +5095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c1fb201-49b7-46dc-9186-ccdd826f6f14
+      - d91b9f4c-e3c8-4ed5-bde7-51fa35978872
     status: 200 OK
     code: 200
     duration: ""
@@ -5095,16 +5104,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/de5a99d9-75aa-4247-98cd-d0386a847193
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/91b0a766-6804-4986-92f5-6637c058042e
     method: GET
   response:
-    body: '{"placement_group": {"id": "de5a99d9-75aa-4247-98cd-d0386a847193", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "nl-ams-2"}}'
+    body: '{"placement_group":{"id":"91b0a766-6804-4986-92f5-6637c058042e","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "326"
@@ -5113,7 +5118,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5123,7 +5128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53ffff42-f662-4a48-aa95-6bf4c2250567
+      - f054a504-49c2-47a0-9538-e8304e06d91f
     status: 200 OK
     code: 200
     duration: ""
@@ -5132,12 +5137,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGRPVkVWNVRXcE5NVTFHYjFoRVZFMTVUVlJCZDA1VVJYbE5hazB4VFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVEZLQ21Jck5HbFFkbFprVVd4VGFqa3ZTRWgyVG1nM1EyMVNhV1prTlZKTlExUnZLMVZSUmpWV1ZYTkdSQzlNUjIxaWJIa3pXbU5HZDFScGF5dGFaVk5TYzNjS2FqazRjalZ5ZFZacWNEUnROM04xYnpGTmJsQndXV2Q2YkhoUlFYQmhibWhVYjJ0Vk9IY3lPQzluTlUxbWVsbGhPVUZLVkVKWUx6QlZhRTQ1TkhJd2JBcG5ZMjFxVkRWV2NsRklRWGR5YWpKNFpHVkpOM2hSWlV4V01Vb3JNblYyWXpnMVMyUlFRMVpuWjJFeVJucEZhWEY1WWtvNGIxbGxMekp0TVNzMGNGQXdDbUY2Y0daa01rOUdjRFp5TUVjMmVsQndSV3Q0VkUxWU1tbGFVREJYY1RsSlZUQlpXWHBCTmpSMFUzSklaR0pHVjA1d1JtUnBOM0pIVERWNVVVUnBWelFLVEV0WVREUTRkalpVV1cxdlN6RlJjR0ZZU0dwU05ISnBZVUZ4VTNaQ09HSjFUek5NZW1oM2JtTlZlaTk0VG0wd2RWZ3ZiVlJXWlc4NVVqUmxkRFJHTHdwWFozVjZORTVETVZFM2QzTlJSVzlCVHl0TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1RqZDBlWEZ1TWtSMFpFTkxkRUkzUVdadFNGbzFMM1o2WkVKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1ZIaE1URzFOY0VoRFpXOXRaMnM1YjJGdloxQmFVbTA1YWtveE9HVlVXakF2TmpodGJuVmtja3BLUjBKaFVrTlRSZ3B5V25sTlkzbzJiM3B3ZVhKM05IaFFZVXB2Vm5kd1NqbE1UamhzUlVWcFRTOVZVMFZCZWpOdGRFMVNSMHBSVW5obFZYSlJNbTg0Tnk4d2QybEJNR2R0Q2tWT1QwWkZlV1p6U21SMVMyWTFOMVphUzBjd1pFWXdjWE5DV0RWbmNXdFFaV1ZvYzAxa1dtbDVMMWN5T0RKd05IVTJjRXBwU1hCdVVFUjFRVGhOTlRNS1dpOW9SREJRVFZZdmJUY3djbWRoY1haMFVIRXJjRlp6V25saVZUUnhhWEZ6V2xKb1pWSXZhVWhDVUVaV2RVaHJjRTlMUjBwdFpuQmllWFJtT1dOdE5ncDNPVTlGYTNoRlZsWmpNR0pEY0RKMGEyc3ljbmRQUlhFck1UWnZaWGRqVTI1Vk1USXpVR1IzVFdSRGQyUlhhMjlzVmpSWmFVRlNWR1Z6VVVzNFQxSnlDbGxuZDJGR1VGRnpibVEzUXpNMFRHOVlaVTloVkV4U1NHNVZPV3hpTTBoeGEwUmlOUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTMxOWUyZmQtMWUwOC00NTQyLWIwYjYtNmNiZmFjNGZkYTY3LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6MFN3N01tVU1jZGR6WFFGZFBUT0t3ZFNxdUJpU0xEQ2I1WXBPeUY3SUN3Y3g4cmxNT1R6TVh6aQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUlJNVTFXYjFoRVZFMTZUVVJGZDAxVVJUQk5WRkV4VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEI0Q2xWQ04xZFFUemRZVW1VemNXNVZTMkUwTTJnNGMxTlhka053WjFremNUUnRibXRSZDJVemNFSjZTV3haUzJnMmVTOXRWa1V2ZVdSMmRUQTRXV05yT0M4S01rUkVlRXMzY0hkWFdISk9iSEV4VmtkVmFDOXBNMDVDU3l0RWRqUk9TRlZRZERsbldXUkxSMWhxU0V4eVNGTm1XbEJMVWsxRWJFNU5hR2hEVDJ4NGJBcDNXR0Z4UlhCc2NtZEthMmd5YVVsRlp6a3lZblVyUVc0MVZsSlNhSFZsZDB0MlpFSlVlRXBEYWxCb1NrSlFlazFIZEZaV05rNXlkMFZtYzBWWFMyZ3hDaTlJTmk5alZETjFWM1ZMYm5wMFUxSndha0V5VldkbVRtOTJPVm80VG14c1VGTnNNbkJaYjBwak5YaFFTMFFyWVhOUlRHRmhNRGR0TWtSdGFYUmtMMHNLYTJFM2FHWnBkbkF2Ylhob2VWRk5ia2xQZWtkQmJISjVNakpJTkVkNGN6Qk5NakprYWsxMlptdE5VMUUzWlVwQ1REaDZSMGhUVFU0elRsWXhaelpDU3dwbldGTllSWFJrVVV3d1VXSkVWVUY2TjBwelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTU16Sm1hRzFNVlVKVmNUbGpSMUJLWXpSSVFrcGxZa3hCTUdkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1IzRklaVmhxZEdObVVYVnVNMFZpYVV0bVNXaFplVGswYmtwSFowbGpTVGRhSzFoNVEwSTFZMXBGYW5wdVVXODBid3BZUXpoWlJVNVBWRWh1VVM5cGRWQlNaSFZHY0ZVNVNYWXZLMEppTDJzNFNIaG1lRVJEZFVkblZuSkdhRGg0WWpBeVVra3hhalExUTNFeWNqbEdUMmwzQ210cldITTNUbTlXY25CaFpHMWhVV3g2ZUZRNWFtVm1NM2hwUWxRd2MxVXhZV2hHUVdWcmIwMWxOMm94UVVsNVVrRlZZazFYV0RKVVJuVnlNREFyWmtJS1dHeHpWbkpSYm1OVWFEaHZNa1ZWWmpsck5reDFZa2xFYVZwT1MycFhOeTlFVkhkWmFGbElOa3B5YjJ0bFVHUmFURU5XYlVwWlVFbDZVWHBGTUU5VGN3cGxOSGg0VEhORWRXWnZOWEJVYURGcVdGbHdkbVpaVlhreVVUZG1NalZYZGpGd09HSkpRV2RCYkhwaFRFZENkbk5rV2xoQ1NqSkRWMVl6YmpBd2RHNXRDbFZtSzJGelFqVXpTVFJ0Vld4alExVlBhRE50WnpOWlNIRTVObUZDYTBOb00yTTNlUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZmZkYzk2ODUtMTM0Ni00Yzg3LWE0M2MtMjA0YzM2YzI5MDA0LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIWFFJSzFiNTBweHhlczRrY3Q0TzE2cURSd2FBMDhHQXlDM0I0SXJweHpjNVczREpqY0kxTURtag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -5146,7 +5151,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5156,7 +5161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0503fe7-6d6c-4d15-8e93-5e3d2fd257a3
+      - 2b131d64-ac15-404c-9520-2026805f5054
     status: 200 OK
     code: 200
     duration: ""
@@ -5165,12 +5170,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:28:29.913687Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:41.343092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "609"
@@ -5179,7 +5184,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5189,7 +5194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc55463b-bc5f-4670-be5b-fd03179db651
+      - 012bbaf0-9f82-464a-aa41-331085b6844d
     status: 200 OK
     code: 200
     duration: ""
@@ -5198,21 +5203,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67/nodes?order_by=created_at_asc&page=1&pool_id=0773a1b9-9fe6-41cf-9b5e-868decf70cae&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004/nodes?order_by=created_at_asc&page=1&pool_id=18ed8423-0530-4b8a-a270-923fc7557c2e&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"nl-ams","id":"5d7f59d1-54ec-4d07-8fd1-1032b7771ddf","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:24:59.884339Z","updated_at":"2022-10-06T12:28:29.889366Z","pool_id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-placement-group-placement-group-5d7f59d154","public_ip_v4":"51.158.236.40","public_ip_v6":null,"provider_id":"scaleway://instance/nl-ams-2/b3f96b65-3b64-4de4-ae5d-dd2b3bff44ab","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:16:54.867582Z","error_message":null,"id":"5e9a2717-f53b-4aa2-8cdf-d34566dfac0d","name":"scw-placement-group-placement-group-5e9a2717f5","pool_id":"18ed8423-0530-4b8a-a270-923fc7557c2e","provider_id":"scaleway://instance/nl-ams-2/c67bebb9-0dbb-4f1a-87a8-080ab689a99f","public_ip_v4":"51.158.243.1","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-01-02T14:19:41.320768Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5222,7 +5227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 748312e7-9dce-4fe8-8f4d-64e2dcbdf8c9
+      - aef79a78-ef38-492a-8325-d64559b0079f
     status: 200 OK
     code: 200
     duration: ""
@@ -5231,12 +5236,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:24:44.901470Z","type":"kapsule","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:16:05.429153Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -5245,7 +5250,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5255,7 +5260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a753e5b3-96df-4161-bc32-8372ccd25766
+      - 15fd3b7a-96d5-4035-8bf2-45467bebcbf8
     status: 200 OK
     code: 200
     duration: ""
@@ -5264,16 +5269,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/de5a99d9-75aa-4247-98cd-d0386a847193
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/91b0a766-6804-4986-92f5-6637c058042e
     method: GET
   response:
-    body: '{"placement_group": {"id": "de5a99d9-75aa-4247-98cd-d0386a847193", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "nl-ams-2"}}'
+    body: '{"placement_group":{"id":"91b0a766-6804-4986-92f5-6637c058042e","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "326"
@@ -5282,7 +5283,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5292,7 +5293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf520c62-ebfd-45db-975d-2aef09d88e58
+      - fe880fc7-370a-4bef-ac9f-7dfc14326580
     status: 200 OK
     code: 200
     duration: ""
@@ -5301,12 +5302,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGRPVkVWNVRXcE5NVTFHYjFoRVZFMTVUVlJCZDA1VVJYbE5hazB4VFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVEZLQ21Jck5HbFFkbFprVVd4VGFqa3ZTRWgyVG1nM1EyMVNhV1prTlZKTlExUnZLMVZSUmpWV1ZYTkdSQzlNUjIxaWJIa3pXbU5HZDFScGF5dGFaVk5TYzNjS2FqazRjalZ5ZFZacWNEUnROM04xYnpGTmJsQndXV2Q2YkhoUlFYQmhibWhVYjJ0Vk9IY3lPQzluTlUxbWVsbGhPVUZLVkVKWUx6QlZhRTQ1TkhJd2JBcG5ZMjFxVkRWV2NsRklRWGR5YWpKNFpHVkpOM2hSWlV4V01Vb3JNblYyWXpnMVMyUlFRMVpuWjJFeVJucEZhWEY1WWtvNGIxbGxMekp0TVNzMGNGQXdDbUY2Y0daa01rOUdjRFp5TUVjMmVsQndSV3Q0VkUxWU1tbGFVREJYY1RsSlZUQlpXWHBCTmpSMFUzSklaR0pHVjA1d1JtUnBOM0pIVERWNVVVUnBWelFLVEV0WVREUTRkalpVV1cxdlN6RlJjR0ZZU0dwU05ISnBZVUZ4VTNaQ09HSjFUek5NZW1oM2JtTlZlaTk0VG0wd2RWZ3ZiVlJXWlc4NVVqUmxkRFJHTHdwWFozVjZORTVETVZFM2QzTlJSVzlCVHl0TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1RqZDBlWEZ1TWtSMFpFTkxkRUkzUVdadFNGbzFMM1o2WkVKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1ZIaE1URzFOY0VoRFpXOXRaMnM1YjJGdloxQmFVbTA1YWtveE9HVlVXakF2TmpodGJuVmtja3BLUjBKaFVrTlRSZ3B5V25sTlkzbzJiM3B3ZVhKM05IaFFZVXB2Vm5kd1NqbE1UamhzUlVWcFRTOVZVMFZCZWpOdGRFMVNSMHBSVW5obFZYSlJNbTg0Tnk4d2QybEJNR2R0Q2tWT1QwWkZlV1p6U21SMVMyWTFOMVphUzBjd1pFWXdjWE5DV0RWbmNXdFFaV1ZvYzAxa1dtbDVMMWN5T0RKd05IVTJjRXBwU1hCdVVFUjFRVGhOTlRNS1dpOW9SREJRVFZZdmJUY3djbWRoY1haMFVIRXJjRlp6V25saVZUUnhhWEZ6V2xKb1pWSXZhVWhDVUVaV2RVaHJjRTlMUjBwdFpuQmllWFJtT1dOdE5ncDNPVTlGYTNoRlZsWmpNR0pEY0RKMGEyc3ljbmRQUlhFck1UWnZaWGRqVTI1Vk1USXpVR1IzVFdSRGQyUlhhMjlzVmpSWmFVRlNWR1Z6VVVzNFQxSnlDbGxuZDJGR1VGRnpibVEzUXpNMFRHOVlaVTloVkV4U1NHNVZPV3hpTTBoeGEwUmlOUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTMxOWUyZmQtMWUwOC00NTQyLWIwYjYtNmNiZmFjNGZkYTY3LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6MFN3N01tVU1jZGR6WFFGZFBUT0t3ZFNxdUJpU0xEQ2I1WXBPeUY3SUN3Y3g4cmxNT1R6TVh6aQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RWUlJNVTFXYjFoRVZFMTZUVVJGZDAxVVJUQk5WRkV4VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSEI0Q2xWQ04xZFFUemRZVW1VemNXNVZTMkUwTTJnNGMxTlhka053WjFremNUUnRibXRSZDJVemNFSjZTV3haUzJnMmVTOXRWa1V2ZVdSMmRUQTRXV05yT0M4S01rUkVlRXMzY0hkWFdISk9iSEV4VmtkVmFDOXBNMDVDU3l0RWRqUk9TRlZRZERsbldXUkxSMWhxU0V4eVNGTm1XbEJMVWsxRWJFNU5hR2hEVDJ4NGJBcDNXR0Z4UlhCc2NtZEthMmd5YVVsRlp6a3lZblVyUVc0MVZsSlNhSFZsZDB0MlpFSlVlRXBEYWxCb1NrSlFlazFIZEZaV05rNXlkMFZtYzBWWFMyZ3hDaTlJTmk5alZETjFWM1ZMYm5wMFUxSndha0V5VldkbVRtOTJPVm80VG14c1VGTnNNbkJaYjBwak5YaFFTMFFyWVhOUlRHRmhNRGR0TWtSdGFYUmtMMHNLYTJFM2FHWnBkbkF2Ylhob2VWRk5ia2xQZWtkQmJISjVNakpJTkVkNGN6Qk5NakprYWsxMlptdE5VMUUzWlVwQ1REaDZSMGhUVFU0elRsWXhaelpDU3dwbldGTllSWFJrVVV3d1VXSkVWVUY2TjBwelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTU16Sm1hRzFNVlVKVmNUbGpSMUJLWXpSSVFrcGxZa3hCTUdkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1IzRklaVmhxZEdObVVYVnVNMFZpYVV0bVNXaFplVGswYmtwSFowbGpTVGRhSzFoNVEwSTFZMXBGYW5wdVVXODBid3BZUXpoWlJVNVBWRWh1VVM5cGRWQlNaSFZHY0ZVNVNYWXZLMEppTDJzNFNIaG1lRVJEZFVkblZuSkdhRGg0WWpBeVVra3hhalExUTNFeWNqbEdUMmwzQ210cldITTNUbTlXY25CaFpHMWhVV3g2ZUZRNWFtVm1NM2hwUWxRd2MxVXhZV2hHUVdWcmIwMWxOMm94UVVsNVVrRlZZazFYV0RKVVJuVnlNREFyWmtJS1dHeHpWbkpSYm1OVWFEaHZNa1ZWWmpsck5reDFZa2xFYVZwT1MycFhOeTlFVkhkWmFGbElOa3B5YjJ0bFVHUmFURU5XYlVwWlVFbDZVWHBGTUU5VGN3cGxOSGg0VEhORWRXWnZOWEJVYURGcVdGbHdkbVpaVlhreVVUZG1NalZYZGpGd09HSkpRV2RCYkhwaFRFZENkbk5rV2xoQ1NqSkRWMVl6YmpBd2RHNXRDbFZtSzJGelFqVXpTVFJ0Vld4alExVlBhRE50WnpOWlNIRTVObUZDYTBOb00yTTNlUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZmZkYzk2ODUtMTM0Ni00Yzg3LWE0M2MtMjA0YzM2YzI5MDA0LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIWFFJSzFiNTBweHhlczRrY3Q0TzE2cURSd2FBMDhHQXlDM0I0SXJweHpjNVczREpqY0kxTURtag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -5315,7 +5316,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5325,7 +5326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4d78260-d77b-4229-a803-ddfc77fff64f
+      - ad5d2301-6ec2-4b71-8fdf-d385a9457764
     status: 200 OK
     code: 200
     duration: ""
@@ -5334,12 +5335,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:28:29.913687Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:41.343092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "609"
@@ -5348,7 +5349,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5358,7 +5359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e5d51a4-56c4-4db8-abb1-b6492d4565a3
+      - 6a2d487d-a898-4487-8062-2e20c83ba665
     status: 200 OK
     code: 200
     duration: ""
@@ -5367,21 +5368,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67/nodes?order_by=created_at_asc&page=1&pool_id=0773a1b9-9fe6-41cf-9b5e-868decf70cae&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004/nodes?order_by=created_at_asc&page=1&pool_id=18ed8423-0530-4b8a-a270-923fc7557c2e&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"nl-ams","id":"5d7f59d1-54ec-4d07-8fd1-1032b7771ddf","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:24:59.884339Z","updated_at":"2022-10-06T12:28:29.889366Z","pool_id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-placement-group-placement-group-5d7f59d154","public_ip_v4":"51.158.236.40","public_ip_v6":null,"provider_id":"scaleway://instance/nl-ams-2/b3f96b65-3b64-4de4-ae5d-dd2b3bff44ab","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:16:54.867582Z","error_message":null,"id":"5e9a2717-f53b-4aa2-8cdf-d34566dfac0d","name":"scw-placement-group-placement-group-5e9a2717f5","pool_id":"18ed8423-0530-4b8a-a270-923fc7557c2e","provider_id":"scaleway://instance/nl-ams-2/c67bebb9-0dbb-4f1a-87a8-080ab689a99f","public_ip_v4":"51.158.243.1","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-01-02T14:19:41.320768Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:31 GMT
+      - Mon, 02 Jan 2023 14:19:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5391,7 +5392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84729570-e0c5-452a-a5b4-da1181a29ada
+      - 1ad7df14-7095-471d-a44b-af55c0763b69
     status: 200 OK
     code: 200
     duration: ""
@@ -5400,12 +5401,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/0773a1b9-9fe6-41cf-9b5e-868decf70cae
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/18ed8423-0530-4b8a-a270-923fc7557c2e
     method: DELETE
   response:
-    body: '{"region":"nl-ams","id":"0773a1b9-9fe6-41cf-9b5e-868decf70cae","cluster_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","created_at":"2022-10-06T12:23:54.666890Z","updated_at":"2022-10-06T12:28:32.382983308Z","name":"placement_group","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"de5a99d9-75aa-4247-98cd-d0386a847193","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ffdc9685-1346-4c87-a43c-204c36c29004","container_runtime":"containerd","created_at":"2023-01-02T14:14:56.104530Z","id":"18ed8423-0530-4b8a-a270-923fc7557c2e","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"91b0a766-6804-4986-92f5-6637c058042e","region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-01-02T14:19:42.966815525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "615"
@@ -5414,7 +5415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:32 GMT
+      - Mon, 02 Jan 2023 14:19:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5424,7 +5425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec8352e8-8422-472c-850c-2a243146455c
+      - d0a99a6b-0d4a-45f2-9e62-7f5ccec9995f
     status: 200 OK
     code: 200
     duration: ""
@@ -5433,21 +5434,17 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67?with_additional_resources=false
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/91b0a766-6804-4986-92f5-6637c058042e
     method: DELETE
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:28:32.500798023Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: ""
     headers:
-      Content-Length:
-      - "1335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:32 GMT
+      - Mon, 02 Jan 2023 14:19:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5457,36 +5454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4126f193-ff22-4762-ada9-80110a839891
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/de5a99d9-75aa-4247-98cd-d0386a847193
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Thu, 06 Oct 2022 12:28:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 550139a3-9935-474d-b60e-45e2e5696e95
+      - 6d69a61f-d167-4eda-860a-1f0edbae42e2
     status: 204 No Content
     code: 204
     duration: ""
@@ -5495,21 +5463,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
-    method: GET
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004?with_additional_resources=true
+    method: DELETE
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:28:32.500798Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:19:43.077969263Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
-      - "1332"
+      - "1335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:32 GMT
+      - Mon, 02 Jan 2023 14:19:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5519,27 +5487,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 780ca874-4505-413c-a0bd-2810697977a8
+      - a5a7dde9-b670-44d9-ba8e-2fb517075401
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group": {"id": "4e57cfaf-9262-47d0-93c4-73270652828b", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "nl-ams-1"}}'
+    body: '{"placement_group":{"id":"e8934ffa-57e6-46c2-8094-0f0f11116144","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "326"
@@ -5548,9 +5512,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:32 GMT
+      - Mon, 02 Jan 2023 14:19:43 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/4e57cfaf-9262-47d0-93c4-73270652828b
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/e8934ffa-57e6-46c2-8094-0f0f11116144
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5560,7 +5524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 607b9e9c-bc43-4f2b-8218-0fc927144f1e
+      - 0747c822-8d78-4ceb-a22e-da653b9c5897
     status: 201 Created
     code: 201
     duration: ""
@@ -5569,16 +5533,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/4e57cfaf-9262-47d0-93c4-73270652828b
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"placement_group": {"id": "4e57cfaf-9262-47d0-93c4-73270652828b", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "nl-ams-1"}}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:19:43.077969Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1332"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:19:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 274a3791-efb5-44f9-a749-f65b84d25e35
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/e8934ffa-57e6-46c2-8094-0f0f11116144
+    method: GET
+  response:
+    body: '{"placement_group":{"id":"e8934ffa-57e6-46c2-8094-0f0f11116144","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "326"
@@ -5587,7 +5580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:32 GMT
+      - Mon, 02 Jan 2023 14:19:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5597,7 +5590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a4ba3ec-cda2-4383-9352-ae37062a920f
+      - 5cab275a-85a3-4a70-b0f4-240890834206
     status: 200 OK
     code: 200
     duration: ""
@@ -5606,12 +5599,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:28:32.500798Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:19:43.077969Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -5620,7 +5613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:37 GMT
+      - Mon, 02 Jan 2023 14:19:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5630,7 +5623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c86a90a8-cac9-494a-8a7e-883115540302
+      - 12fdd383-abf5-4a7e-9fe7-4562dee472e2
     status: 200 OK
     code: 200
     duration: ""
@@ -5639,12 +5632,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"region":"nl-ams","id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:23:49.014118Z","updated_at":"2022-10-06T12:28:32.500798Z","type":"kapsule","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://9319e2fd-1e08-4542-b0b6-6cbfac4fda67.api.k8s.nl-ams.scw.cloud:6443","dns_wildcard":"*.9319e2fd-1e08-4542-b0b6-6cbfac4fda67.nodes.k8s.nl-ams.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ffdc9685-1346-4c87-a43c-204c36c29004.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:14:50.471598Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ffdc9685-1346-4c87-a43c-204c36c29004.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ffdc9685-1346-4c87-a43c-204c36c29004","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-01-02T14:19:43.077969Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1332"
@@ -5653,7 +5646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:42 GMT
+      - Mon, 02 Jan 2023 14:19:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5663,7 +5656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99130de2-e1d1-4935-ad0d-99cec97434ca
+      - ffbacb5a-1a07-4103-9022-810fd1425a8b
     status: 200 OK
     code: 200
     duration: ""
@@ -5672,12 +5665,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/9319e2fd-1e08-4542-b0b6-6cbfac4fda67
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ffdc9685-1346-4c87-a43c-204c36c29004
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"9319e2fd-1e08-4542-b0b6-6cbfac4fda67","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ffdc9685-1346-4c87-a43c-204c36c29004","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -5686,7 +5679,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:47 GMT
+      - Mon, 02 Jan 2023 14:19:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5696,23 +5689,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a6113ce-92fe-4d5b-be67-41717d4674ce
+      - 83a671fc-be71-4652-9b1d-65bd78023369
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"multicloud","name":"placement_group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.24.5","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud","name":"placement_group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.24.7","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126458Z","updated_at":"2022-10-06T12:28:48.604487693Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521572992Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392163Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1339"
@@ -5721,7 +5714,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:48 GMT
+      - Mon, 02 Jan 2023 14:19:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5731,7 +5724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df5c4234-7e37-45cb-bbaa-abc26bd66f73
+      - 63bb8969-08d4-4225-b3b1-8ada45407ff8
     status: 200 OK
     code: 200
     duration: ""
@@ -5740,12 +5733,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -5754,7 +5747,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:48 GMT
+      - Mon, 02 Jan 2023 14:19:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5764,7 +5757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc309361-678f-49ca-907b-4c5fc323c61c
+      - 0229b261-2508-4c7f-a950-1185ba42dbdd
     status: 200 OK
     code: 200
     duration: ""
@@ -5773,12 +5766,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -5787,7 +5780,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:28:54 GMT
+      - Mon, 02 Jan 2023 14:20:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5797,7 +5790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a813e423-84a9-4a00-9966-005e0175722a
+      - ae427a43-3c5f-4992-b6fe-a57bbb56861b
     status: 200 OK
     code: 200
     duration: ""
@@ -5806,12 +5799,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -5820,7 +5813,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:01 GMT
+      - Mon, 02 Jan 2023 14:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5830,7 +5823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 354879ed-25b6-4936-8db3-3a4a28bc9bcc
+      - 1858d9e6-c2dc-4eb0-84ba-fa5f022c85f7
     status: 200 OK
     code: 200
     duration: ""
@@ -5839,12 +5832,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -5853,7 +5846,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:07 GMT
+      - Mon, 02 Jan 2023 14:20:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5863,7 +5856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4c2b9cb-c026-4b11-a27c-8ae1a64733f7
+      - 7e276a28-91fb-4e0f-a0de-0fe1c0a52fd5
     status: 200 OK
     code: 200
     duration: ""
@@ -5872,12 +5865,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -5886,7 +5879,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:13 GMT
+      - Mon, 02 Jan 2023 14:20:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5896,7 +5889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abcea27a-258a-41f0-a0d1-c5a576cefb33
+      - 40eb845c-a769-4503-87c3-23528da32276
     status: 200 OK
     code: 200
     duration: ""
@@ -5905,12 +5898,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -5919,7 +5912,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:18 GMT
+      - Mon, 02 Jan 2023 14:20:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5929,7 +5922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fe28986-0f70-4e5a-be3e-adc9502d614b
+      - 2368a1a1-10fd-4e93-abe9-d48303b847d1
     status: 200 OK
     code: 200
     duration: ""
@@ -5938,12 +5931,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -5952,7 +5945,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:24 GMT
+      - Mon, 02 Jan 2023 14:20:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5962,7 +5955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aab6e9a-f131-4052-8eec-89fa78dac126
+      - d10e7770-5606-4a93-a565-049ce33e8c85
     status: 200 OK
     code: 200
     duration: ""
@@ -5971,12 +5964,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -5985,7 +5978,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:30 GMT
+      - Mon, 02 Jan 2023 14:20:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5995,7 +5988,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd3ba9e7-4c75-43e6-b053-28be75d7edf1
+      - 2ba7bcd2-40e7-4028-8568-81dd5f00036f
     status: 200 OK
     code: 200
     duration: ""
@@ -6004,12 +5997,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -6018,7 +6011,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:35 GMT
+      - Mon, 02 Jan 2023 14:20:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6028,7 +6021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6362a6db-11ec-43b1-8794-02f23834c2be
+      - a9bde71f-0a56-4d95-a639-43ccbf8b4629
     status: 200 OK
     code: 200
     duration: ""
@@ -6037,12 +6030,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -6051,7 +6044,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:42 GMT
+      - Mon, 02 Jan 2023 14:20:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6061,7 +6054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adada79b-e892-44c1-8b9c-44a0bd1cc048
+      - 17b8fb7c-5ae9-4abb-bb3d-67699d2c41e0
     status: 200 OK
     code: 200
     duration: ""
@@ -6070,12 +6063,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -6084,7 +6077,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:47 GMT
+      - Mon, 02 Jan 2023 14:20:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6094,7 +6087,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d1cdf52-290b-4b01-bad8-3b71324a819c
+      - 4e835f5e-146e-4866-bc86-cfe953d6df94
     status: 200 OK
     code: 200
     duration: ""
@@ -6103,12 +6096,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -6117,7 +6110,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:52 GMT
+      - Mon, 02 Jan 2023 14:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6127,7 +6120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c572093d-28aa-4b66-82f8-fa125aee3528
+      - 219446a1-1049-40d8-bf25-98ba7db387ec
     status: 200 OK
     code: 200
     duration: ""
@@ -6136,12 +6129,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:28:48.604488Z","type":"multicloud","name":"placement_group","description":"","status":"creating","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -6150,7 +6143,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:29:58 GMT
+      - Mon, 02 Jan 2023 14:20:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6160,7 +6153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e05a61af-c9cd-46cd-841e-8d3454632160
+      - 384e46bd-dfe4-4395-b850-854fdda5e4ba
     status: 200 OK
     code: 200
     duration: ""
@@ -6169,12 +6162,78 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:29:59.264005Z","type":"multicloud","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1333"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfc5d6cb-b444-4374-bc66-607a02a2fc46
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:19:58.530392Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1333"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 88f31a4d-fbde-4076-bc39-3d473766fd03
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:21:10.055763Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -6183,7 +6242,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:03 GMT
+      - Mon, 02 Jan 2023 14:21:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6193,7 +6252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - badc0511-e999-459c-83cb-19eaa5ad4695
+      - d814fb52-083a-4a53-b285-61a08b383da0
     status: 200 OK
     code: 200
     duration: ""
@@ -6202,12 +6261,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:29:59.264005Z","type":"multicloud","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:21:10.055763Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -6216,7 +6275,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:03 GMT
+      - Mon, 02 Jan 2023 14:21:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6226,7 +6285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77a9ba6f-d13a-4ff0-9587-3f3075fb2f74
+      - 3292e2c9-69fe-4609-8acb-e4cae39f1d22
     status: 200 OK
     code: 200
     duration: ""
@@ -6235,12 +6294,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGRPVkVWNVRXcG5NVTFXYjFoRVZFMTVUVlJCZDA1VVJYbE5hbWN4VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbFpKQ2xKVlJHeHZRbmxZZDBsTFdIQXphbE5XUW1SdE1UVjNVVzh2UTJwbFEwMVNNbmRHTUdnMlltSktTWEpMVkdzNWVtaEVlbGhPVUdkcWNGSmpZM0pWUlc0S00wcGFSbmROY25GWUwwSXphV2xHWW1SWmFYTllNalZhU1daU1ZETXJWeTlxT0dZd1NWUTNTVFZKY0RsTVJqVjJUR2d2VDFSNVFYbHRTRkYzUW5SS1RBcDJOVEpSWTFObFFVUnJMekp3V1U5dk1reFlTVk5QTTBwWlpWWlNaMDlLWjJaRk1HdHhTMXBWYzA5ak5XUTFTbmN5UzJaV1JHbE1TR0ZVU0VaQlFscFZDbVI1TVRjd05rWmxTM2R3VkhaMFFrdDFSeTlzTUZoWlpUSklOMWd3Y2xKT2FXdGlSMmhPYldGMU9WcFpRVkpvUVhOalpIcGhZa0pxTTFneE9GWXJjbFlLT0d4WFFXNXhUSFpJVFhGTFUyOVNjekZ2YlZjM09GWjNSMUJ5V0c5d1ZETmhiRVZpSzFwMVVrZE5VblF5TTBGVGJVMXhObkZ3TjNkQmFtRkpNVlJIUVFwd2JFSkNVRmh1ZVc1T2JYQnFVRFJFVDFWalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTVFXeFJXRTB5TVV0WFV6WnlNV3hLVkcxVmEzYzNiaXRDWlVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFpGWmFSRXQxVUd0UU5EQTRVVTFLTkVGRGNHZHFaSGRJZVZObVIwMXRhRVI2YW1sRE1WUlpiV2MyUVdaRlVURkVXUXAzUW5Cek0yWkxkR1k0Y1VKSFZHdGFjMU0zUlV0dmVqSnFUalV4TldRcmRYSlJaRk5CU1ROcVNtZElja0pxZDFaSFJUaFFXWEpQTUhBd2JUUjROR2xZQ2pCUFV6RlJlRkIwSzB4VFRWRk5TRFpyUTNkTWRHZDBhVFp1WjFFM1NGZ3lkbUY2WkRSM01GZHNaMm94TjI5R2JVdGhZbFp0YzBWc1J6ZEdRM05CTW1rS1pIVm1lVWRKWlhSbWRVZ3lUbUZJY1RRelRFWlRNa3RCVm1SQk1VRTBiRWRsWkdabVJEaGFSMk5xTkZwM1ZUVlBXalpoTDI5a1pscEdkVFZWT1dOblZ3b3dMMGRDUkhSaGJHRmlOMEZhUkdkVk0wcG1XalJ6TVdwWWFIVlFhRGh1TlhrMk0wUm1WVmMxZUZGSFEyZDRkMUZ0TW5CUWNuaFZTRlJWTUZkV1ozRXZDakJ2VkZSTE9XVlZNRGd4WlVoVk4yTnRXR2hyV0ZKeE1uSldXVGg0ZWpWWlpqUlNjd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTQzZGE1MDctMThhNS00YmNhLTkyZDAtYzBiMDc1OGZmNWI2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNdEk5MFV0RXBGM0dqdER6Um5WYk1wWmJJSzdqNExxVHRlb09MNERKekpzRHVsQUVrV2lWNEN5VQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RXcEJkMDFHYjFoRVZFMTZUVVJGZDAxVVJUQk5ha0YzVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0pYQ2pSdGJETklibmxuV2xaTGJFTXJRbkYyUmtsTGRUVnZXV2xDZW14elFucHdNMFZHY1ROWVoxaGlWRTFuUjFsMk4xVkRXV3B4VURFMVEzZEZWazF0UXpBS2NUWjJjV1pDUjNSMllXUlZlRk51TkZwc2REWkNaVXA0WnpaUVZHdHVOemswVGtGTFZXMHphMjlRV1dwT2NEWnVjVkJvYzJaNE5FMXBTbUY2UTA1UmVRcE1ObVJsT1hkRFZuTm5aRTB2VkVRelVqUXpXRk5SYTA5cGNXMHlSM05qTUZaaVNYUkplSFo1Y2poUVYwcFpXRzR6ZVhoQlNURnNhRXBVVDNJdmVGVnRDbEkyU1dJeVJIaFJMMDV5YmtaS1UxTTJTVkI2Tld3M1RWWlpZMGQ1VFVoNGRISm1SRE5PV0daR1ZXbzJaRzAxTWpkSlNFZ3hORlZaZERoclpVcENSakFLZG14UWQwcGpSWE12ZFdVeGQwUnBSMlJQVVdvMlQyaDJVWG8wVEUxamVrWlVhM1pSUjNwMldHTkJabk5DVVdsVlVWQXJSbVZGZG5sd1QxWjFUVE5OUXdwTlJrODViVWczYzBWRE1IWlhkR3d6VUd4clEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTGEybDRkVkJQWjBJcmMzVlBWakpNYUcxcllVbENTM2MwVERKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1dsZDRiRTFOVjBoc1ZtUnFiMXBRYW1OMFVXdzJTRFpKUkZkcmNtSmFUR1ZIZG0xUWIwaHpSVmREWlcxV1JWUllSd3BIVFVkME5qVkJVakJKWTNWNGFWcE1VM000VjA5YWNYUlZkRVY1WkROa2IwdzJPV2Q0TVZsR2VWUlhUMGQ0YTFGWVdsQjVUWGhvTHpkQmJFSmtkM1ZKQ2pac0syazFWV0p2VldoSlZFMURhbU5IZEdWR1pqRnZUMUE1TTNGVFMyMWtRMVp0YVN0WU1tZG9VVm8wUmxjNVpVaDJhbVl3WXpoNE0yNXliMFZUZVRRS1FVaEVTRzVrVGtzME1tSlRlREU0TjFvMlJFVnpXWFpOUTBkaWFtMUVNa0Z6YTBSdFlYQlFPV2M1TVdkaksyOVRaMWxYWVhkaFZEa3ljMWhyZG1wQ2FncEhiM1ZSV1RSUlEzSnlVRGgwUmtrdlpYSXpVSEJ1V2poVEwzcEVNR280SzFabWNEVkdaRUZ3VEdOV2NGWkJPVFZEWm5ONlFWSTJNRlJyUmxKamNHdEdDbWhPVW14SVdGY3dkRmhwUVRsTVFsQnZkVk5KV2tWdVQwRnhOWFYxVUdSWFptNVdiQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vODkxY2JlZmUtMmI1Zi00Njg2LWFiZGYtMDc5ZWFmZjdlOTc3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6djlpdDMzNTZpYXVzOVdQREZOc2tXUjdjQWxrVzc2RHZla1I1UzlMbFJiUEU4VlRScDdLMXR1Tw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -6249,7 +6308,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:04 GMT
+      - Mon, 02 Jan 2023 14:21:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6259,7 +6318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52796542-f6de-4cf7-a9ed-19c668783954
+      - 4ed1172d-d0e2-40d2-9284-ab6953781bee
     status: 200 OK
     code: 200
     duration: ""
@@ -6268,12 +6327,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:29:59.264005Z","type":"multicloud","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:21:10.055763Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -6282,7 +6341,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:04 GMT
+      - Mon, 02 Jan 2023 14:21:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6292,23 +6351,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 614dd8c9-dedc-46c6-b620-d6ae4362722c
+      - fef1f460-cef9-41bb-87b0-72cd99b91089
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"placement_group","node_type":"gp1_xs","placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"nl-ams-1","root_volume_type":"default_volume_type","root_volume_size":null}'
+    body: '{"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"nl-ams-1","root_volume_type":"default_volume_type","root_volume_size":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254381Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746173896Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "614"
@@ -6317,7 +6376,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:06 GMT
+      - Mon, 02 Jan 2023 14:21:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6327,7 +6386,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acaf9cd3-fc8a-4385-9663-8276140f6c41
+      - 8283fbf0-20f8-4f1a-91db-88a4addab055
     status: 200 OK
     code: 200
     duration: ""
@@ -6336,12 +6395,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6350,7 +6409,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:11 GMT
+      - Mon, 02 Jan 2023 14:21:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6360,7 +6419,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 147e650f-0669-495c-88a1-68756d6cee4b
+      - ed3baaac-cb84-4dfb-b65a-c0281f697fec
     status: 200 OK
     code: 200
     duration: ""
@@ -6369,12 +6428,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6383,7 +6442,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:17 GMT
+      - Mon, 02 Jan 2023 14:21:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6393,7 +6452,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b427701-022a-4195-816e-12c4cb99d2e0
+      - 4ac2b13f-ae69-4de9-a782-88a504eece99
     status: 200 OK
     code: 200
     duration: ""
@@ -6402,12 +6461,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6416,7 +6475,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:22 GMT
+      - Mon, 02 Jan 2023 14:21:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6426,7 +6485,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75f6428a-77bb-497d-991c-cc18e911b829
+      - 841642b5-2b03-49b5-85a6-53d7ab810ed8
     status: 200 OK
     code: 200
     duration: ""
@@ -6435,12 +6494,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6449,7 +6508,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:27 GMT
+      - Mon, 02 Jan 2023 14:21:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6459,7 +6518,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52b17aaf-8636-4b05-9d09-8a03cbadd756
+      - 12208746-0de9-4049-9830-5bc7621b8191
     status: 200 OK
     code: 200
     duration: ""
@@ -6468,12 +6527,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6482,7 +6541,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:33 GMT
+      - Mon, 02 Jan 2023 14:21:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6492,7 +6551,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4ff4949-6572-4e7a-b7eb-3632c86371ed
+      - 895a481a-c17e-4baf-b229-85e82bc75bd1
     status: 200 OK
     code: 200
     duration: ""
@@ -6501,12 +6560,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6515,7 +6574,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:39 GMT
+      - Mon, 02 Jan 2023 14:21:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6525,7 +6584,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82704849-b33d-4277-bbe0-5fc3ad0cc68e
+      - fe26571c-20b5-4b3a-be7c-2ca17cf7627e
     status: 200 OK
     code: 200
     duration: ""
@@ -6534,12 +6593,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6548,7 +6607,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:46 GMT
+      - Mon, 02 Jan 2023 14:21:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6558,7 +6617,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47d77bef-c960-4b29-a9e4-2a58a9069324
+      - e6472eed-c23b-49fe-94d8-50ce5e987daf
     status: 200 OK
     code: 200
     duration: ""
@@ -6567,12 +6626,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6581,7 +6640,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:51 GMT
+      - Mon, 02 Jan 2023 14:21:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6591,7 +6650,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c96390b-1c45-427d-ab12-1ad255223c68
+      - f1c8f42d-ec46-4f6d-bb05-676d84837086
     status: 200 OK
     code: 200
     duration: ""
@@ -6600,12 +6659,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6614,7 +6673,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:30:57 GMT
+      - Mon, 02 Jan 2023 14:21:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6624,7 +6683,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfcd174c-1297-4453-817d-563932570385
+      - f1419ec7-728c-4d43-b785-26b77fa9d700
     status: 200 OK
     code: 200
     duration: ""
@@ -6633,12 +6692,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6647,7 +6706,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:03 GMT
+      - Mon, 02 Jan 2023 14:22:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6657,7 +6716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7f3ebc8-1344-46e0-8b89-dcd4aca2e12b
+      - 58d841ed-ff20-4591-b932-2d8ce53aa7f2
     status: 200 OK
     code: 200
     duration: ""
@@ -6666,12 +6725,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6680,7 +6739,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:08 GMT
+      - Mon, 02 Jan 2023 14:22:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6690,7 +6749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb901a6d-8954-4b9f-9b55-539095898019
+      - a1dbaa21-5e79-42de-9f01-75e60c9e8939
     status: 200 OK
     code: 200
     duration: ""
@@ -6699,12 +6758,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6713,7 +6772,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:13 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6723,7 +6782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 231b7caa-83ea-45d4-8349-19720edad8b2
+      - 425dbac8-ea62-4232-95b4-bc5a8e0f996d
     status: 200 OK
     code: 200
     duration: ""
@@ -6732,12 +6791,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6746,7 +6805,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:20 GMT
+      - Mon, 02 Jan 2023 14:22:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6756,7 +6815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a075544-4362-4112-8c51-a918957cd19b
+      - 080de6ec-7c59-41f1-8346-2f2b2fa05aa4
     status: 200 OK
     code: 200
     duration: ""
@@ -6765,12 +6824,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6779,7 +6838,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:25 GMT
+      - Mon, 02 Jan 2023 14:22:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6789,7 +6848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bacd0956-2ea1-4724-8b69-7f8a1ad440dc
+      - 36fa1be9-4d2b-4986-a8d8-83c6196d3d0d
     status: 200 OK
     code: 200
     duration: ""
@@ -6798,12 +6857,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6812,7 +6871,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:32 GMT
+      - Mon, 02 Jan 2023 14:22:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6822,7 +6881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41c71a68-fb91-4fcc-b94d-bd7fb29026ff
+      - 9cb962e5-bd5e-487c-8747-1ecd4cd20b51
     status: 200 OK
     code: 200
     duration: ""
@@ -6831,12 +6890,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6845,7 +6904,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:39 GMT
+      - Mon, 02 Jan 2023 14:22:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6855,7 +6914,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4c6427b-1335-40de-8129-338178495228
+      - d450fb60-6541-47bf-bcc7-5b4b43a5fb97
     status: 200 OK
     code: 200
     duration: ""
@@ -6864,12 +6923,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6878,7 +6937,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:44 GMT
+      - Mon, 02 Jan 2023 14:22:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6888,7 +6947,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bcf341b-0ce0-4077-833e-9971cf786e31
+      - 6d44fe19-fb32-41a5-9b91-f15f0c02eb04
     status: 200 OK
     code: 200
     duration: ""
@@ -6897,12 +6956,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6911,7 +6970,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:50 GMT
+      - Mon, 02 Jan 2023 14:22:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6921,7 +6980,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10098da8-1daf-4bad-b232-3f44fd6c6e0e
+      - 1f7b28ea-6096-4697-a193-63247745cad1
     status: 200 OK
     code: 200
     duration: ""
@@ -6930,12 +6989,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6944,7 +7003,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:31:55 GMT
+      - Mon, 02 Jan 2023 14:22:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6954,7 +7013,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 218836c6-f7bf-4d66-9006-e3f18fdcfbc1
+      - f70ba0fd-fa58-4c68-8b8a-136b1c767245
     status: 200 OK
     code: 200
     duration: ""
@@ -6963,12 +7022,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -6977,7 +7036,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:00 GMT
+      - Mon, 02 Jan 2023 14:22:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6987,7 +7046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7a7cbc0-0a2d-437b-967d-02e7a501114e
+      - 8bb5a649-6354-4cab-b113-501372a36f9a
     status: 200 OK
     code: 200
     duration: ""
@@ -6996,12 +7055,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7010,7 +7069,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:06 GMT
+      - Mon, 02 Jan 2023 14:22:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7020,7 +7079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd620ba1-c5e4-44dc-9528-145b2768d037
+      - 6b3fecff-4df6-41e0-8156-f56fded4ef2a
     status: 200 OK
     code: 200
     duration: ""
@@ -7029,12 +7088,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7043,7 +7102,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:13 GMT
+      - Mon, 02 Jan 2023 14:23:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7053,7 +7112,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5514680-a812-419e-a7f9-5a6b67966829
+      - 16686f65-8da8-4cce-acba-83a415c7f471
     status: 200 OK
     code: 200
     duration: ""
@@ -7062,12 +7121,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7076,7 +7135,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:18 GMT
+      - Mon, 02 Jan 2023 14:23:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7086,7 +7145,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b3c2d4d-d7ee-44b8-aaa9-92597df90dd3
+      - f2aa8be0-c4e1-4aee-85d3-72583b9aeefb
     status: 200 OK
     code: 200
     duration: ""
@@ -7095,12 +7154,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7109,7 +7168,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:25 GMT
+      - Mon, 02 Jan 2023 14:23:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7119,7 +7178,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6d8a5e5-ac4f-48cb-9066-b1be30376d93
+      - b26a1058-4715-40c8-9509-de25ad8a19d4
     status: 200 OK
     code: 200
     duration: ""
@@ -7128,12 +7187,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7142,7 +7201,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:31 GMT
+      - Mon, 02 Jan 2023 14:23:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7152,7 +7211,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0396ac64-2b21-4077-82cb-b9dd5f8ce6a1
+      - 5f8fe15f-5eaa-47c6-b86c-5b96121b7c2d
     status: 200 OK
     code: 200
     duration: ""
@@ -7161,12 +7220,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7175,7 +7234,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:43 GMT
+      - Mon, 02 Jan 2023 14:23:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7185,7 +7244,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 810accb1-f6d1-4e53-a066-5f7aeb82fa6a
+      - 2843d2c5-608d-4df0-bf24-6f755f0ce988
     status: 200 OK
     code: 200
     duration: ""
@@ -7194,12 +7253,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7208,7 +7267,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:49 GMT
+      - Mon, 02 Jan 2023 14:23:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7218,7 +7277,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfde7aae-d38e-41f1-8fab-2ed14c2075c3
+      - 2ae8c690-7a2e-4415-9a1c-4c7fe630a8e9
     status: 200 OK
     code: 200
     duration: ""
@@ -7227,12 +7286,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7241,7 +7300,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:32:55 GMT
+      - Mon, 02 Jan 2023 14:23:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7251,7 +7310,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0187c43e-ebf7-44dc-87e2-21ae8d7643ce
+      - 5e075076-ef39-43e5-88d6-6fea0cbd69ff
     status: 200 OK
     code: 200
     duration: ""
@@ -7260,12 +7319,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7274,7 +7333,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:33:00 GMT
+      - Mon, 02 Jan 2023 14:23:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7284,7 +7343,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6df3fe0a-0b9d-4d3f-91e3-5440f9e4f19a
+      - 440de18e-ddb6-4d01-9ba7-ea0e0d65d540
     status: 200 OK
     code: 200
     duration: ""
@@ -7293,12 +7352,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:21:14.746174Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "611"
@@ -7307,7 +7366,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:33:07 GMT
+      - Mon, 02 Jan 2023 14:23:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7317,7 +7376,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 537b3301-f926-4697-a04c-b991cca7eb17
+      - 4ffd13d2-95e0-4053-9397-95679ea385ff
     status: 200 OK
     code: 200
     duration: ""
@@ -7326,177 +7385,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:33:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e401780-f919-4e4f-9bcb-f16302d8d6ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:33:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 029c0801-fe0c-4af7-a00d-155a1604a5b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:33:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b20283b3-fcd3-436d-8813-f7d6deea92ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:33:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 27ce4f58-2737-4f9b-bfe6-1500d929133d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:30:05.276254Z","name":"placement_group","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "611"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:33:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a733564a-9692-499d-9296-2807582d322a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:33:47.093525Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:23:44.652286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "609"
@@ -7505,7 +7399,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:33:48 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7515,7 +7409,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 161ecc5e-063c-424e-98f9-9b72864a4818
+      - e6b40e02-d23f-4d13-a441-f35ca99fd5aa
     status: 200 OK
     code: 200
     duration: ""
@@ -7524,12 +7418,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:33:47.093525Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:23:44.652286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "609"
@@ -7538,7 +7432,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:33:49 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7548,7 +7442,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50669c49-b478-4434-a2f1-10c3e09c582a
+      - 47b76462-e17f-4fd1-bbbb-a3a719ac4454
     status: 200 OK
     code: 200
     duration: ""
@@ -7557,12 +7451,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6/nodes?order_by=created_at_asc&page=1&pool_id=1912afd8-7250-4219-892c-ec7dd5a25c92&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977/nodes?order_by=created_at_asc&page=1&pool_id=0c0c0d2d-57af-41d3-8947-bb511a6bb32b&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"c0dbe6dc-00cb-4c03-8777-5fc5f08b6def","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:31:24.901602Z","updated_at":"2022-10-06T12:33:46.883473Z","pool_id":"1912afd8-7250-4219-892c-ec7dd5a25c92","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-placement-group-placement-group-c0dbe6dc00","public_ip_v4":"51.15.54.161","public_ip_v6":null,"provider_id":"scaleway://instance/nl-ams-1/33b87d57-7139-483a-aec9-355ac8c609a6","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:21:24.860367Z","error_message":null,"id":"1ae9cc4a-26f5-4771-aa75-3bae033e592b","name":"scw-placement-group-placement-group-1ae9cc4a26","pool_id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","provider_id":"scaleway://instance/nl-ams-1/86b94d2c-a0e7-44b9-8cad-33d515be5aa4","public_ip_v4":"51.15.94.228","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:23:44.630222Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "604"
@@ -7571,7 +7465,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:33:54 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7581,7 +7475,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f210b2f8-069d-433e-9387-961258a37e58
+      - 08f42c4b-6bf8-470f-845e-20c01b6ec740
     status: 200 OK
     code: 200
     duration: ""
@@ -7590,12 +7484,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:29:59.264005Z","type":"multicloud","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:21:10.055763Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1330"
@@ -7604,7 +7498,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:33:56 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7614,7 +7508,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 390095cf-fdfb-4852-bd5a-10a66921081d
+      - e05a684f-060f-446a-86de-c2e70efc8b93
     status: 200 OK
     code: 200
     duration: ""
@@ -7623,12 +7517,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:33:47.093525Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:23:44.652286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "609"
@@ -7637,7 +7531,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:00 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7647,7 +7541,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86a0e7bc-3da9-4755-8cf4-c59e24285a7a
+      - 08606955-9de0-4dfb-8a15-2505b0b5f255
     status: 200 OK
     code: 200
     duration: ""
@@ -7656,16 +7550,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/4e57cfaf-9262-47d0-93c4-73270652828b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"placement_group": {"id": "4e57cfaf-9262-47d0-93c4-73270652828b", "name":
-      "pool-placement-group", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "policy_mode": "optional",
-      "policy_type": "max_availability", "policy_respected": true, "tags": [], "zone":
-      "nl-ams-1"}}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:21:10.055763Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1330"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:23:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c15f71f-cf4a-4548-8ba7-2d36d3a6ade5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/e8934ffa-57e6-46c2-8094-0f0f11116144
+    method: GET
+  response:
+    body: '{"placement_group":{"id":"e8934ffa-57e6-46c2-8094-0f0f11116144","name":"pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "326"
@@ -7674,7 +7597,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:01 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7684,7 +7607,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dc05528-48a6-476e-87ce-dc5ac6696c02
+      - 623364a9-5fd8-4731-af2d-952ddeeb99fd
     status: 200 OK
     code: 200
     duration: ""
@@ -7693,45 +7616,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977/kubeconfig
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:29:59.264005Z","type":"multicloud","name":"placement_group","description":"","status":"ready","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1330"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 06 Oct 2022 12:34:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b7044948-76ce-42c3-bb18-5f92e6ccf9c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6/kubeconfig
-    method: GET
-  response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVVMVVRWGRPVkVWNVRXcG5NVTFXYjFoRVZFMTVUVlJCZDA1VVJYbE5hbWN4VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbFpKQ2xKVlJHeHZRbmxZZDBsTFdIQXphbE5XUW1SdE1UVjNVVzh2UTJwbFEwMVNNbmRHTUdnMlltSktTWEpMVkdzNWVtaEVlbGhPVUdkcWNGSmpZM0pWUlc0S00wcGFSbmROY25GWUwwSXphV2xHWW1SWmFYTllNalZhU1daU1ZETXJWeTlxT0dZd1NWUTNTVFZKY0RsTVJqVjJUR2d2VDFSNVFYbHRTRkYzUW5SS1RBcDJOVEpSWTFObFFVUnJMekp3V1U5dk1reFlTVk5QTTBwWlpWWlNaMDlLWjJaRk1HdHhTMXBWYzA5ak5XUTFTbmN5UzJaV1JHbE1TR0ZVU0VaQlFscFZDbVI1TVRjd05rWmxTM2R3VkhaMFFrdDFSeTlzTUZoWlpUSklOMWd3Y2xKT2FXdGlSMmhPYldGMU9WcFpRVkpvUVhOalpIcGhZa0pxTTFneE9GWXJjbFlLT0d4WFFXNXhUSFpJVFhGTFUyOVNjekZ2YlZjM09GWjNSMUJ5V0c5d1ZETmhiRVZpSzFwMVVrZE5VblF5TTBGVGJVMXhObkZ3TjNkQmFtRkpNVlJIUVFwd2JFSkNVRmh1ZVc1T2JYQnFVRFJFVDFWalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTVFXeFJXRTB5TVV0WFV6WnlNV3hLVkcxVmEzYzNiaXRDWlVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFpGWmFSRXQxVUd0UU5EQTRVVTFLTkVGRGNHZHFaSGRJZVZObVIwMXRhRVI2YW1sRE1WUlpiV2MyUVdaRlVURkVXUXAzUW5Cek0yWkxkR1k0Y1VKSFZHdGFjMU0zUlV0dmVqSnFUalV4TldRcmRYSlJaRk5CU1ROcVNtZElja0pxZDFaSFJUaFFXWEpQTUhBd2JUUjROR2xZQ2pCUFV6RlJlRkIwSzB4VFRWRk5TRFpyUTNkTWRHZDBhVFp1WjFFM1NGZ3lkbUY2WkRSM01GZHNaMm94TjI5R2JVdGhZbFp0YzBWc1J6ZEdRM05CTW1rS1pIVm1lVWRKWlhSbWRVZ3lUbUZJY1RRelRFWlRNa3RCVm1SQk1VRTBiRWRsWkdabVJEaGFSMk5xTkZwM1ZUVlBXalpoTDI5a1pscEdkVFZWT1dOblZ3b3dMMGRDUkhSaGJHRmlOMEZhUkdkVk0wcG1XalJ6TVdwWWFIVlFhRGh1TlhrMk0wUm1WVmMxZUZGSFEyZDRkMUZ0TW5CUWNuaFZTRlJWTUZkV1ozRXZDakJ2VkZSTE9XVlZNRGd4WlVoVk4yTnRXR2hyV0ZKeE1uSldXVGg0ZWpWWlpqUlNjd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTQzZGE1MDctMThhNS00YmNhLTkyZDAtYzBiMDc1OGZmNWI2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNdEk5MFV0RXBGM0dqdER6Um5WYk1wWmJJSzdqNExxVHRlb09MNERKekpzRHVsQUVrV2lWNEN5VQ=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBsYWNlbWVudC1ncm91cCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVSWGROVkVVd1RXcEJkMDFHYjFoRVZFMTZUVVJGZDAxVVJUQk5ha0YzVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0pYQ2pSdGJETklibmxuV2xaTGJFTXJRbkYyUmtsTGRUVnZXV2xDZW14elFucHdNMFZHY1ROWVoxaGlWRTFuUjFsMk4xVkRXV3B4VURFMVEzZEZWazF0UXpBS2NUWjJjV1pDUjNSMllXUlZlRk51TkZwc2REWkNaVXA0WnpaUVZHdHVOemswVGtGTFZXMHphMjlRV1dwT2NEWnVjVkJvYzJaNE5FMXBTbUY2UTA1UmVRcE1ObVJsT1hkRFZuTm5aRTB2VkVRelVqUXpXRk5SYTA5cGNXMHlSM05qTUZaaVNYUkplSFo1Y2poUVYwcFpXRzR6ZVhoQlNURnNhRXBVVDNJdmVGVnRDbEkyU1dJeVJIaFJMMDV5YmtaS1UxTTJTVkI2Tld3M1RWWlpZMGQ1VFVoNGRISm1SRE5PV0daR1ZXbzJaRzAxTWpkSlNFZ3hORlZaZERoclpVcENSakFLZG14UWQwcGpSWE12ZFdVeGQwUnBSMlJQVVdvMlQyaDJVWG8wVEUxamVrWlVhM1pSUjNwMldHTkJabk5DVVdsVlVWQXJSbVZGZG5sd1QxWjFUVE5OUXdwTlJrODViVWczYzBWRE1IWlhkR3d6VUd4clEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTGEybDRkVkJQWjBJcmMzVlBWakpNYUcxcllVbENTM2MwVERKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1dsZDRiRTFOVjBoc1ZtUnFiMXBRYW1OMFVXdzJTRFpKUkZkcmNtSmFUR1ZIZG0xUWIwaHpSVmREWlcxV1JWUllSd3BIVFVkME5qVkJVakJKWTNWNGFWcE1VM000VjA5YWNYUlZkRVY1WkROa2IwdzJPV2Q0TVZsR2VWUlhUMGQ0YTFGWVdsQjVUWGhvTHpkQmJFSmtkM1ZKQ2pac0syazFWV0p2VldoSlZFMURhbU5IZEdWR1pqRnZUMUE1TTNGVFMyMWtRMVp0YVN0WU1tZG9VVm8wUmxjNVpVaDJhbVl3WXpoNE0yNXliMFZUZVRRS1FVaEVTRzVrVGtzME1tSlRlREU0TjFvMlJFVnpXWFpOUTBkaWFtMUVNa0Z6YTBSdFlYQlFPV2M1TVdkaksyOVRaMWxYWVhkaFZEa3ljMWhyZG1wQ2FncEhiM1ZSV1RSUlEzSnlVRGgwUmtrdlpYSXpVSEJ1V2poVEwzcEVNR280SzFabWNEVkdaRUZ3VEdOV2NGWkJPVFZEWm5ONlFWSTJNRlJyUmxKamNHdEdDbWhPVW14SVdGY3dkRmhwUVRsTVFsQnZkVk5KV2tWdVQwRnhOWFYxVUdSWFptNVdiQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vODkxY2JlZmUtMmI1Zi00Njg2LWFiZGYtMDc5ZWFmZjdlOTc3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHBsYWNlbWVudC1ncm91cAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAicGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogcGxhY2VtZW50LWdyb3VwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AcGxhY2VtZW50LWdyb3VwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6djlpdDMzNTZpYXVzOVdQREZOc2tXUjdjQWxrVzc2RHZla1I1UzlMbFJiUEU4VlRScDdLMXR1Tw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -7740,7 +7630,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:02 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7750,7 +7640,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 912ce0cf-4564-4e0c-b887-52d2d196479d
+      - 0ad23872-ba5a-4399-adec-3cf5902bd6f6
     status: 200 OK
     code: 200
     duration: ""
@@ -7759,12 +7649,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: GET
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:33:47.093525Z","name":"placement_group","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:23:44.652286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "609"
@@ -7773,7 +7663,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:04 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7783,7 +7673,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7fd2e0b-111b-4eb2-b177-20e6d5af20a6
+      - fd071199-1040-42fd-a92f-22ca7f07fee5
     status: 200 OK
     code: 200
     duration: ""
@@ -7792,12 +7682,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6/nodes?order_by=created_at_asc&page=1&pool_id=1912afd8-7250-4219-892c-ec7dd5a25c92&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977/nodes?order_by=created_at_asc&page=1&pool_id=0c0c0d2d-57af-41d3-8947-bb511a6bb32b&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"c0dbe6dc-00cb-4c03-8777-5fc5f08b6def","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:31:24.901602Z","updated_at":"2022-10-06T12:33:46.883473Z","pool_id":"1912afd8-7250-4219-892c-ec7dd5a25c92","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-placement-group-placement-group-c0dbe6dc00","public_ip_v4":"51.15.54.161","public_ip_v6":null,"provider_id":"scaleway://instance/nl-ams-1/33b87d57-7139-483a-aec9-355ac8c609a6","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:21:24.860367Z","error_message":null,"id":"1ae9cc4a-26f5-4771-aa75-3bae033e592b","name":"scw-placement-group-placement-group-1ae9cc4a26","pool_id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","provider_id":"scaleway://instance/nl-ams-1/86b94d2c-a0e7-44b9-8cad-33d515be5aa4","public_ip_v4":"51.15.94.228","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:23:44.630222Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "604"
@@ -7806,7 +7696,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:06 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7816,7 +7706,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f8e730b-8e3d-4f1f-a2bd-f6c6a9793e62
+      - e9f10891-7443-452f-beb8-900b0f60d289
     status: 200 OK
     code: 200
     duration: ""
@@ -7825,12 +7715,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1912afd8-7250-4219-892c-ec7dd5a25c92
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0c0c0d2d-57af-41d3-8947-bb511a6bb32b
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"1912afd8-7250-4219-892c-ec7dd5a25c92","cluster_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","created_at":"2022-10-06T12:30:05.183972Z","updated_at":"2022-10-06T12:34:08.347626260Z","name":"placement_group","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":"4e57cfaf-9262-47d0-93c4-73270652828b","kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"nl-ams-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","container_runtime":"containerd","created_at":"2023-01-02T14:21:14.736874Z","id":"0c0c0d2d-57af-41d3-8947-bb511a6bb32b","kubelet_args":{},"max_size":1,"min_size":1,"name":"placement_group","node_type":"gp1_xs","placement_group_id":"e8934ffa-57e6-46c2-8094-0f0f11116144","region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-01-02T14:23:47.855170165Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "615"
@@ -7839,7 +7729,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:08 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7849,7 +7739,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5e7c780-0c26-450c-ab2d-b195b49920cc
+      - fa776808-4023-4af8-8ea3-8c653a9fbf81
     status: 200 OK
     code: 200
     duration: ""
@@ -7858,41 +7748,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/4e57cfaf-9262-47d0-93c4-73270652828b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977?with_additional_resources=true
     method: DELETE
   response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Thu, 06 Oct 2022 12:34:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6192a30d-b7b3-41ab-ad6f-4645d5b42588
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6?with_additional_resources=false
-    method: DELETE
-  response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286952544Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958010Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1336"
@@ -7901,7 +7762,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:09 GMT
+      - Mon, 02 Jan 2023 14:23:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7911,7 +7772,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d08ee74-6d7e-4ead-a301-e2f498f880ab
+      - 4164e564-9d7b-4089-9e33-d2faab01a9e6
     status: 200 OK
     code: 200
     duration: ""
@@ -7920,12 +7781,41 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/e8934ffa-57e6-46c2-8094-0f0f11116144
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Mon, 02 Jan 2023 14:23:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f05e38f8-e9f1-4570-b923-ccd20a1c2aac
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -7934,7 +7824,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:10 GMT
+      - Mon, 02 Jan 2023 14:23:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7944,7 +7834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebd44d4c-b987-4ea9-a000-fac8e4c6794b
+      - 5ee84470-210f-4a1b-a096-897ea284ebd9
     status: 200 OK
     code: 200
     duration: ""
@@ -7953,12 +7843,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -7967,7 +7857,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:16 GMT
+      - Mon, 02 Jan 2023 14:23:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7977,7 +7867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cf40fae-d44a-43f0-80e0-b7ce288f805b
+      - c889dc45-66f8-4237-bf8a-0a6115d00efb
     status: 200 OK
     code: 200
     duration: ""
@@ -7986,12 +7876,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -8000,7 +7890,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:21 GMT
+      - Mon, 02 Jan 2023 14:23:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8010,7 +7900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26383479-9031-44e9-8df0-c10374a7c63b
+      - 7f8d4e5a-3356-4a1e-b47e-5e476b3b04f9
     status: 200 OK
     code: 200
     duration: ""
@@ -8019,12 +7909,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -8033,7 +7923,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:26 GMT
+      - Mon, 02 Jan 2023 14:24:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8043,7 +7933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87d60574-0b29-4990-bd41-e6bb09486289
+      - 38aa1e85-a105-4fc1-b374-46a3871cef77
     status: 200 OK
     code: 200
     duration: ""
@@ -8052,12 +7942,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -8066,7 +7956,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:32 GMT
+      - Mon, 02 Jan 2023 14:24:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8076,7 +7966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6db7c77c-b7db-4601-a0a3-b5b3c261504f
+      - ad604ba8-2d45-4669-ae4c-0bcea832f6b5
     status: 200 OK
     code: 200
     duration: ""
@@ -8085,12 +7975,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -8099,7 +7989,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:38 GMT
+      - Mon, 02 Jan 2023 14:24:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8109,7 +7999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5abebe9e-7bc4-4a18-80a5-935f66e8ee4a
+      - 6c999a8d-5ce4-4d96-ab98-1d2af76e5851
     status: 200 OK
     code: 200
     duration: ""
@@ -8118,12 +8008,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -8132,7 +8022,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:44 GMT
+      - Mon, 02 Jan 2023 14:24:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8142,7 +8032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 112f8278-5553-4f8e-af61-e750d8dc7b40
+      - 6369f377-d59a-488b-8c9e-2454bf117f19
     status: 200 OK
     code: 200
     duration: ""
@@ -8151,12 +8041,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -8165,7 +8055,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:50 GMT
+      - Mon, 02 Jan 2023 14:24:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8175,7 +8065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83916d31-893c-4279-8652-fd93a4f32787
+      - a0fa9d80-90e9-46d2-8a14-8710a4e5c8d4
     status: 200 OK
     code: 200
     duration: ""
@@ -8184,12 +8074,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -8198,7 +8088,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:34:57 GMT
+      - Mon, 02 Jan 2023 14:24:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8208,7 +8098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9792059a-461b-45ec-9225-63883ba4f607
+      - 035b9e6f-447b-4f81-a24b-5588176fc286
     status: 200 OK
     code: 200
     duration: ""
@@ -8217,12 +8107,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"region":"fr-par","id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","created_at":"2022-10-06T12:28:48.557126Z","updated_at":"2022-10-06T12:34:09.286953Z","type":"multicloud","name":"placement_group","description":"","status":"deleting","version":"1.24.5","cni":"kilo","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"cluster_url":"https://a43da507-18a5-4bca-92d0-c0b0758ff5b6.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.a43da507-18a5-4bca-92d0-c0b0758ff5b6.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://891cbefe-2b5f-4686-abdf-079eaff7e977.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","created_at":"2023-01-02T14:19:58.521573Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.891cbefe-2b5f-4686-abdf-079eaff7e977.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"891cbefe-2b5f-4686-abdf-079eaff7e977","ingress":"none","name":"placement_group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-01-02T14:23:47.930958Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1333"
@@ -8231,7 +8121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:35:02 GMT
+      - Mon, 02 Jan 2023 14:24:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8241,7 +8131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac51804b-ff14-4a42-baa7-269195f4cbd5
+      - 8fa60a51-dc61-4867-9ee2-579401eae702
     status: 200 OK
     code: 200
     duration: ""
@@ -8250,12 +8140,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -8264,7 +8154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:35:07 GMT
+      - Mon, 02 Jan 2023 14:24:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8274,7 +8164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba8bd554-4762-4a28-ab5d-22d723df61c9
+      - e408c3a3-4ab5-46c0-9cb2-74991e35c300
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8283,12 +8173,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a43da507-18a5-4bca-92d0-c0b0758ff5b6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/891cbefe-2b5f-4686-abdf-079eaff7e977
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a43da507-18a5-4bca-92d0-c0b0758ff5b6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"891cbefe-2b5f-4686-abdf-079eaff7e977","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -8297,7 +8187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Oct 2022 12:35:08 GMT
+      - Mon, 02 Jan 2023 14:24:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8307,7 +8197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad10d491-b229-4a02-83c0-21af2fc6498b
+      - 4bb780cb-8436-4bab-8429-4af72208c32a
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-upgrade-policy.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-upgrade-policy.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:24 GMT
+      - Mon, 02 Jan 2023 14:10:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baf62626-2120-4f8e-9e5a-218c423aea12
+      - 4d8ea24f-d4e1-41ca-8e23-09b078f23c16
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"K8SPoolConfigUpgradePolicy","description":"","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"version":"1.24.5","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"K8SPoolConfigUpgradePolicy","description":"","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"version":"1.24.7","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416037Z","updated_at":"2022-10-25T08:39:25.540243107Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698187Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.594562506Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1348"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85fd167d-53ed-4462-887c-32a08c0a67c8
+      - dfc91e3c-f1cb-4c34-b710-ff1c5c4072be
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:39:25.540243Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.594563Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1342"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37d7e15e-fa4e-407e-9174-4a8d87b4b5f2
+      - 2ace8dd5-eefa-4863-90ee-5be8ff13fbc4
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:39:29.020295Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.703038Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1347"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c04e0e71-28fb-43f2-98c5-aa916ef4e254
+      - 3e2f0025-297e-4e4b-8c15-071fa6becf46
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:39:29.020295Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.703038Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1347"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecbaad2d-ae8a-47b9-a4c7-af3aecbb1e97
+      - 6a8275aa-6020-4e68-a28b-fb1eb5fa2d74
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlN6ZGhDblp2TURCdEswOURSR1ZGTVdoWWVreFVRM0pUUlU5c1UyeFBVVGQyT1N0VmMyUnNNeTlNU1ZsRlVsbEpUR1o0YWpGb1MyZHBZWGRMVlM5RU1sWmtaRGdLWVZOM2VHeDZabFZzWW1kV1lYTnllbWgzVkVsUk9XNURWWEJrYUU5elNXMWhjMUpvVW5RNVFXTnhLMU4yTldnMVpFSmtSSFp3YVRabVdrRmxUREpUVkFwMWJYTkVUMFJRVm5Kc1NHRllhWE5vTW5wWFpYWk5NVU5OYzJKR1YzRTNiVEJ1V0N0MWIxcFJjSEVyU3poSVEwaERNMWh0VGt4S04xcDZOWFpxYUZBeUNsTlpPV0pKWjNOQmJVMWxkR05LVUZKWU1sSnJNbGRLWTBkcFpXdFNWR2h4VkUxMVQzUkxSRU5YVDFRMGQxQnBaM28zWjBzemNsQkhMMlU0YjJWRFZXTUtkRXN3ZWxaMmRVeFRlRTlFT1RkNWJGTkRZM0ZKYlV4d1NVbERjREJsYVVZNVlrWkJSMmRsYmtseGNWcHVWR2wzZUZoNE5HOXRNelpFWkU5Q1VGaHJaUW93ZUc5cVdYUlBPRWRYYmxCdVJua3hUazlWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCYUdJclF6QnZWbmd4VDJkSlRsaHBiRE42ZGxaV0syZEpZbWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWlhWSGFFZDRjbGhNY2t4b1RXTk9hazUzUWs1WlFqQm9TV2hGTmswNFVUaFliMFJRTVdkdFUxTjZVbFp4SzJGTGVBcFVVeXRvWjBSdVpHWnlSWFo2UzJkTFRYTm1hRGhMVjNGNVlpdElOR1pWYzNSbGFraDNOVkJGU0RSWlNXNVZaa2xvWVVrM1kzUllUblZRY1ZKaE1ETjNDbXRNYTJjMVRVZHFhRVpLTkVaYVFXOWljbVprUnpBME5EZDVVazFpWTBWRGRsSjJhVGR0YjFablFtczJhR0pVYVd4VFJGbEZkekEyZW5wbE9GQjJhMUFLZUdORVIyMXphRlJWUVhJemJEZEtZME5wVlV4TlVWTnBWM3A2VWtjMmNYUnFWa3RxUmtSVlVXYzVVMmRuYlhFclRtVkVXa2MyV21aaGJYVjJTVEZMVlFwa2VGaHVOalpZUVZKSk0xRjRNSGx0Y2tSSWNUQldjamRYTVhVeGVVUnJNM3BJZFcxc2F6Vm1aSFJETVRaVlIwaHNlRUZ2V21GbmJIQnBlV05EYjBkUkNsbFRNblJXYTNOcU5FUm5lbFJFZUZWd2FsSndjMWRJWW5JeU4zUk9VbTlMU1ZFd2JBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wMmQwY2E0NC0yY2E3LTQ1ZTEtODg3NC01NGQzMTFmNzczODQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3kKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3ktYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlndXBncmFkZXBvbGljeQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxS0lqSmJHT0s2SHVlbkR3bWxTekd3YVdHc2N4OXZBN01jZE40YjlHQkgxUG80bjNrMDFlcHZzMg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQwRXZDbTkyYTI5ME1ESldNa05vYUUxa2JWVnZLM05tT1dkTU5FdG1RMmt4SzBKVWRVZG1XRTQzYWk4NVZqVmlaWFJYYlU4MmVsY3lhVUUxWm1veFVIRlZXblVLYm5SWVVIUkxOMDVWYkdJelZIaHhka3gyWlZaMGRVWnRZaTloVmpWM05raEJkVEZPT0RsblFYRkpTRGhETjFKT1dubDFNakF6UkRkUldVRlBTREIzVFFwWU5VVnBNWFl3TjB4M2RVOWxhV1pvUVVaMWFtRm5XRmR5Vkd4WlMxaFhkMFpwYW1jeU56SkxhREo2ZFhJNFZWQnJhblpyUTAxNFdXb3JZVXBtWW5wckNuVmtabTUwTkU4clYyWmxTemRZY25oaUswUTBhVlZaVmtnM1dtTk9ZMjl5YzNsYWJVVXhSWFYwTDNkemNERlpSRlpqVmpWeEwyaG1Ta1Y2U0V0UWR6WUtUR2xGVG14MVRGSnZLMVl6Ums1VldUVjNaU3RPVmt4S1RIWmtWelY1VjJSbVJEbHZjbk4xWkhWd2QwcFhRazFzUTNsS2FYbEdNRTlhY21ad05razRUZ296YTIwellreDJiVmhWYURKUmRWQTVXRVJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGYnpjd1IxY3ZiRVJ5ZVdONksybERlRUY2UkRWNmIzWkdSQ3ROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZVdSd2RXeE5NbWh3ZWtKaWVscFBiVWdyTlhWSE5FWkxTamhqU1RKelEwTnlPVzk0WkRONmNYUndRbVZoTUd0RU5nbzBkbEp3YmpkMU16aG9TRmRuVG1oS1kyY3JPRmhZT0ZweU9HVXJURlZTYVRWcVlrWTVTMjV0ZWxOc1pUTmFVbmxhU1RZNE1IY3lNbko1YjFWNU1XWkVDbWhFTDFwT2VXWkJiMjR2ZG1KSVowUXZlR1J5TjFCU2FUZGpNU3MwWXpKdlV6STRURFZtV0VJek1ETnJORGQwVGtkamVISkZTRGR2U2pCWFFXRlZNVFVLU1VsTlptSXpXbXBWT1Zkb1EwbGpaemwwU1ZFeGFucDZOekZzYW14eU1YaEJVQzkzV2xaeU4ydFdSWE5PY1c5UFJtTkpWV3BuUW5oQmFYTk5aV053TkFwblVtODRjemwzU0Vsd1FWVlBjMWR1T1VabmJtbGxPRTVUVkZkeE4zTkxNek56WW1nelVXMU1SRU5NU1djeUsycE1XRU5ZUzBKNVoycGFUREpGTlVzeENuaG9TWHB3TVc5NVR6WTVjblZpZFdweVdsYzVSM0pMYW1sSVZVb3pkelJrWW1KWmFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kOGFmNWQwNS04YjdmLTQ1NTItYTgwYi0yMTVmYWM2MGQ3NDYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3kKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3ktYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlndXBncmFkZXBvbGljeQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKeVVkYkZQM1ZBVGZmeDVabUVCQ2R5OXhodWhjU2NqOUFTSHhNV1ZRWVR0N1lWaVJYV0l2NkFmaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2700"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a992ca10-572d-4da2-a91d-f59067c94f4a
+      - bb9a158f-17ee-4874-b4d5-c27c99ef4538
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:39:29.020295Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:10:35.703038Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1347"
@@ -223,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebb352ae-c7e7-4c15-baad-00c281c50563
+      - 61450783-42eb-4165-b550-9f42a287d353
     status: 200 OK
     code: 200
     duration: ""
@@ -244,12 +245,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572233Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267267922Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -258,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 14:10:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -268,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40b39061-cdd0-455f-b361-ecaaccb59f41
+      - 0beb2c10-2877-4595-bdfb-e0fab2201643
     status: 200 OK
     code: 200
     duration: ""
@@ -277,12 +278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -291,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:33 GMT
+      - Mon, 02 Jan 2023 14:10:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -301,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b43641f-7562-4fd8-a17a-b46200afda7d
+      - b35ec971-9add-414f-afbd-6f018bcee387
     status: 200 OK
     code: 200
     duration: ""
@@ -310,12 +311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -324,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:38 GMT
+      - Mon, 02 Jan 2023 14:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -334,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ef8da66-d20f-4520-99cf-1e2b1fdd5ee3
+      - 3be1d225-71f3-4189-99a0-b05b912418e9
     status: 200 OK
     code: 200
     duration: ""
@@ -343,12 +344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -357,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:43 GMT
+      - Mon, 02 Jan 2023 14:10:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -367,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bf4b69c-c21d-4e6b-a5ee-20d073c4a8a2
+      - c5731baa-ec18-4539-84bb-fdba6cbaeb9e
     status: 200 OK
     code: 200
     duration: ""
@@ -376,12 +377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -390,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:49 GMT
+      - Mon, 02 Jan 2023 14:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 430e5206-66ec-4458-9052-1f79f46c57f8
+      - 255c3772-a06f-47a0-9756-f838c3cf37ca
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -423,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:54 GMT
+      - Mon, 02 Jan 2023 14:11:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f49faf0-dea1-45f7-9cdb-2db7a1c03d81
+      - 33b2a364-b30a-48ad-97ad-16092f9fa9c5
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -456,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:00 GMT
+      - Mon, 02 Jan 2023 14:11:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be51984b-ff9f-4c68-b351-f28809ea8414
+      - d3e1e2a9-08c2-47e0-af8d-ed2c28afe9e8
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -489,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:05 GMT
+      - Mon, 02 Jan 2023 14:11:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2fb8dc9-70ca-495c-9930-e264145a92a2
+      - e8472478-c866-4a3e-83f0-69871ed0a0a2
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -522,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:10 GMT
+      - Mon, 02 Jan 2023 14:11:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 228a29af-fbad-467f-830f-3d06d467a6a7
+      - 2c87a6e1-a206-4e9d-ad35-8297f2bf21d0
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -555,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:16 GMT
+      - Mon, 02 Jan 2023 14:11:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0516761e-d58d-415c-9948-18f1ce1ee55c
+      - e6191606-609d-4ec9-bbf2-f4b3fa762b35
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -588,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:21 GMT
+      - Mon, 02 Jan 2023 14:11:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95936111-5443-451d-a18d-fc39c8b619e2
+      - 08f5da89-7270-414a-895e-f9566c8d07a3
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -621,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:26 GMT
+      - Mon, 02 Jan 2023 14:11:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dbdcd5d-8b0e-44d9-82b6-4d102be9a164
+      - 003ab9be-22fb-4176-b8b6-33fe5390afa3
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -654,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:32 GMT
+      - Mon, 02 Jan 2023 14:11:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b0fa146-bd36-4c6f-92e4-3c63121299d8
+      - 26a1b6e0-1215-4625-baa4-503c90799b2c
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -687,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:37 GMT
+      - Mon, 02 Jan 2023 14:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5077890e-7bb8-47b1-9cda-09ccf927329d
+      - 39a9a599-b43e-4a29-bed8-71bd6a4996ab
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -720,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:43 GMT
+      - Mon, 02 Jan 2023 14:11:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ab44a52-0356-4637-837b-10835d1bb0d2
+      - b9b15fc6-018a-449d-9703-cdee0dcf30ba
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -753,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:48 GMT
+      - Mon, 02 Jan 2023 14:11:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46817b19-5138-4595-8ce0-d22b5d2baa26
+      - 5de4bf8c-dc74-48a5-b00a-3c79c895d18d
     status: 200 OK
     code: 200
     duration: ""
@@ -772,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -786,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:53 GMT
+      - Mon, 02 Jan 2023 14:11:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c39023a-a45c-45e5-86a5-104917e19814
+      - 71cd4073-7ebe-4171-b27c-cff0722784e4
     status: 200 OK
     code: 200
     duration: ""
@@ -805,12 +806,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -819,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:59 GMT
+      - Mon, 02 Jan 2023 14:12:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1aec570-b4b9-40bf-98b6-21f064e064ae
+      - 32037f88-ae05-4b7d-b35f-3ab99ae3779c
     status: 200 OK
     code: 200
     duration: ""
@@ -838,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -852,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:04 GMT
+      - Mon, 02 Jan 2023 14:12:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98093b39-3501-4e52-bb18-e3b55334b1b2
+      - 9914ac97-9056-47ac-9e7a-db8044008f51
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -885,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:10 GMT
+      - Mon, 02 Jan 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c6df383-7e0d-43c6-91ce-1d04f75ff392
+      - 4f8342ee-b459-4373-a9cb-476d75adae00
     status: 200 OK
     code: 200
     duration: ""
@@ -904,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -918,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:15 GMT
+      - Mon, 02 Jan 2023 14:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2db5f29e-9cf4-4817-871c-c4d0d4280b6d
+      - 3a9924ba-ef2c-4065-93bb-7dc89e6b8a0e
     status: 200 OK
     code: 200
     duration: ""
@@ -937,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -951,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:21 GMT
+      - Mon, 02 Jan 2023 14:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32421968-e113-4420-bc9e-56c8bc3cc07a
+      - 4a6da626-d214-4347-ad0d-47e8f7ce1036
     status: 200 OK
     code: 200
     duration: ""
@@ -970,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -984,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:26 GMT
+      - Mon, 02 Jan 2023 14:12:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 142cbe03-21ab-45ce-a2e2-f01d1cb7c5f1
+      - 055908c5-a947-486d-9f8b-a96d3c34319b
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1017,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:31 GMT
+      - Mon, 02 Jan 2023 14:12:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6fd4190-ba19-4805-b802-8c642aea2d86
+      - 151669af-cb46-49c9-bdbb-b538114cbc54
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1050,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:36 GMT
+      - Mon, 02 Jan 2023 14:12:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f98f024e-5540-40b5-9816-3ae6fd67b908
+      - c9115f20-7eda-412b-82ac-b52987152519
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1083,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:42 GMT
+      - Mon, 02 Jan 2023 14:12:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7234aae7-146d-47a8-82f5-f5195dc5cef9
+      - 31f8e93f-4c2d-43b6-a418-9ddbb7b931f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1116,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:47 GMT
+      - Mon, 02 Jan 2023 14:12:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5609a356-c294-43e4-81d1-63629cf7eaab
+      - 58febdc5-7f69-4b2e-a7ac-f6c255ebd80e
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1149,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:53 GMT
+      - Mon, 02 Jan 2023 14:12:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5afb3b35-665c-45d5-bdf0-44078f3e73da
+      - f3e6db45-b6b4-4371-bed5-ebc4fd89a040
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1182,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:58 GMT
+      - Mon, 02 Jan 2023 14:12:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d993b24e-49b0-4ad8-826b-292f5cf6847b
+      - 4554cbe3-75be-43b2-b9d7-927379737b78
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1202,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1215,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:03 GMT
+      - Mon, 02 Jan 2023 14:13:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec6d0cc2-8cba-49ed-a4d5-fcd0c00bb9b8
+      - 3408d475-872f-4c2d-bda7-8ec13d0d7ee3
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1235,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1248,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:08 GMT
+      - Mon, 02 Jan 2023 14:13:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e9bba9a-6d8d-4ba1-966e-08d9db8838dc
+      - 46fc1002-d814-476b-84a7-2a8e50d852eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1268,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1281,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:13 GMT
+      - Mon, 02 Jan 2023 14:13:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2dcead34-48cb-4c9e-816d-f66e71dda9b1
+      - 065b5136-e19e-42ca-99d8-872eeda9babb
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1301,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1314,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:19 GMT
+      - Mon, 02 Jan 2023 14:13:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e7a86fa-171c-4721-adc9-06620c1523a9
+      - ce5130fd-d530-4105-8c61-2c7c02eb1df8
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1347,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:24 GMT
+      - Mon, 02 Jan 2023 14:13:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ba42414-d7e5-44da-8b22-41fa292fd474
+      - a1085cf7-cbea-42a8-9608-d6ab2ad552d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1380,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:30 GMT
+      - Mon, 02 Jan 2023 14:13:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef1fcfc3-d560-4893-95b0-333c86a64552
+      - 87ee84d9-1e6c-41d6-90a8-fa80d608009a
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1413,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:35 GMT
+      - Mon, 02 Jan 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d49ea11-0794-416d-92df-cf8e9c040816
+      - 8bf44c97-3841-48e8-8727-939d11329ade
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1446,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:41 GMT
+      - Mon, 02 Jan 2023 14:13:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbb4e60a-0a2f-4742-8624-bb0bbe8a4799
+      - a85f55b1-5be2-455b-8abc-e91c20030030
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,12 +1466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1479,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:46 GMT
+      - Mon, 02 Jan 2023 14:13:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5dbb55c-96fb-406a-88f8-747fc59689d5
+      - 10c84496-49d7-41fe-8a16-18704a4df14d
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,12 +1499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1512,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:52 GMT
+      - Mon, 02 Jan 2023 14:13:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2743ef83-b64a-49b3-b982-9afe17ee63db
+      - 7ed24f6b-4902-4993-a30b-e0d675b345b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,12 +1532,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1545,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:57 GMT
+      - Mon, 02 Jan 2023 14:13:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b98f454-46db-4b15-ae80-bb9fd2a2146f
+      - 5dfda76a-54bd-46c7-baf8-0be1a817926d
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,12 +1565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1578,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:02 GMT
+      - Mon, 02 Jan 2023 14:13:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73cca608-3178-4d10-9354-dbe42ab837b9
+      - 7cb80ffe-1dd0-4e24-9835-5e3ec68f47e1
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,12 +1598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1611,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:08 GMT
+      - Mon, 02 Jan 2023 14:14:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dae1c3d5-82d7-4fdb-90d5-14f70d10dc5f
+      - 4a40e6ca-a2d7-4187-b8df-ea98eab96413
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,12 +1631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1644,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:13 GMT
+      - Mon, 02 Jan 2023 14:14:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f6b9522-31e1-4905-8179-3c7f8c063ec4
+      - 1239ee9c-5fb2-4f3e-b714-f41618b7830e
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,12 +1664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1677,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:19 GMT
+      - Mon, 02 Jan 2023 14:14:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 756ea895-6492-4599-8118-af7fb8b5f144
+      - 3bf2a259-5e5f-4070-9a53-00384159d679
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,12 +1697,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1710,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:24 GMT
+      - Mon, 02 Jan 2023 14:14:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f3491ff-615c-4e92-bd49-b15e9ecf636d
+      - b4ea467a-0541-4401-b131-1f03843d9f95
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1730,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1743,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:29 GMT
+      - Mon, 02 Jan 2023 14:14:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d47b3711-75ee-4f39-909f-317b52f56745
+      - 40e840a5-57cb-4a44-aa34-035abb054fa9
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,12 +1763,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1776,7 +1777,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:34 GMT
+      - Mon, 02 Jan 2023 14:14:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50c05591-1468-49b8-b651-48e2e48aa862
+      - 2e4bcc00-8615-426c-9b9c-e7cd62dce4ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,12 +1796,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1809,7 +1810,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:40 GMT
+      - Mon, 02 Jan 2023 14:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c95a9ad-3fac-4b6b-ab8d-ae973fc8b799
+      - cbf25645-4606-403e-998f-4ae46bae897d
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,12 +1829,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1842,7 +1843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:45 GMT
+      - Mon, 02 Jan 2023 14:14:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c063d24-76bf-4ef7-9fce-550410978ca5
+      - 977a0be3-3cdb-4f45-9bc3-5e367077f997
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,12 +1862,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1875,7 +1876,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:50 GMT
+      - Mon, 02 Jan 2023 14:14:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eede951a-8c3c-4c2c-9df1-2e2042d02bd5
+      - 12d4d2bc-c1bf-465a-aa15-d66bd65fae60
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,12 +1895,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:39:31.937572Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "623"
@@ -1908,7 +1909,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:55 GMT
+      - Mon, 02 Jan 2023 14:14:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41d461ec-fa0f-483d-addc-e6b05c5e2b8d
+      - 27ce2cfa-d975-4db0-a3a0-c90d12321def
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,12 +1928,342 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:00.888759Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7f619f76-c404-470f-b3c0-82eb8d7b8a9c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fc9dba5d-5714-4cfc-9bc3-763d8762f945
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d9087ecd-3830-43c3-a44f-e9196fcb8a31
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4dc4dc7e-ea22-4249-92ef-78659a658bce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a3144f3c-aa90-447a-8b8e-d6e73336197c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9db74cac-8d91-4cfb-8775-ee7b444ce22d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c0c03cd4-b74c-4c26-ad14-327195a02389
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8ec2e9d-1f84-43a0-820c-306f6ad08e28
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aa119df8-8dfa-4b3e-a349-1abc1cdb426a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:10:39.267268Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "623"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b065f29-64fe-4a84-9957-aee71cef7b84
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:41.198691Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -1941,7 +2272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:01 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1951,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a0e0bd2-2187-4819-a006-719b78cb84bb
+      - cacb9bcf-2433-49cc-81f0-07177c999ff4
     status: 200 OK
     code: 200
     duration: ""
@@ -1960,12 +2291,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:41:05.417998Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:12:04.793866Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1339"
@@ -1974,7 +2305,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:01 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1984,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 270aae99-4f79-4ff9-bd3f-6fe68d002bbd
+      - d4015fd4-b7ab-4429-8bc7-e33a8df06cc5
     status: 200 OK
     code: 200
     duration: ""
@@ -1993,12 +2324,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:00.888759Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:41.198691Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -2007,7 +2338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:01 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2017,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da57b9c0-5278-44a0-ada4-d3c544442058
+      - d0bab4af-508d-4823-96ab-ea3afa6d6961
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,21 +2357,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/nodes?order_by=created_at_asc&page=1&pool_id=e78bc7c7-ca5e-460f-9d96-3fb065ba43dc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/nodes?order_by=created_at_asc&page=1&pool_id=6f02495f-1c19-4fbe-bb96-5fef8fc68616&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2e2b27a5-fb35-42e5-9a36-1e6e7ad1683e","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:41:51.526589Z","updated_at":"2022-10-25T08:44:00.876321Z","pool_id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigupgradepolicy-default-2e2b27a","public_ip_v4":"212.47.236.63","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/69415c9e-500d-4fe0-b575-4858157ded6a","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:53.842567Z","error_message":null,"id":"6070a04b-6871-4530-917a-d20f3b867bb5","name":"scw-k8spoolconfigupgradepolicy-default-6070a04","pool_id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","provider_id":"scaleway://instance/fr-par-1/ed7acf05-dde9-4f11-ada5-63cb4caf9e5a","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:41.188313Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:02 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2050,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4068d3c4-dcaf-4443-a0b1-fa5f19186146
+      - 4fe92398-4591-4f79-908c-51a12fb64d6a
     status: 200 OK
     code: 200
     duration: ""
@@ -2059,12 +2390,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:41:05.417998Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:12:04.793866Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1339"
@@ -2073,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:02 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2083,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5755c905-ca9d-4aae-98b9-b2850ce8da82
+      - 091e73fa-0457-413b-b0a2-740fae859555
     status: 200 OK
     code: 200
     duration: ""
@@ -2092,12 +2423,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:00.888759Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:41.198691Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -2106,7 +2437,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:02 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2116,7 +2447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3d600eb-6604-45b1-8778-50f9600bb482
+      - 6ac1741d-5a32-4151-8591-9d88f55362a3
     status: 200 OK
     code: 200
     duration: ""
@@ -2125,12 +2456,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:41:05.417998Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:12:04.793866Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1339"
@@ -2139,7 +2470,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:03 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 716cf5dc-a4fd-4e9a-940f-ee5eabe54880
+      - bfa1b2bb-27ed-44c1-b3f6-5eefb5b1ffb4
     status: 200 OK
     code: 200
     duration: ""
@@ -2158,12 +2489,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlN6ZGhDblp2TURCdEswOURSR1ZGTVdoWWVreFVRM0pUUlU5c1UyeFBVVGQyT1N0VmMyUnNNeTlNU1ZsRlVsbEpUR1o0YWpGb1MyZHBZWGRMVlM5RU1sWmtaRGdLWVZOM2VHeDZabFZzWW1kV1lYTnllbWgzVkVsUk9XNURWWEJrYUU5elNXMWhjMUpvVW5RNVFXTnhLMU4yTldnMVpFSmtSSFp3YVRabVdrRmxUREpUVkFwMWJYTkVUMFJRVm5Kc1NHRllhWE5vTW5wWFpYWk5NVU5OYzJKR1YzRTNiVEJ1V0N0MWIxcFJjSEVyU3poSVEwaERNMWh0VGt4S04xcDZOWFpxYUZBeUNsTlpPV0pKWjNOQmJVMWxkR05LVUZKWU1sSnJNbGRLWTBkcFpXdFNWR2h4VkUxMVQzUkxSRU5YVDFRMGQxQnBaM28zWjBzemNsQkhMMlU0YjJWRFZXTUtkRXN3ZWxaMmRVeFRlRTlFT1RkNWJGTkRZM0ZKYlV4d1NVbERjREJsYVVZNVlrWkJSMmRsYmtseGNWcHVWR2wzZUZoNE5HOXRNelpFWkU5Q1VGaHJaUW93ZUc5cVdYUlBPRWRYYmxCdVJua3hUazlWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCYUdJclF6QnZWbmd4VDJkSlRsaHBiRE42ZGxaV0syZEpZbWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWlhWSGFFZDRjbGhNY2t4b1RXTk9hazUzUWs1WlFqQm9TV2hGTmswNFVUaFliMFJRTVdkdFUxTjZVbFp4SzJGTGVBcFVVeXRvWjBSdVpHWnlSWFo2UzJkTFRYTm1hRGhMVjNGNVlpdElOR1pWYzNSbGFraDNOVkJGU0RSWlNXNVZaa2xvWVVrM1kzUllUblZRY1ZKaE1ETjNDbXRNYTJjMVRVZHFhRVpLTkVaYVFXOWljbVprUnpBME5EZDVVazFpWTBWRGRsSjJhVGR0YjFablFtczJhR0pVYVd4VFJGbEZkekEyZW5wbE9GQjJhMUFLZUdORVIyMXphRlJWUVhJemJEZEtZME5wVlV4TlVWTnBWM3A2VWtjMmNYUnFWa3RxUmtSVlVXYzVVMmRuYlhFclRtVkVXa2MyV21aaGJYVjJTVEZMVlFwa2VGaHVOalpZUVZKSk0xRjRNSGx0Y2tSSWNUQldjamRYTVhVeGVVUnJNM3BJZFcxc2F6Vm1aSFJETVRaVlIwaHNlRUZ2V21GbmJIQnBlV05EYjBkUkNsbFRNblJXYTNOcU5FUm5lbFJFZUZWd2FsSndjMWRJWW5JeU4zUk9VbTlMU1ZFd2JBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wMmQwY2E0NC0yY2E3LTQ1ZTEtODg3NC01NGQzMTFmNzczODQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3kKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3ktYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlndXBncmFkZXBvbGljeQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxS0lqSmJHT0s2SHVlbkR3bWxTekd3YVdHc2N4OXZBN01jZE40YjlHQkgxUG80bjNrMDFlcHZzMg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQwRXZDbTkyYTI5ME1ESldNa05vYUUxa2JWVnZLM05tT1dkTU5FdG1RMmt4SzBKVWRVZG1XRTQzYWk4NVZqVmlaWFJYYlU4MmVsY3lhVUUxWm1veFVIRlZXblVLYm5SWVVIUkxOMDVWYkdJelZIaHhka3gyWlZaMGRVWnRZaTloVmpWM05raEJkVEZPT0RsblFYRkpTRGhETjFKT1dubDFNakF6UkRkUldVRlBTREIzVFFwWU5VVnBNWFl3TjB4M2RVOWxhV1pvUVVaMWFtRm5XRmR5Vkd4WlMxaFhkMFpwYW1jeU56SkxhREo2ZFhJNFZWQnJhblpyUTAxNFdXb3JZVXBtWW5wckNuVmtabTUwTkU4clYyWmxTemRZY25oaUswUTBhVlZaVmtnM1dtTk9ZMjl5YzNsYWJVVXhSWFYwTDNkemNERlpSRlpqVmpWeEwyaG1Ta1Y2U0V0UWR6WUtUR2xGVG14MVRGSnZLMVl6Ums1VldUVjNaU3RPVmt4S1RIWmtWelY1VjJSbVJEbHZjbk4xWkhWd2QwcFhRazFzUTNsS2FYbEdNRTlhY21ad05razRUZ296YTIwellreDJiVmhWYURKUmRWQTVXRVJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGYnpjd1IxY3ZiRVJ5ZVdONksybERlRUY2UkRWNmIzWkdSQ3ROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZVdSd2RXeE5NbWh3ZWtKaWVscFBiVWdyTlhWSE5FWkxTamhqU1RKelEwTnlPVzk0WkRONmNYUndRbVZoTUd0RU5nbzBkbEp3YmpkMU16aG9TRmRuVG1oS1kyY3JPRmhZT0ZweU9HVXJURlZTYVRWcVlrWTVTMjV0ZWxOc1pUTmFVbmxhU1RZNE1IY3lNbko1YjFWNU1XWkVDbWhFTDFwT2VXWkJiMjR2ZG1KSVowUXZlR1J5TjFCU2FUZGpNU3MwWXpKdlV6STRURFZtV0VJek1ETnJORGQwVGtkamVISkZTRGR2U2pCWFFXRlZNVFVLU1VsTlptSXpXbXBWT1Zkb1EwbGpaemwwU1ZFeGFucDZOekZzYW14eU1YaEJVQzkzV2xaeU4ydFdSWE5PY1c5UFJtTkpWV3BuUW5oQmFYTk5aV053TkFwblVtODRjemwzU0Vsd1FWVlBjMWR1T1VabmJtbGxPRTVUVkZkeE4zTkxNek56WW1nelVXMU1SRU5NU1djeUsycE1XRU5ZUzBKNVoycGFUREpGTlVzeENuaG9TWHB3TVc5NVR6WTVjblZpZFdweVdsYzVSM0pMYW1sSVZVb3pkelJrWW1KWmFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kOGFmNWQwNS04YjdmLTQ1NTItYTgwYi0yMTVmYWM2MGQ3NDYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3kKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3ktYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlndXBncmFkZXBvbGljeQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKeVVkYkZQM1ZBVGZmeDVabUVCQ2R5OXhodWhjU2NqOUFTSHhNV1ZRWVR0N1lWaVJYV0l2NkFmaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2700"
@@ -2172,7 +2503,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:03 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4efe52e-b2c1-4447-a86b-afbedbf80929
+      - 6738faf8-488e-40c7-9f93-55fb605cd9e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,12 +2522,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:00.888759Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:41.198691Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -2205,7 +2536,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:04 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2215,7 +2546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e7c09b7-cca8-4d53-ab93-0655d0256cfa
+      - 9e46b8c4-bfcf-47f9-a2e1-99e34c4ac030
     status: 200 OK
     code: 200
     duration: ""
@@ -2224,21 +2555,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/nodes?order_by=created_at_asc&page=1&pool_id=e78bc7c7-ca5e-460f-9d96-3fb065ba43dc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/nodes?order_by=created_at_asc&page=1&pool_id=6f02495f-1c19-4fbe-bb96-5fef8fc68616&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2e2b27a5-fb35-42e5-9a36-1e6e7ad1683e","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:41:51.526589Z","updated_at":"2022-10-25T08:44:00.876321Z","pool_id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigupgradepolicy-default-2e2b27a","public_ip_v4":"212.47.236.63","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/69415c9e-500d-4fe0-b575-4858157ded6a","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:53.842567Z","error_message":null,"id":"6070a04b-6871-4530-917a-d20f3b867bb5","name":"scw-k8spoolconfigupgradepolicy-default-6070a04","pool_id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","provider_id":"scaleway://instance/fr-par-1/ed7acf05-dde9-4f11-ada5-63cb4caf9e5a","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:41.188313Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:04 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2248,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93699ed7-dc91-479d-95f1-174dbb062387
+      - e3b3d574-9609-427d-8877-37ba0fc957a4
     status: 200 OK
     code: 200
     duration: ""
@@ -2257,12 +2588,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:41:05.417998Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:12:04.793866Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1339"
@@ -2271,7 +2602,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:05 GMT
+      - Mon, 02 Jan 2023 14:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2281,7 +2612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96eadf14-11ad-4768-bbdd-6c691bf09742
+      - 95acf5d6-c46d-4d3c-8183-b6afe286b233
     status: 200 OK
     code: 200
     duration: ""
@@ -2290,12 +2621,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlN6ZGhDblp2TURCdEswOURSR1ZGTVdoWWVreFVRM0pUUlU5c1UyeFBVVGQyT1N0VmMyUnNNeTlNU1ZsRlVsbEpUR1o0YWpGb1MyZHBZWGRMVlM5RU1sWmtaRGdLWVZOM2VHeDZabFZzWW1kV1lYTnllbWgzVkVsUk9XNURWWEJrYUU5elNXMWhjMUpvVW5RNVFXTnhLMU4yTldnMVpFSmtSSFp3YVRabVdrRmxUREpUVkFwMWJYTkVUMFJRVm5Kc1NHRllhWE5vTW5wWFpYWk5NVU5OYzJKR1YzRTNiVEJ1V0N0MWIxcFJjSEVyU3poSVEwaERNMWh0VGt4S04xcDZOWFpxYUZBeUNsTlpPV0pKWjNOQmJVMWxkR05LVUZKWU1sSnJNbGRLWTBkcFpXdFNWR2h4VkUxMVQzUkxSRU5YVDFRMGQxQnBaM28zWjBzemNsQkhMMlU0YjJWRFZXTUtkRXN3ZWxaMmRVeFRlRTlFT1RkNWJGTkRZM0ZKYlV4d1NVbERjREJsYVVZNVlrWkJSMmRsYmtseGNWcHVWR2wzZUZoNE5HOXRNelpFWkU5Q1VGaHJaUW93ZUc5cVdYUlBPRWRYYmxCdVJua3hUazlWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCYUdJclF6QnZWbmd4VDJkSlRsaHBiRE42ZGxaV0syZEpZbWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWlhWSGFFZDRjbGhNY2t4b1RXTk9hazUzUWs1WlFqQm9TV2hGTmswNFVUaFliMFJRTVdkdFUxTjZVbFp4SzJGTGVBcFVVeXRvWjBSdVpHWnlSWFo2UzJkTFRYTm1hRGhMVjNGNVlpdElOR1pWYzNSbGFraDNOVkJGU0RSWlNXNVZaa2xvWVVrM1kzUllUblZRY1ZKaE1ETjNDbXRNYTJjMVRVZHFhRVpLTkVaYVFXOWljbVprUnpBME5EZDVVazFpWTBWRGRsSjJhVGR0YjFablFtczJhR0pVYVd4VFJGbEZkekEyZW5wbE9GQjJhMUFLZUdORVIyMXphRlJWUVhJemJEZEtZME5wVlV4TlVWTnBWM3A2VWtjMmNYUnFWa3RxUmtSVlVXYzVVMmRuYlhFclRtVkVXa2MyV21aaGJYVjJTVEZMVlFwa2VGaHVOalpZUVZKSk0xRjRNSGx0Y2tSSWNUQldjamRYTVhVeGVVUnJNM3BJZFcxc2F6Vm1aSFJETVRaVlIwaHNlRUZ2V21GbmJIQnBlV05EYjBkUkNsbFRNblJXYTNOcU5FUm5lbFJFZUZWd2FsSndjMWRJWW5JeU4zUk9VbTlMU1ZFd2JBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wMmQwY2E0NC0yY2E3LTQ1ZTEtODg3NC01NGQzMTFmNzczODQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3kKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3ktYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlndXBncmFkZXBvbGljeQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxS0lqSmJHT0s2SHVlbkR3bWxTekd3YVdHc2N4OXZBN01jZE40YjlHQkgxUG80bjNrMDFlcHZzMg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQwRXZDbTkyYTI5ME1ESldNa05vYUUxa2JWVnZLM05tT1dkTU5FdG1RMmt4SzBKVWRVZG1XRTQzYWk4NVZqVmlaWFJYYlU4MmVsY3lhVUUxWm1veFVIRlZXblVLYm5SWVVIUkxOMDVWYkdJelZIaHhka3gyWlZaMGRVWnRZaTloVmpWM05raEJkVEZPT0RsblFYRkpTRGhETjFKT1dubDFNakF6UkRkUldVRlBTREIzVFFwWU5VVnBNWFl3TjB4M2RVOWxhV1pvUVVaMWFtRm5XRmR5Vkd4WlMxaFhkMFpwYW1jeU56SkxhREo2ZFhJNFZWQnJhblpyUTAxNFdXb3JZVXBtWW5wckNuVmtabTUwTkU4clYyWmxTemRZY25oaUswUTBhVlZaVmtnM1dtTk9ZMjl5YzNsYWJVVXhSWFYwTDNkemNERlpSRlpqVmpWeEwyaG1Ta1Y2U0V0UWR6WUtUR2xGVG14MVRGSnZLMVl6Ums1VldUVjNaU3RPVmt4S1RIWmtWelY1VjJSbVJEbHZjbk4xWkhWd2QwcFhRazFzUTNsS2FYbEdNRTlhY21ad05razRUZ296YTIwellreDJiVmhWYURKUmRWQTVXRVJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGYnpjd1IxY3ZiRVJ5ZVdONksybERlRUY2UkRWNmIzWkdSQ3ROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZVdSd2RXeE5NbWh3ZWtKaWVscFBiVWdyTlhWSE5FWkxTamhqU1RKelEwTnlPVzk0WkRONmNYUndRbVZoTUd0RU5nbzBkbEp3YmpkMU16aG9TRmRuVG1oS1kyY3JPRmhZT0ZweU9HVXJURlZTYVRWcVlrWTVTMjV0ZWxOc1pUTmFVbmxhU1RZNE1IY3lNbko1YjFWNU1XWkVDbWhFTDFwT2VXWkJiMjR2ZG1KSVowUXZlR1J5TjFCU2FUZGpNU3MwWXpKdlV6STRURFZtV0VJek1ETnJORGQwVGtkamVISkZTRGR2U2pCWFFXRlZNVFVLU1VsTlptSXpXbXBWT1Zkb1EwbGpaemwwU1ZFeGFucDZOekZzYW14eU1YaEJVQzkzV2xaeU4ydFdSWE5PY1c5UFJtTkpWV3BuUW5oQmFYTk5aV053TkFwblVtODRjemwzU0Vsd1FWVlBjMWR1T1VabmJtbGxPRTVUVkZkeE4zTkxNek56WW1nelVXMU1SRU5NU1djeUsycE1XRU5ZUzBKNVoycGFUREpGTlVzeENuaG9TWHB3TVc5NVR6WTVjblZpZFdweVdsYzVSM0pMYW1sSVZVb3pkelJrWW1KWmFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kOGFmNWQwNS04YjdmLTQ1NTItYTgwYi0yMTVmYWM2MGQ3NDYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3kKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3ktYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlndXBncmFkZXBvbGljeQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKeVVkYkZQM1ZBVGZmeDVabUVCQ2R5OXhodWhjU2NqOUFTSHhNV1ZRWVR0N1lWaVJYV0l2NkFmaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2700"
@@ -2304,7 +2635,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:05 GMT
+      - Mon, 02 Jan 2023 14:15:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5e59205-0ef3-4963-b6a1-40026bbe3858
+      - 113af2ca-36ef-4594-bf83-90b0b8b8b292
     status: 200 OK
     code: 200
     duration: ""
@@ -2323,12 +2654,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:00.888759Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:41.198691Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -2337,7 +2668,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:05 GMT
+      - Mon, 02 Jan 2023 14:15:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8401320-ea95-4fc7-99d1-713175e655a9
+      - 4824460a-095d-4356-a5d6-88250fdd7d9e
     status: 200 OK
     code: 200
     duration: ""
@@ -2356,21 +2687,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/nodes?order_by=created_at_asc&page=1&pool_id=e78bc7c7-ca5e-460f-9d96-3fb065ba43dc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/nodes?order_by=created_at_asc&page=1&pool_id=6f02495f-1c19-4fbe-bb96-5fef8fc68616&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2e2b27a5-fb35-42e5-9a36-1e6e7ad1683e","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:41:51.526589Z","updated_at":"2022-10-25T08:44:00.876321Z","pool_id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigupgradepolicy-default-2e2b27a","public_ip_v4":"212.47.236.63","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/69415c9e-500d-4fe0-b575-4858157ded6a","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:53.842567Z","error_message":null,"id":"6070a04b-6871-4530-917a-d20f3b867bb5","name":"scw-k8spoolconfigupgradepolicy-default-6070a04","pool_id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","provider_id":"scaleway://instance/fr-par-1/ed7acf05-dde9-4f11-ada5-63cb4caf9e5a","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:41.188313Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:05 GMT
+      - Mon, 02 Jan 2023 14:15:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2380,7 +2711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9b96cc7-91bf-4e36-82a0-aff94da06fe3
+      - 5336fea1-5dfd-465b-9778-a67a2a812398
     status: 200 OK
     code: 200
     duration: ""
@@ -2391,12 +2722,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:06.705782396Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:46.404489576Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -2405,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:07 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2415,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8116d4b0-4043-4a5c-92be-e98cb8217ddb
+      - 0a204677-5b85-4902-995a-771305171004
     status: 200 OK
     code: 200
     duration: ""
@@ -2424,12 +2755,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:06.705782Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:46.404490Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -2438,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:07 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2448,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d37cf76-e149-4ad7-94aa-83da3719da41
+      - cc70e7a0-229b-4567-9687-86b11011efc2
     status: 200 OK
     code: 200
     duration: ""
@@ -2457,12 +2788,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:06.705782Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:46.404490Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -2471,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:08 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2481,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46916ccc-28a0-4a76-b34a-d54c9d2e7e0d
+      - b797f213-43dc-4f58-9676-bdda436450c8
     status: 200 OK
     code: 200
     duration: ""
@@ -2490,21 +2821,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/nodes?order_by=created_at_asc&page=1&pool_id=e78bc7c7-ca5e-460f-9d96-3fb065ba43dc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/nodes?order_by=created_at_asc&page=1&pool_id=6f02495f-1c19-4fbe-bb96-5fef8fc68616&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2e2b27a5-fb35-42e5-9a36-1e6e7ad1683e","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:41:51.526589Z","updated_at":"2022-10-25T08:44:08.277791Z","pool_id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigupgradepolicy-default-2e2b27a","public_ip_v4":"212.47.236.63","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/69415c9e-500d-4fe0-b575-4858157ded6a","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:53.842567Z","error_message":null,"id":"6070a04b-6871-4530-917a-d20f3b867bb5","name":"scw-k8spoolconfigupgradepolicy-default-6070a04","pool_id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","provider_id":"scaleway://instance/fr-par-1/ed7acf05-dde9-4f11-ada5-63cb4caf9e5a","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:41.188313Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:08 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2514,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ddabb59-193c-4528-a7e1-a024b47a133c
+      - cb8514d0-361f-4c4e-81a6-5a85f1c9bfa2
     status: 200 OK
     code: 200
     duration: ""
@@ -2523,12 +2854,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:41:05.417998Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:12:04.793866Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1339"
@@ -2537,7 +2868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:08 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2547,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a63cc8ce-61eb-4503-a7d2-925bb2ccfa1f
+      - 7f2547ca-b411-4584-8823-da413041465c
     status: 200 OK
     code: 200
     duration: ""
@@ -2556,12 +2887,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:06.705782Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:46.404490Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -2570,7 +2901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:09 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2580,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b83a407b-c2ad-44ad-9d6d-951da59f013a
+      - eced0527-53f7-4e38-92b9-4868b25afc57
     status: 200 OK
     code: 200
     duration: ""
@@ -2589,12 +2920,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:41:05.417998Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:12:04.793866Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1339"
@@ -2603,7 +2934,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:09 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2613,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d43a426-5094-427a-8571-74528239ca3f
+      - 32ce757e-7b51-40cd-b0a7-5b71e310399d
     status: 200 OK
     code: 200
     duration: ""
@@ -2622,12 +2953,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlN6ZGhDblp2TURCdEswOURSR1ZGTVdoWWVreFVRM0pUUlU5c1UyeFBVVGQyT1N0VmMyUnNNeTlNU1ZsRlVsbEpUR1o0YWpGb1MyZHBZWGRMVlM5RU1sWmtaRGdLWVZOM2VHeDZabFZzWW1kV1lYTnllbWgzVkVsUk9XNURWWEJrYUU5elNXMWhjMUpvVW5RNVFXTnhLMU4yTldnMVpFSmtSSFp3YVRabVdrRmxUREpUVkFwMWJYTkVUMFJRVm5Kc1NHRllhWE5vTW5wWFpYWk5NVU5OYzJKR1YzRTNiVEJ1V0N0MWIxcFJjSEVyU3poSVEwaERNMWh0VGt4S04xcDZOWFpxYUZBeUNsTlpPV0pKWjNOQmJVMWxkR05LVUZKWU1sSnJNbGRLWTBkcFpXdFNWR2h4VkUxMVQzUkxSRU5YVDFRMGQxQnBaM28zWjBzemNsQkhMMlU0YjJWRFZXTUtkRXN3ZWxaMmRVeFRlRTlFT1RkNWJGTkRZM0ZKYlV4d1NVbERjREJsYVVZNVlrWkJSMmRsYmtseGNWcHVWR2wzZUZoNE5HOXRNelpFWkU5Q1VGaHJaUW93ZUc5cVdYUlBPRWRYYmxCdVJua3hUazlWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCYUdJclF6QnZWbmd4VDJkSlRsaHBiRE42ZGxaV0syZEpZbWROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWlhWSGFFZDRjbGhNY2t4b1RXTk9hazUzUWs1WlFqQm9TV2hGTmswNFVUaFliMFJRTVdkdFUxTjZVbFp4SzJGTGVBcFVVeXRvWjBSdVpHWnlSWFo2UzJkTFRYTm1hRGhMVjNGNVlpdElOR1pWYzNSbGFraDNOVkJGU0RSWlNXNVZaa2xvWVVrM1kzUllUblZRY1ZKaE1ETjNDbXRNYTJjMVRVZHFhRVpLTkVaYVFXOWljbVprUnpBME5EZDVVazFpWTBWRGRsSjJhVGR0YjFablFtczJhR0pVYVd4VFJGbEZkekEyZW5wbE9GQjJhMUFLZUdORVIyMXphRlJWUVhJemJEZEtZME5wVlV4TlVWTnBWM3A2VWtjMmNYUnFWa3RxUmtSVlVXYzVVMmRuYlhFclRtVkVXa2MyV21aaGJYVjJTVEZMVlFwa2VGaHVOalpZUVZKSk0xRjRNSGx0Y2tSSWNUQldjamRYTVhVeGVVUnJNM3BJZFcxc2F6Vm1aSFJETVRaVlIwaHNlRUZ2V21GbmJIQnBlV05EYjBkUkNsbFRNblJXYTNOcU5FUm5lbFJFZUZWd2FsSndjMWRJWW5JeU4zUk9VbTlMU1ZFd2JBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wMmQwY2E0NC0yY2E3LTQ1ZTEtODg3NC01NGQzMTFmNzczODQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3kKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3ktYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlndXBncmFkZXBvbGljeQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAxS0lqSmJHT0s2SHVlbkR3bWxTekd3YVdHc2N4OXZBN01jZE40YjlHQkgxUG80bjNrMDFlcHZzMg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQwRXZDbTkyYTI5ME1ESldNa05vYUUxa2JWVnZLM05tT1dkTU5FdG1RMmt4SzBKVWRVZG1XRTQzYWk4NVZqVmlaWFJYYlU4MmVsY3lhVUUxWm1veFVIRlZXblVLYm5SWVVIUkxOMDVWYkdJelZIaHhka3gyWlZaMGRVWnRZaTloVmpWM05raEJkVEZPT0RsblFYRkpTRGhETjFKT1dubDFNakF6UkRkUldVRlBTREIzVFFwWU5VVnBNWFl3TjB4M2RVOWxhV1pvUVVaMWFtRm5XRmR5Vkd4WlMxaFhkMFpwYW1jeU56SkxhREo2ZFhJNFZWQnJhblpyUTAxNFdXb3JZVXBtWW5wckNuVmtabTUwTkU4clYyWmxTemRZY25oaUswUTBhVlZaVmtnM1dtTk9ZMjl5YzNsYWJVVXhSWFYwTDNkemNERlpSRlpqVmpWeEwyaG1Ta1Y2U0V0UWR6WUtUR2xGVG14MVRGSnZLMVl6Ums1VldUVjNaU3RPVmt4S1RIWmtWelY1VjJSbVJEbHZjbk4xWkhWd2QwcFhRazFzUTNsS2FYbEdNRTlhY21ad05razRUZ296YTIwellreDJiVmhWYURKUmRWQTVXRVJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGYnpjd1IxY3ZiRVJ5ZVdONksybERlRUY2UkRWNmIzWkdSQ3ROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZVdSd2RXeE5NbWh3ZWtKaWVscFBiVWdyTlhWSE5FWkxTamhqU1RKelEwTnlPVzk0WkRONmNYUndRbVZoTUd0RU5nbzBkbEp3YmpkMU16aG9TRmRuVG1oS1kyY3JPRmhZT0ZweU9HVXJURlZTYVRWcVlrWTVTMjV0ZWxOc1pUTmFVbmxhU1RZNE1IY3lNbko1YjFWNU1XWkVDbWhFTDFwT2VXWkJiMjR2ZG1KSVowUXZlR1J5TjFCU2FUZGpNU3MwWXpKdlV6STRURFZtV0VJek1ETnJORGQwVGtkamVISkZTRGR2U2pCWFFXRlZNVFVLU1VsTlptSXpXbXBWT1Zkb1EwbGpaemwwU1ZFeGFucDZOekZzYW14eU1YaEJVQzkzV2xaeU4ydFdSWE5PY1c5UFJtTkpWV3BuUW5oQmFYTk5aV053TkFwblVtODRjemwzU0Vsd1FWVlBjMWR1T1VabmJtbGxPRTVUVkZkeE4zTkxNek56WW1nelVXMU1SRU5NU1djeUsycE1XRU5ZUzBKNVoycGFUREpGTlVzeENuaG9TWHB3TVc5NVR6WTVjblZpZFdweVdsYzVSM0pMYW1sSVZVb3pkelJrWW1KWmFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kOGFmNWQwNS04YjdmLTQ1NTItYTgwYi0yMTVmYWM2MGQ3NDYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3kKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5IgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3VwZ3JhZGVwb2xpY3ktYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlndXBncmFkZXBvbGljeQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd1cGdyYWRlcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKeVVkYkZQM1ZBVGZmeDVabUVCQ2R5OXhodWhjU2NqOUFTSHhNV1ZRWVR0N1lWaVJYV0l2NkFmaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2700"
@@ -2636,7 +2967,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:10 GMT
+      - Mon, 02 Jan 2023 14:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2646,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d9ce166-4d6e-4045-bdea-2afb35c056c5
+      - 867bdb46-132d-472e-9743-32e897af06b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2655,12 +2986,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: GET
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:06.705782Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:46.404490Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -2669,7 +3000,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:10 GMT
+      - Mon, 02 Jan 2023 14:15:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2679,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 768e5108-1b8b-4ab6-a3c7-5541dee92e9c
+      - d7e3f627-d1be-4da0-b18c-1c7ef2720ae6
     status: 200 OK
     code: 200
     duration: ""
@@ -2688,21 +3019,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384/nodes?order_by=created_at_asc&page=1&pool_id=e78bc7c7-ca5e-460f-9d96-3fb065ba43dc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746/nodes?order_by=created_at_asc&page=1&pool_id=6f02495f-1c19-4fbe-bb96-5fef8fc68616&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"2e2b27a5-fb35-42e5-9a36-1e6e7ad1683e","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:41:51.526589Z","updated_at":"2022-10-25T08:44:08.277791Z","pool_id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigupgradepolicy-default-2e2b27a","public_ip_v4":"212.47.236.63","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/69415c9e-500d-4fe0-b575-4858157ded6a","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:53.842567Z","error_message":null,"id":"6070a04b-6871-4530-917a-d20f3b867bb5","name":"scw-k8spoolconfigupgradepolicy-default-6070a04","pool_id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","provider_id":"scaleway://instance/fr-par-1/ed7acf05-dde9-4f11-ada5-63cb4caf9e5a","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:47.832898Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:10 GMT
+      - Mon, 02 Jan 2023 14:15:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2712,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c85936d-b987-4c25-b70d-7066b7a679b2
+      - 2d25d4fb-89d3-47cc-abfd-8226e5d104c8
     status: 200 OK
     code: 200
     duration: ""
@@ -2721,12 +3052,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e78bc7c7-ca5e-460f-9d96-3fb065ba43dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6f02495f-1c19-4fbe-bb96-5fef8fc68616
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"e78bc7c7-ca5e-460f-9d96-3fb065ba43dc","cluster_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","created_at":"2022-10-25T08:39:31.926664Z","updated_at":"2022-10-25T08:44:11.456513219Z","name":"default","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","container_runtime":"containerd","created_at":"2023-01-02T14:10:39.260782Z","id":"6f02495f-1c19-4fbe-bb96-5fef8fc68616","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-01-02T14:15:48.315301165Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2735,7 +3066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:11 GMT
+      - Mon, 02 Jan 2023 14:15:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2745,7 +3076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a15b473-51d7-4848-9d4e-38d22bafc9bf
+      - b900aaa4-ec8c-4aca-87bd-96ae14a5efa6
     status: 200 OK
     code: 200
     duration: ""
@@ -2754,12 +3085,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:44:12.082701233Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:15:48.405599158Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1345"
@@ -2768,7 +3099,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:12 GMT
+      - Mon, 02 Jan 2023 14:15:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2778,7 +3109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 423b2195-c54a-49dc-81e1-8ad5f39c6cdb
+      - 39180b64-4c54-4500-b4a0-d0bda9013793
     status: 200 OK
     code: 200
     duration: ""
@@ -2787,12 +3118,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:44:12.082701Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:15:48.405599Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1342"
@@ -2801,7 +3132,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:12 GMT
+      - Mon, 02 Jan 2023 14:15:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2811,7 +3142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9621ac8d-2e83-484d-81b3-c58486e52d35
+      - 4734747f-8931-4b71-ab14-8dd25cdc9fb9
     status: 200 OK
     code: 200
     duration: ""
@@ -2820,12 +3151,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"region":"fr-par","id":"02d0ca44-2ca7-45e1-8874-54d311f77384","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.507416Z","updated_at":"2022-10-25T08:44:12.082701Z","type":"kapsule","name":"K8SPoolConfigUpgradePolicy","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"cluster_url":"https://02d0ca44-2ca7-45e1-8874-54d311f77384.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.02d0ca44-2ca7-45e1-8874-54d311f77384.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:15:48.405599Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1342"
@@ -2834,7 +3165,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:17 GMT
+      - Mon, 02 Jan 2023 14:15:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2844,7 +3175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c471907-09db-4c95-b051-98f10caeaa1d
+      - 1350246e-63a2-4119-a8cb-d2b46418c5d1
     status: 200 OK
     code: 200
     duration: ""
@@ -2853,12 +3184,111 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:15:48.405599Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1342"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - edadc43e-18b3-443e-8109-80d3509c4e97
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:15:48.405599Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1342"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:16:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0ce38a82-b219-4042-9f5f-4f8931c851bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8af5d05-8b7f-4552-a80b-215fac60d746.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.560698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8af5d05-8b7f-4552-a80b-215fac60d746.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8af5d05-8b7f-4552-a80b-215fac60d746","ingress":"none","name":"K8SPoolConfigUpgradePolicy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-01-02T14:15:48.405599Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1342"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:16:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 646bd803-ff52-4379-b959-a80bc61de1e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2867,7 +3297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:16:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2877,7 +3307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca0a633d-d021-49ce-a14e-9d68204c80e1
+      - e8b4ece8-b71a-44aa-8a4b-49692bbdf0fe
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2886,12 +3316,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/02d0ca44-2ca7-45e1-8874-54d311f77384
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8af5d05-8b7f-4552-a80b-215fac60d746
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"02d0ca44-2ca7-45e1-8874-54d311f77384","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d8af5d05-8b7f-4552-a80b-215fac60d746","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2900,7 +3330,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:16:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2910,7 +3340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b77bf00a-5930-43ac-8ac6-02038e2c89ce
+      - 08731da4-eb7f-41d3-a056-bdacb7f2dc30
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-wait.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-wait.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:23 GMT
+      - Mon, 02 Jan 2023 14:10:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b7e5473-68fd-4963-9659-3bc38291c62f
+      - 0564e5fd-394f-4d47-94d2-49c30f93836f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"PoolConfigWait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.24.5","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"PoolConfigWait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.24.7","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467958627Z","updated_at":"2022-10-25T08:39:25.488743368Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485170Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.535281442Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4de3c6d8-e7f3-4591-8174-672a12e36568
+      - 840f6e23-c9ff-4ec2-8ae0-c8ea16295682
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:39:25.488743Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"creating","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.535281Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1323"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc4aa7a9-6b14-4dfa-90c0-02f18c020a65
+      - d1250fe5-fd9e-4908-91ee-0e689304506c
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:39:29.160245Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:38.047006Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -124,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e683630-8604-421d-9e49-91b4b4a15d2a
+      - d5a3d989-6ae8-4892-b231-1f2c2c21a14d
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:39:29.160245Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:38.047006Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -157,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 949f1507-836d-4110-b2aa-c6919af727c8
+      - 3ad907f1-e2db-4704-871e-5af748b5b1e6
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -190,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa9387f6-955f-4d9d-8f24-2cde1314b591
+      - 5e173e1d-212a-48ae-a16e-80df34df2e09
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:39:29.160245Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"pool_required","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:10:38.047006Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -223,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0adaeba-5c20-49e1-8b2a-a106488351f0
+      - 4ab8564d-4b36-4367-bead-e3c9cdd16299
     status: 200 OK
     code: 200
     duration: ""
@@ -244,12 +245,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937473867Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "572"
@@ -258,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 14:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -268,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ae778a3-02aa-4df1-983d-30f3770200f4
+      - 30babada-7bf1-42ad-b739-bae2952b695e
     status: 200 OK
     code: 200
     duration: ""
@@ -277,12 +278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -291,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 14:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -301,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bab91b20-fe14-4785-94ee-296c7d7c6300
+      - 5e89a0cd-8831-4442-b08e-4769b61cae3a
     status: 200 OK
     code: 200
     duration: ""
@@ -310,12 +311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -324,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:38 GMT
+      - Mon, 02 Jan 2023 14:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -334,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bce3c702-2060-4948-b054-7d41ecd572f6
+      - 353f1d8e-b346-407e-9343-29cf05d57286
     status: 200 OK
     code: 200
     duration: ""
@@ -343,12 +344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -357,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:43 GMT
+      - Mon, 02 Jan 2023 14:10:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -367,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f78b04dc-d051-4b0f-b8d1-47711bcbbfdb
+      - 847f74cf-d96e-4638-bae0-f0c2777e08f1
     status: 200 OK
     code: 200
     duration: ""
@@ -376,12 +377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -390,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:49 GMT
+      - Mon, 02 Jan 2023 14:10:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 037396e3-1ddc-4e5d-93ff-2bdb71dabbe4
+      - edf9ba59-4ef2-4910-96a4-9cde9fd2bd6a
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -423,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:54 GMT
+      - Mon, 02 Jan 2023 14:11:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 975b2941-cfa3-4b2a-86bd-84bf3d561afc
+      - ea3adfa2-bb3d-4d00-b355-930905c68171
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -456,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:59 GMT
+      - Mon, 02 Jan 2023 14:11:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d522875-29c1-4569-a175-7cf212431189
+      - 5e5b9b5d-64fb-44c9-8796-87e3a9e3ffb5
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -489,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:05 GMT
+      - Mon, 02 Jan 2023 14:11:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa7ed471-ff63-4c5d-bf5e-173d214d2dee
+      - b8deeee0-1738-4338-82e5-95c87bac0bd9
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -522,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:10 GMT
+      - Mon, 02 Jan 2023 14:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b31b0da0-c443-49a1-9287-c87546b3fc6a
+      - 55ee4bdf-d1cf-483b-9122-ed5f2a4d5eaf
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -555,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:16 GMT
+      - Mon, 02 Jan 2023 14:11:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f891451-27d2-4776-9d68-5f7bfaa19a4e
+      - 6a5018a0-cda3-4ee8-bd7a-f93af672608c
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -588,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:21 GMT
+      - Mon, 02 Jan 2023 14:11:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a792bffb-6954-48fc-8367-152cca81f2ac
+      - 43683f41-a991-4b98-b3f0-98487aacd4e3
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -621,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:26 GMT
+      - Mon, 02 Jan 2023 14:11:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb73f746-9b39-4327-ae96-9c9bd80654f0
+      - 4d2d5931-0868-4099-90cc-e20ee2b77f6f
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -654,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:32 GMT
+      - Mon, 02 Jan 2023 14:11:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 377d1036-8752-49df-855c-30bd8c939947
+      - aa9a9e8e-383d-4547-93e7-73b67e16f5ce
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -687,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:37 GMT
+      - Mon, 02 Jan 2023 14:11:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77185c6a-d542-4853-bce7-4de1600a79b9
+      - bc067371-09bd-4430-9ab3-9f55a4f01146
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -720,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:43 GMT
+      - Mon, 02 Jan 2023 14:11:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7cdb34c-1f4b-413a-b09f-95eeea241cd5
+      - 72b1ad17-ca80-462b-86ab-abc39c4b48af
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -753,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:48 GMT
+      - Mon, 02 Jan 2023 14:11:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0bf25ee-4cbd-4f7f-9c90-e1aaf74464b8
+      - 4ff49fe2-b733-497f-8856-1bf4c21f4caf
     status: 200 OK
     code: 200
     duration: ""
@@ -772,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -786,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:53 GMT
+      - Mon, 02 Jan 2023 14:11:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8941381-f428-4856-9986-efc2dc4dd9ce
+      - d847cf9c-dbce-4bc4-958a-0efc92825b41
     status: 200 OK
     code: 200
     duration: ""
@@ -805,12 +806,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -819,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:59 GMT
+      - Mon, 02 Jan 2023 14:12:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6818e3ec-8f84-4ad4-9afc-caaa614f2b86
+      - 320eb1e3-0f8a-42bf-9920-03567eaf9daf
     status: 200 OK
     code: 200
     duration: ""
@@ -838,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -852,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:04 GMT
+      - Mon, 02 Jan 2023 14:12:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d566b69-2d85-4289-8ce9-6b87781f73ce
+      - 50f7ea68-2328-4556-983d-a2f36b54a084
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -885,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:10 GMT
+      - Mon, 02 Jan 2023 14:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 034159c1-b5d0-4f06-8ddf-3f59dd965b2a
+      - 030c5669-9449-4074-b052-af2ed40461fe
     status: 200 OK
     code: 200
     duration: ""
@@ -904,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -918,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:15 GMT
+      - Mon, 02 Jan 2023 14:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a4e7234-da1b-438d-8b64-13972218000c
+      - cde41809-7eba-42fa-aecf-2c0d9362682b
     status: 200 OK
     code: 200
     duration: ""
@@ -937,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -951,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:21 GMT
+      - Mon, 02 Jan 2023 14:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cf9e0e2-0157-4140-9c7e-6c32d528a87f
+      - e272896e-ce05-4ba7-8aa0-8911bf0f5f61
     status: 200 OK
     code: 200
     duration: ""
@@ -970,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -984,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:26 GMT
+      - Mon, 02 Jan 2023 14:12:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4279c033-7d18-441a-ae5f-dc0d31b59a0f
+      - a4078b5c-c5e1-4954-a162-1c7afb3ef25b
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1017,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:31 GMT
+      - Mon, 02 Jan 2023 14:12:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4a8c01e-ce8d-49d4-bfd3-69a4fdd4d76b
+      - 870cea8d-ccc7-46bd-a5a7-3c7722e7f2b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1050,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:36 GMT
+      - Mon, 02 Jan 2023 14:12:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 693a872e-dbba-4076-b477-38bc78e513fa
+      - 571bdf3b-5824-432f-96c5-b1c4ca64ef38
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1083,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:42 GMT
+      - Mon, 02 Jan 2023 14:12:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3daff58d-a3a1-4b2f-93a6-18ca7e9a01ef
+      - 8ec73d99-3840-423b-8282-6e65449d2422
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1116,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:47 GMT
+      - Mon, 02 Jan 2023 14:12:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83884fa2-0523-43c0-b90a-6aaaee425a75
+      - 16015114-ecfa-496c-81d6-de5a7d9697fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1149,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:53 GMT
+      - Mon, 02 Jan 2023 14:12:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 002e4d78-05c8-4dd3-a036-e926756f8979
+      - 07b4b077-1e19-4953-8f39-a8a82f663af1
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1182,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:58 GMT
+      - Mon, 02 Jan 2023 14:12:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9198dcbc-fe09-4f8b-bdbf-f909a71b3870
+      - 5fa78130-273c-4e6c-9960-9770ac55736c
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1202,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1215,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:03 GMT
+      - Mon, 02 Jan 2023 14:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fa54eb7-facb-433b-8061-e98be55a06f0
+      - ce913327-4679-4121-998b-452de540bd1d
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1235,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1248,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:08 GMT
+      - Mon, 02 Jan 2023 14:13:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ad2ce4-4f42-4fff-9e12-92ba93414d76
+      - 59009e08-2382-473d-92a1-9cbc0ccd8021
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1268,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1281,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:13 GMT
+      - Mon, 02 Jan 2023 14:13:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34d9f44c-e33b-49f9-96f3-f398ccd99ae3
+      - 392f7e80-5a60-4bce-8df2-df8eab815c2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1301,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1314,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:19 GMT
+      - Mon, 02 Jan 2023 14:13:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 892f511d-f18e-4511-b794-c5e1066b64e5
+      - ebc0d1aa-139b-47b3-90c6-4d45bc421089
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1347,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:24 GMT
+      - Mon, 02 Jan 2023 14:13:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b89fd1b3-9763-42af-b707-03b22fac5479
+      - 06469655-3dd3-4348-ba07-c9f9129610bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1380,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:30 GMT
+      - Mon, 02 Jan 2023 14:13:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1513db2-2bf2-4ff2-914a-d9a39a298566
+      - f726f670-562d-4399-8eb1-7b6e0dd06a71
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1413,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:35 GMT
+      - Mon, 02 Jan 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6853eaf7-4ce4-48ca-95c7-0be8ea1dd78a
+      - 8235d2fa-93ac-4f26-8baa-ea55b3c186c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1446,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:41 GMT
+      - Mon, 02 Jan 2023 14:13:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e59b350-a019-4776-9dd8-d94a1e6b26bd
+      - 04c44d9e-2f27-446b-b5cf-0f21d7c63b6c
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,12 +1466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1479,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:46 GMT
+      - Mon, 02 Jan 2023 14:13:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94447555-b36d-4c29-a3a2-ed37675e9218
+      - c43fdd9f-11df-4f31-8dc4-aa7d83cb0079
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,12 +1499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1512,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:51 GMT
+      - Mon, 02 Jan 2023 14:13:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73b64367-ba17-4c2a-b80c-eff95592c7cb
+      - 84652811-4e71-47f3-851b-f47ce4c032e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,12 +1532,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1545,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:57 GMT
+      - Mon, 02 Jan 2023 14:13:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - affe0f10-14fc-4285-9834-6348f849e0b2
+      - 2070d306-b137-4852-9e12-07a180d4538f
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,12 +1565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1578,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:02 GMT
+      - Mon, 02 Jan 2023 14:13:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97c8c07b-afe1-423a-9a1f-d5a4af8c8776
+      - 6c57ee95-a375-491a-b36f-da32ddacc961
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,12 +1598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1611,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:07 GMT
+      - Mon, 02 Jan 2023 14:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65287805-6a8f-4fdf-a6f4-bfba623e31ba
+      - d3b5e05d-5293-4daa-b885-b3517478c867
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,12 +1631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1644,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:12 GMT
+      - Mon, 02 Jan 2023 14:14:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cef03d99-b2fa-4e0f-8294-c450a56951b4
+      - ebe50ffe-7710-42e3-bdbf-0a21e7e31893
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,12 +1664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1677,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:18 GMT
+      - Mon, 02 Jan 2023 14:14:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38249ef2-fc6c-48d7-b8d5-2f1909c534d7
+      - df69d41e-df58-44cd-8811-de1d82984d26
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,12 +1697,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1710,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:23 GMT
+      - Mon, 02 Jan 2023 14:14:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d838e88-e8af-40b9-ae25-648d0f8a0365
+      - 116d084c-ba0d-4a93-b9ec-8f60da770326
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1730,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1743,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:28 GMT
+      - Mon, 02 Jan 2023 14:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 951ed42f-63b1-45da-b1ec-531c462bb27e
+      - 9c6de442-6e28-462c-9f6e-535139f9797f
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,12 +1763,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1776,7 +1777,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:33 GMT
+      - Mon, 02 Jan 2023 14:14:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a4d8959-111c-4672-ab6d-f2fe9d5d6a09
+      - 1a0c9898-dee1-4d06-9293-ddb7728e5adc
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,12 +1796,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1809,7 +1810,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:39 GMT
+      - Mon, 02 Jan 2023 14:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e63bc82e-68f3-4df4-ac92-06b50eb0e3b5
+      - bd39a840-91aa-4599-b0b5-d813890bebe4
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,12 +1829,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1842,7 +1843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:44 GMT
+      - Mon, 02 Jan 2023 14:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dfdaa79-6549-472d-9d0f-58d13f01713b
+      - ded49f8d-0a41-4d85-8d54-6e7a75e33c0b
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,12 +1862,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1875,7 +1876,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:49 GMT
+      - Mon, 02 Jan 2023 14:14:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88ebd533-da79-41c9-85f6-f67e0a455d3e
+      - ec2e3ca0-d7c2-4d96-b7d8-1d6438c563a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,12 +1895,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:10:38.934207Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -1908,7 +1909,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:55 GMT
+      - Mon, 02 Jan 2023 14:14:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee9acbdf-1fe8-4d0c-959a-d2ee136a16f2
+      - 71eae6a8-b5a6-4a75-9f5a-bfb52c75e1c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,144 +1928,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "569"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:44:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f5fbdd5-f9e0-4722-a191-d4624b68cd7e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "569"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:44:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bb86cf79-a0ac-419a-a2f2-8e812eb7af8d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "569"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:44:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a3f9170f-cf82-4723-a02c-a0939ca3039e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:39:31.937474Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "569"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:44:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7d1b147b-2a57-41b1-a6ad-aa2719635d38
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -2073,7 +1942,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:21 GMT
+      - Mon, 02 Jan 2023 14:14:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2083,7 +1952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73976c4e-c76d-4489-8182-89e078a99752
+      - cc75d0da-887d-4fb0-ad16-810cb481b47b
     status: 200 OK
     code: 200
     duration: ""
@@ -2092,12 +1961,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -2106,7 +1975,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:22 GMT
+      - Mon, 02 Jan 2023 14:14:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2116,7 +1985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94d58c8c-eded-4efd-8a37-131676a60fcd
+      - a0ba7a6a-afa5-4f1a-ad03-ca12fb7b8f21
     status: 200 OK
     code: 200
     duration: ""
@@ -2125,12 +1994,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -2139,7 +2008,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:22 GMT
+      - Mon, 02 Jan 2023 14:14:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2018,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e412ebb4-738b-4a69-9969-f296576643d8
+      - 42bb0b2f-8acd-462a-8758-a3b5f073beb0
     status: 200 OK
     code: 200
     duration: ""
@@ -2158,21 +2027,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:44:19.275652Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:48.817515Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:22 GMT
+      - Mon, 02 Jan 2023 14:14:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83144520-99e9-4caa-86db-a3acefe05c2a
+      - 4178cf4b-acf2-4148-87ea-bc54a387c925
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,12 +2060,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -2205,7 +2074,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:22 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2215,7 +2084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75e56b3f-c457-4108-a488-cebcf48cc3ef
+      - 81916ff4-e313-4738-99c1-955500811347
     status: 200 OK
     code: 200
     duration: ""
@@ -2224,12 +2093,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -2238,7 +2107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:22 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2248,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4087578a-c0b7-4f38-9048-ca9262c188e4
+      - 1e006e4c-d566-4ca4-a1b7-2314c092abaa
     status: 200 OK
     code: 200
     duration: ""
@@ -2257,12 +2126,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -2271,7 +2140,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2281,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48128db2-46da-4ad1-b28b-5837df9ab02d
+      - e97ac2c6-1ff6-46af-ba4f-a298f2f571fd
     status: 200 OK
     code: 200
     duration: ""
@@ -2290,12 +2159,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -2304,7 +2173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2c7a4fe-ac35-420e-95d6-e5d12c66547f
+      - 314a84d8-48a3-48db-b2ed-23d87d552679
     status: 200 OK
     code: 200
     duration: ""
@@ -2323,12 +2192,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -2337,7 +2206,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b46fa3bf-7de0-4e00-bc1c-48b656e32825
+      - c0ad2e14-43d2-4f74-9e65-7f909320d2a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2356,21 +2225,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:44:19.275652Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:48.817515Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2380,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2eb4b3e-9294-4daf-8965-60706198d5f3
+      - 02e98ebc-0b1b-453f-b6b3-9047aa02fb45
     status: 200 OK
     code: 200
     duration: ""
@@ -2389,12 +2258,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -2403,7 +2272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:23 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2413,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90e90163-436b-49aa-bfbb-f2134b499c22
+      - f6656b67-c4f7-49ea-a17c-e03f0eb472a9
     status: 200 OK
     code: 200
     duration: ""
@@ -2422,12 +2291,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -2436,7 +2305,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:24 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2446,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0d0d5a8-ae6c-4d7f-a226-fba5dbc2dc9b
+      - 547b6c3d-b479-4f93-86c7-fed61b80a635
     status: 200 OK
     code: 200
     duration: ""
@@ -2455,12 +2324,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -2469,7 +2338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:24 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2479,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5c63696-0b7b-4b8e-b082-f02b89e472a4
+      - d3f606b9-d57b-4129-8753-72c56477fbc0
     status: 200 OK
     code: 200
     duration: ""
@@ -2488,21 +2357,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:44:19.275652Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:14:48.817515Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "605"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:24 GMT
+      - Mon, 02 Jan 2023 14:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2512,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26f0af5c-4d4d-422c-918d-ff2ac0cdbfc8
+      - 950ff269-e1b6-4f62-b95f-9eba5d3c7a30
     status: 200 OK
     code: 200
     duration: ""
@@ -2521,12 +2390,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -2535,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:24 GMT
+      - Mon, 02 Jan 2023 14:14:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2545,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41060c49-2fc7-4e29-b927-71dc32181bd8
+      - 02416bd3-ceac-4342-9560-f2ed15249ce6
     status: 200 OK
     code: 200
     duration: ""
@@ -2556,12 +2425,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307289906Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "572"
@@ -2570,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:26 GMT
+      - Mon, 02 Jan 2023 14:14:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2580,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7b98c35-91ed-4be3-9085-2347a80afcda
+      - bb41b6c2-6317-4177-bd2c-dfb0168e7463
     status: 200 OK
     code: 200
     duration: ""
@@ -2589,12 +2458,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2603,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:26 GMT
+      - Mon, 02 Jan 2023 14:14:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2613,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16737a6d-2ec8-47f4-8c36-18c11c5a684f
+      - c042cfc3-4475-47c8-86ba-28cd9816a69b
     status: 200 OK
     code: 200
     duration: ""
@@ -2622,12 +2491,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2636,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:31 GMT
+      - Mon, 02 Jan 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2646,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcb2896d-0920-43f4-a065-53f45a2b8feb
+      - 5e3451b6-7a76-4c52-a0b0-f223b052339f
     status: 200 OK
     code: 200
     duration: ""
@@ -2655,12 +2524,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2669,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:37 GMT
+      - Mon, 02 Jan 2023 14:15:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2679,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ab7bb9b-a80c-4a32-a4b1-128cecb6a46a
+      - 95db84d4-d188-43e3-b254-032e89e97b0e
     status: 200 OK
     code: 200
     duration: ""
@@ -2688,12 +2557,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2702,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:42 GMT
+      - Mon, 02 Jan 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2712,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 100d2038-8a60-4b04-bb84-ad6cbbb58379
+      - 4131a158-11aa-4ecd-9129-708621ab7192
     status: 200 OK
     code: 200
     duration: ""
@@ -2721,12 +2590,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2735,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:48 GMT
+      - Mon, 02 Jan 2023 14:15:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2745,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb4cf257-7002-4ebc-a464-29c23f3ae760
+      - 8855ee94-7d2e-41a6-979c-ff4fa17e81f4
     status: 200 OK
     code: 200
     duration: ""
@@ -2754,12 +2623,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2768,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:53 GMT
+      - Mon, 02 Jan 2023 14:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2778,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d4422d6-6a94-45cf-ae88-7c72aa2a499b
+      - b00a64a2-99f4-4958-a08a-2248f7682c62
     status: 200 OK
     code: 200
     duration: ""
@@ -2787,12 +2656,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2801,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:59 GMT
+      - Mon, 02 Jan 2023 14:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2811,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38706184-3f8a-4ff5-93b6-13cc4a92c897
+      - 8712020b-b1cc-47db-921a-1fb18d56b596
     status: 200 OK
     code: 200
     duration: ""
@@ -2820,12 +2689,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2834,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:04 GMT
+      - Mon, 02 Jan 2023 14:15:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2844,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f99ca431-bf6f-4156-af11-527c58811efb
+      - c10e64a4-3409-41ee-9187-02a950809a67
     status: 200 OK
     code: 200
     duration: ""
@@ -2853,12 +2722,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2867,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:10 GMT
+      - Mon, 02 Jan 2023 14:15:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2877,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2580c454-c708-4b03-9051-da56b76b867d
+      - f8ae27ec-5084-4d91-bf37-7b4082a53e72
     status: 200 OK
     code: 200
     duration: ""
@@ -2886,12 +2755,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2900,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:15 GMT
+      - Mon, 02 Jan 2023 14:15:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2910,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34c9a1f2-1705-4b25-86dd-786197a4bd0d
+      - e595749d-4c02-4a68-b1b3-23a9e1c9797b
     status: 200 OK
     code: 200
     duration: ""
@@ -2919,12 +2788,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2933,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:21 GMT
+      - Mon, 02 Jan 2023 14:15:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2943,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d67142e9-40da-40f8-83ec-4d3f396c7061
+      - d29e800a-3283-4903-9d16-b0a76d892fc5
     status: 200 OK
     code: 200
     duration: ""
@@ -2952,12 +2821,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2966,7 +2835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:26 GMT
+      - Mon, 02 Jan 2023 14:15:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2976,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c43c0991-8eac-4d91-b5d4-f61d6358e958
+      - deff1d5e-614c-461c-916f-bd470459b973
     status: 200 OK
     code: 200
     duration: ""
@@ -2985,12 +2854,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -2999,7 +2868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:31 GMT
+      - Mon, 02 Jan 2023 14:15:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3009,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a0f8292-0ec9-40dc-8081-3b92c6027c06
+      - fec74d68-ee11-43c6-8da9-8647debfe334
     status: 200 OK
     code: 200
     duration: ""
@@ -3018,12 +2887,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3032,7 +2901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:37 GMT
+      - Mon, 02 Jan 2023 14:16:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3042,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 259efb7b-18a5-427e-a235-a52f2b41448a
+      - 045eae5a-36f1-49f5-bda6-cf02309a36c9
     status: 200 OK
     code: 200
     duration: ""
@@ -3051,12 +2920,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3065,7 +2934,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:42 GMT
+      - Mon, 02 Jan 2023 14:16:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3075,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67df0e75-e1e8-4c6a-baf5-041a7059818c
+      - abedc6d3-e72e-48c6-b50e-d6a7b1ee640d
     status: 200 OK
     code: 200
     duration: ""
@@ -3084,12 +2953,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3098,7 +2967,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:47 GMT
+      - Mon, 02 Jan 2023 14:16:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3108,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9596b085-25bf-4175-95b0-9d0b96f0653d
+      - 3c94d645-9a5d-49bd-939f-5e04666630ec
     status: 200 OK
     code: 200
     duration: ""
@@ -3117,12 +2986,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3131,7 +3000,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:53 GMT
+      - Mon, 02 Jan 2023 14:16:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3141,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ece35e3d-4594-4047-96be-a1c0967b61a7
+      - cd596d4f-5286-48b3-a35b-46eae55c05ab
     status: 200 OK
     code: 200
     duration: ""
@@ -3150,12 +3019,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3164,7 +3033,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:45:58 GMT
+      - Mon, 02 Jan 2023 14:16:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3174,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e387d93b-342b-4b97-a862-9d196f2612ce
+      - cfd12616-bd28-483a-9843-bb827c3ad609
     status: 200 OK
     code: 200
     duration: ""
@@ -3183,12 +3052,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3197,7 +3066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:03 GMT
+      - Mon, 02 Jan 2023 14:16:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3207,7 +3076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c2ca957-4ea0-4ad8-be46-e183233d09de
+      - 311601f0-bce0-4c30-b230-9b7420d6ab45
     status: 200 OK
     code: 200
     duration: ""
@@ -3216,12 +3085,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3230,7 +3099,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:08 GMT
+      - Mon, 02 Jan 2023 14:16:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3240,7 +3109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbcb1323-8ad0-4fac-a83d-4b0ab8dc5225
+      - 621c4fb0-4a6a-4128-b92c-ab191a4d6cb5
     status: 200 OK
     code: 200
     duration: ""
@@ -3249,12 +3118,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3263,7 +3132,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:14 GMT
+      - Mon, 02 Jan 2023 14:16:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3273,7 +3142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1141d2b6-4c7f-41ef-9cbf-c266bac992ae
+      - 9c64e8d4-6fb0-4249-8072-b508feefa525
     status: 200 OK
     code: 200
     duration: ""
@@ -3282,12 +3151,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3296,7 +3165,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:19 GMT
+      - Mon, 02 Jan 2023 14:16:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3306,7 +3175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 712a5aa1-4931-49d0-b091-dcfbed4f54b4
+      - e1b3d909-7695-452a-8aa2-9ce6a08ee267
     status: 200 OK
     code: 200
     duration: ""
@@ -3315,12 +3184,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3329,7 +3198,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:25 GMT
+      - Mon, 02 Jan 2023 14:16:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3339,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe2afde9-5bcc-4e84-8f5a-bfe4e86b6d40
+      - ace5cb3e-015c-426b-94d0-64a64dcdf324
     status: 200 OK
     code: 200
     duration: ""
@@ -3348,12 +3217,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3362,7 +3231,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:30 GMT
+      - Mon, 02 Jan 2023 14:16:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3372,7 +3241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7cf3046-13ec-435e-8ecf-1b1ede9c6809
+      - 09c8598c-fe23-4366-807a-3bb4a56a1d3e
     status: 200 OK
     code: 200
     duration: ""
@@ -3381,12 +3250,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3395,7 +3264,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:35 GMT
+      - Mon, 02 Jan 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3405,7 +3274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3237cdf6-09c6-442e-9604-6311d530d6a7
+      - 52f4dc52-3c40-40db-91ba-59ed31c0f8dd
     status: 200 OK
     code: 200
     duration: ""
@@ -3414,12 +3283,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3428,7 +3297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:41 GMT
+      - Mon, 02 Jan 2023 14:17:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3438,7 +3307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a34d83ce-4c9c-4a39-b9e7-94eea1051e41
+      - 7f020c38-6ec9-463e-b1b1-8f63c929f665
     status: 200 OK
     code: 200
     duration: ""
@@ -3447,12 +3316,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3461,7 +3330,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:46 GMT
+      - Mon, 02 Jan 2023 14:17:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3471,7 +3340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aa8842d-e978-44f6-bc03-07322eb2e0cb
+      - a6148587-e6d6-405d-80d0-7faead9343e5
     status: 200 OK
     code: 200
     duration: ""
@@ -3480,12 +3349,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3494,7 +3363,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:51 GMT
+      - Mon, 02 Jan 2023 14:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3504,7 +3373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4069cdc2-ed07-480e-b4e3-eb5ea0282524
+      - 974d4e88-7bc9-4681-baf9-a95a33acb7f6
     status: 200 OK
     code: 200
     duration: ""
@@ -3513,12 +3382,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:44:25.307290Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -3527,7 +3396,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:46:56 GMT
+      - Mon, 02 Jan 2023 14:17:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3537,7 +3406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc41e0b1-8699-419a-8a4e-b514c7232728
+      - 323fe69b-b74a-453b-966b-32ee65849181
     status: 200 OK
     code: 200
     duration: ""
@@ -3546,12 +3415,672 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:46:59.157488Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:17:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee887036-06a4-4147-87a1-465900642a78
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:17:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9ff1b60-aa0e-4bb2-901d-e69e253ee3ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:17:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d3b646c0-66af-49e0-8f67-a414c2d996d6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:17:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6abcdb40-7abd-43d7-bc22-307d55ea1199
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:17:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b5612fbc-850d-4017-8b9e-204310bfef24
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:17:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 27faccf3-ac48-4078-aa26-e778abd780f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:17:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d6eea450-88a0-4f19-9a92-df0fb98eb6a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:17:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61ae3dff-fb40-49e0-8c47-c1437ee169f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ffa343ee-f118-470f-accd-ff5cc9925487
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42220dfd-f5e4-4bc6-82f5-5070c6b05523
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 26833850-f4df-40c8-a3ce-4de486210e9a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2efb4b10-6259-4e2b-bfd4-f747ad93ae7c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c570152-5a31-40fd-9d15-17173a0b58b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 369bcc3a-3780-4069-9e82-bdbf178e57aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 48fcc7b1-db24-4613-af85-564c06266baf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fafd690-d6b3-408a-a5b5-bd1ddc3d49aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a59b4e9-8a59-4558-8925-9ac9c15877d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b79e2557-0b6c-4b5a-a17b-8611c91f1b20
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01951c95-b2d9-4a27-a6d4-6be0c29b9c9a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:14:55.140471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:18:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3856a590-0fe3-47b9-9614-a4039ccfd200
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:02.890011Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -3560,7 +4089,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:02 GMT
+      - Mon, 02 Jan 2023 14:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3570,7 +4099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec3b8fe2-cfeb-4c06-aba6-b721bd108e7e
+      - 45680fb9-db88-43b5-8ad6-8604c053518e
     status: 200 OK
     code: 200
     duration: ""
@@ -3579,12 +4108,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:46:59.157488Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:02.890011Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -3593,7 +4122,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:02 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3603,7 +4132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 207327e4-a27d-49c6-b74c-b4a5b81bc817
+      - 1b30b71f-fc5f-43af-8120-b0cc81349f79
     status: 200 OK
     code: 200
     duration: ""
@@ -3612,21 +4141,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:46:59.144305Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:19:02.880404Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "603"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:02 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3636,7 +4165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5741877a-c570-49ea-b53a-f9b131c5dda2
+      - 95cdcb77-a3e6-40ef-9f7f-6490ae48230f
     status: 200 OK
     code: 200
     duration: ""
@@ -3645,12 +4174,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -3659,7 +4188,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:03 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3669,7 +4198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42d0fca5-90e1-4047-bcdc-452264b0e50c
+      - 51641f2c-b9ef-404f-b2aa-d507ab72cf8d
     status: 200 OK
     code: 200
     duration: ""
@@ -3678,12 +4207,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:46:59.157488Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:02.890011Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -3692,7 +4221,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:04 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3702,7 +4231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80034a3c-cd54-4dc2-b3e2-33e517c32d9e
+      - a22134e1-3b54-439c-a59e-996df282489a
     status: 200 OK
     code: 200
     duration: ""
@@ -3711,12 +4240,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -3725,7 +4254,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:04 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3735,7 +4264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 902baa83-cc02-4ffa-abdc-7ba4a5840000
+      - e10a51f6-8cb7-4c74-a959-25856e8ebcc0
     status: 200 OK
     code: 200
     duration: ""
@@ -3744,12 +4273,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -3758,7 +4287,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:05 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3768,7 +4297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb07afb1-26ad-4d3a-a930-3db797ceb545
+      - 98f5aaac-9f3b-4ada-a073-39999552cc0b
     status: 200 OK
     code: 200
     duration: ""
@@ -3777,12 +4306,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:02.890011Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -3791,7 +4320,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:05 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3801,7 +4330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d900566-f8a9-4ad4-82c2-cfcedb6d85c9
+      - 19931a1e-de1f-48dd-8818-0c91e55a7a1f
     status: 200 OK
     code: 200
     duration: ""
@@ -3810,12 +4339,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:46:59.157488Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -3824,7 +4353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:05 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3834,7 +4363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b308e0d-0633-49f2-8910-4bd37612cc8c
+      - 1e62d41c-35b6-40e2-afad-0a79c90f3f70
     status: 200 OK
     code: 200
     duration: ""
@@ -3843,21 +4372,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:46:59.185237Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:19:02.880404Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "688"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:05 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3867,7 +4396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4fff64e-e72c-41f0-8db2-29f26ffa3de5
+      - 632a6491-437c-4150-806a-fc278976ddc3
     status: 200 OK
     code: 200
     duration: ""
@@ -3876,21 +4405,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:46:59.144305Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:19:02.916519Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "603"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:05 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3900,7 +4429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f7b679e-5d36-4988-84b6-75b6e3b1f385
+      - f4f83bbf-14ab-4814-850f-eac83b53fa5e
     status: 200 OK
     code: 200
     duration: ""
@@ -3909,12 +4438,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -3923,7 +4452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:06 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3933,7 +4462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff262e4d-4d74-4dc2-8e9a-3290183b99dc
+      - 226e6365-c807-44d1-9d1b-728ccff19925
     status: 200 OK
     code: 200
     duration: ""
@@ -3942,12 +4471,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -3956,7 +4485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:06 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3966,7 +4495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23b108df-76c4-4424-886d-ebf815412b63
+      - a829b104-0272-4a8e-b97a-e193de611f30
     status: 200 OK
     code: 200
     duration: ""
@@ -3975,12 +4504,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:46:59.157488Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -3989,7 +4518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:06 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3999,7 +4528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c25b18f4-f201-4d96-b179-dc5fabf5b9af
+      - 812deaf0-b22d-487a-804b-bf18c68666b0
     status: 200 OK
     code: 200
     duration: ""
@@ -4008,12 +4537,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:19:02.890011Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -4022,7 +4551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:06 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4032,7 +4561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c153375-bd93-4945-82a7-31e9278543f3
+      - 3c080492-25ff-4961-98d4-366cd4b57386
     status: 200 OK
     code: 200
     duration: ""
@@ -4041,21 +4570,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:46:59.144305Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:19:02.916519Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "603"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:06 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4065,7 +4594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e49e5f1-8d78-4b0f-9f17-7f5a962b5c4e
+      - 1caf2335-4caf-4479-afa1-300b2255548f
     status: 200 OK
     code: 200
     duration: ""
@@ -4074,21 +4603,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:46:59.185237Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:19:02.880404Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "688"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:06 GMT
+      - Mon, 02 Jan 2023 14:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4098,7 +4627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffb674ac-580a-46f3-b7c2-504e14153b3f
+      - e97770b8-abc2-4aac-a044-75a96ecdf3eb
     status: 200 OK
     code: 200
     duration: ""
@@ -4109,12 +4638,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212824986Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137237945Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "572"
@@ -4123,7 +4652,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:08 GMT
+      - Mon, 02 Jan 2023 14:19:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4133,7 +4662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22dfb5c2-c6a8-4300-b68e-84d7798e2195
+      - 53bc22d8-d54d-4f17-8f51-c2e6e014cd6c
     status: 200 OK
     code: 200
     duration: ""
@@ -4142,12 +4671,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4156,7 +4685,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:08 GMT
+      - Mon, 02 Jan 2023 14:19:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4166,7 +4695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49dd268e-31a2-4ec2-961f-9a8ac334b8c7
+      - 73c122ea-8109-4bab-a69c-7db1a14345d0
     status: 200 OK
     code: 200
     duration: ""
@@ -4175,12 +4704,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4189,7 +4718,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:13 GMT
+      - Mon, 02 Jan 2023 14:19:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4199,7 +4728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d57a7c73-8cb2-4732-bcdf-74fbf491b75b
+      - ece12e27-9c52-4a3c-bdb7-45b46a248665
     status: 200 OK
     code: 200
     duration: ""
@@ -4208,12 +4737,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4222,7 +4751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:19 GMT
+      - Mon, 02 Jan 2023 14:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4232,7 +4761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a90b807-152d-49dc-979c-c32ee2b9500c
+      - c068f7f8-fa7c-4a90-b2d6-d40bb073b283
     status: 200 OK
     code: 200
     duration: ""
@@ -4241,12 +4770,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4255,7 +4784,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:24 GMT
+      - Mon, 02 Jan 2023 14:19:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4265,7 +4794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9a4a6cf-4132-43eb-96c9-ff7fa36969cb
+      - 4d19b357-2fce-4340-a383-c45a63d0fb55
     status: 200 OK
     code: 200
     duration: ""
@@ -4274,12 +4803,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4288,7 +4817,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:29 GMT
+      - Mon, 02 Jan 2023 14:19:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4298,7 +4827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecfbb4d3-59fc-4519-9ebe-4bf7c64952a5
+      - 4585e857-71a2-4a1f-9ba4-df398668edf3
     status: 200 OK
     code: 200
     duration: ""
@@ -4307,12 +4836,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4321,7 +4850,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:35 GMT
+      - Mon, 02 Jan 2023 14:19:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4331,7 +4860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da80d16e-a3da-4077-8cbc-d4684de65e74
+      - 815fdd85-7e65-4ba9-a9a4-d9dbb46f9469
     status: 200 OK
     code: 200
     duration: ""
@@ -4340,12 +4869,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4354,7 +4883,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:40 GMT
+      - Mon, 02 Jan 2023 14:19:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4364,7 +4893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5faed4aa-6103-4f86-87b3-b504c51441a5
+      - 61dedc6e-e1ea-4fc3-b613-ff4792611a52
     status: 200 OK
     code: 200
     duration: ""
@@ -4373,12 +4902,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4387,7 +4916,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:45 GMT
+      - Mon, 02 Jan 2023 14:19:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4397,7 +4926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec817ce6-6686-4f19-90f8-0ccb3eaf164b
+      - aa15b5db-02a9-4c31-b79f-7df884b6b6a2
     status: 200 OK
     code: 200
     duration: ""
@@ -4406,12 +4935,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4420,7 +4949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:51 GMT
+      - Mon, 02 Jan 2023 14:19:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4430,7 +4959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aacfa68-6be5-4432-95c3-2cf01286369f
+      - 1053b8d3-be36-409a-8885-563165f062dd
     status: 200 OK
     code: 200
     duration: ""
@@ -4439,12 +4968,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4453,7 +4982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:47:57 GMT
+      - Mon, 02 Jan 2023 14:19:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4463,7 +4992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1caafb13-d8ff-4e82-b684-b31c9256e31b
+      - 515c931b-a65e-48f8-b029-efba873fbf6b
     status: 200 OK
     code: 200
     duration: ""
@@ -4472,12 +5001,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4486,7 +5015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:02 GMT
+      - Mon, 02 Jan 2023 14:19:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4496,7 +5025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 690845fe-7438-43f4-90b1-04681ab2d166
+      - 368a5aa8-5e56-4542-aa9b-553d65dfcc69
     status: 200 OK
     code: 200
     duration: ""
@@ -4505,12 +5034,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4519,7 +5048,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:07 GMT
+      - Mon, 02 Jan 2023 14:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4529,7 +5058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18a45cb6-31f3-4355-87c4-523068ea43aa
+      - 96a2b586-60c9-4f26-9ad6-e2f59bcecce4
     status: 200 OK
     code: 200
     duration: ""
@@ -4538,12 +5067,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4552,7 +5081,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:13 GMT
+      - Mon, 02 Jan 2023 14:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4562,7 +5091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9771265f-f202-4d0e-a762-aa30b630367b
+      - 20855633-d720-44c7-8dc8-e9288ccb6c8c
     status: 200 OK
     code: 200
     duration: ""
@@ -4571,12 +5100,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4585,7 +5114,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:19 GMT
+      - Mon, 02 Jan 2023 14:20:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4595,7 +5124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c02e0582-9fbd-4887-bba9-ff946db1ec68
+      - 2a835178-888c-4809-8a4e-957c8dc30276
     status: 200 OK
     code: 200
     duration: ""
@@ -4604,12 +5133,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4618,7 +5147,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:25 GMT
+      - Mon, 02 Jan 2023 14:20:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4628,7 +5157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3281dad3-87e3-4c7e-903a-11d01c52db65
+      - dc45f489-7059-49b7-a128-443be9513372
     status: 200 OK
     code: 200
     duration: ""
@@ -4637,12 +5166,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4651,7 +5180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:31 GMT
+      - Mon, 02 Jan 2023 14:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4661,7 +5190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14c7baa6-09b3-4455-884f-e19692fcd10e
+      - f8302e7b-8056-451c-abcd-6a074b9542f5
     status: 200 OK
     code: 200
     duration: ""
@@ -4670,12 +5199,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4684,7 +5213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:36 GMT
+      - Mon, 02 Jan 2023 14:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4694,7 +5223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1655f837-e2e6-4fbd-b5b3-1eb53e296943
+      - 2a8c335d-ed14-45fb-84f0-75745b66d7c7
     status: 200 OK
     code: 200
     duration: ""
@@ -4703,12 +5232,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4717,7 +5246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:42 GMT
+      - Mon, 02 Jan 2023 14:20:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4727,7 +5256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17954a87-0960-45dd-8060-14fad24c4872
+      - 9ef993db-1375-429c-a913-80a8ff744eb1
     status: 200 OK
     code: 200
     duration: ""
@@ -4736,12 +5265,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4750,7 +5279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:47 GMT
+      - Mon, 02 Jan 2023 14:20:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4760,7 +5289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bdae3c4-2e90-4c42-b10e-114eafe9ff00
+      - 60b8109e-fa62-4d6f-93b8-a18a58fee8f7
     status: 200 OK
     code: 200
     duration: ""
@@ -4769,12 +5298,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4783,7 +5312,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:52 GMT
+      - Mon, 02 Jan 2023 14:20:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4793,7 +5322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baa6b13e-a5b8-43b3-b9a4-71392719249e
+      - 0bdd604e-f90f-48f1-8810-535fed17be20
     status: 200 OK
     code: 200
     duration: ""
@@ -4802,12 +5331,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4816,7 +5345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:48:58 GMT
+      - Mon, 02 Jan 2023 14:20:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4826,7 +5355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fc1c2e6-a60a-4d88-a886-3b878921ca79
+      - af91c67f-de3f-41d9-b8c1-437f7ff021eb
     status: 200 OK
     code: 200
     duration: ""
@@ -4835,12 +5364,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4849,7 +5378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:03 GMT
+      - Mon, 02 Jan 2023 14:20:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4859,7 +5388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46b243b0-f1e1-4f49-8612-f71ba401fe8a
+      - 85b0e1ec-3de7-41d2-b00e-f1964e025a11
     status: 200 OK
     code: 200
     duration: ""
@@ -4868,12 +5397,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4882,7 +5411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:08 GMT
+      - Mon, 02 Jan 2023 14:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4892,7 +5421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01c632e0-9952-4544-ab1c-9f3d52795ae6
+      - cf87ddb0-1bc8-44e3-b1fb-11957d9f4233
     status: 200 OK
     code: 200
     duration: ""
@@ -4901,12 +5430,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4915,7 +5444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:14 GMT
+      - Mon, 02 Jan 2023 14:21:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4925,7 +5454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b732842-e338-451d-9b82-ae690a0e4ce9
+      - 8cf84f70-dca1-4284-9cc6-b9aa87b8d225
     status: 200 OK
     code: 200
     duration: ""
@@ -4934,12 +5463,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:47:07.212825Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -4948,7 +5477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:19 GMT
+      - Mon, 02 Jan 2023 14:21:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4958,7 +5487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e990f5c7-e9a6-4c35-aaaa-3a37a9ba6df9
+      - b699c366-46e0-4cb8-837e-e915c0f9b19f
     status: 200 OK
     code: 200
     duration: ""
@@ -4967,12 +5496,342 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:21.822469Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b6b9b3b9-07e2-4588-a78d-78d9f5116213
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6e5d1662-c16f-454c-ab99-f411bb60f4d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 511338d8-e857-4f75-85e6-dce5fcebdffd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e53dde88-2c5a-47bb-a5f2-d49566f256d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cafad93d-c5cf-4435-b53b-ec29ac06d63e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0ac258a6-14fd-4803-98db-ac54eece2e39
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59c70e3b-ec94-4333-ab66-0162eeb3782e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8b24d504-b53f-46bf-b493-155de3b4d045
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1cbf60e9-486e-447a-8c72-a3a02a52bd24
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:19:05.137238Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "569"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:21:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d667912a-43d7-4843-b199-8b296eb437b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-01-02T14:21:59.285092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -4981,7 +5840,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:24 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4991,7 +5850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fa2f31a-3855-4ffa-ae0e-3e6ac3b985b6
+      - 20e25940-5606-42d6-98c2-b691d21966a2
     status: 200 OK
     code: 200
     duration: ""
@@ -5000,12 +5859,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:21.822469Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-01-02T14:21:59.285092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5014,7 +5873,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:24 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5024,7 +5883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef73ad19-3b60-4509-8873-7e0892ea0c8a
+      - 3f625aa4-8b93-4ccb-bb5b-9c1d9bd9f822
     status: 200 OK
     code: 200
     duration: ""
@@ -5033,21 +5892,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
     method: GET
   response:
-    body: '{"total_count":2,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:49:21.807115Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null},{"region":"fr-par","id":"54de7a8c-dc9b-4004-be63-63b86f769c80","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:47:08.711464Z","updated_at":"2022-10-25T08:49:21.789999Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-54de7a8cdc9b4004be6","public_ip_v4":"163.172.178.243","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/0e7ce52f-f175-447e-85fb-0094c53f0166","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:21:59.250348Z"},{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:19:06.546927Z","error_message":null,"id":"37d3e8b2-dba3-4b2c-8f4c-b2ef51ba5782","name":"scw-poolconfigwait-minimal-37d3e8b2dba34b2c8f4","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/2c13ad1b-6a42-402a-b6b5-e68551926d27","public_ip_v4":"51.15.253.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:21:59.269822Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1266"
+      - "1264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:24 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5057,7 +5916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09a1ede9-9e03-4181-a795-af7c78a00e10
+      - e02a86ca-c79a-45db-9ee9-c1484cd740a1
     status: 200 OK
     code: 200
     duration: ""
@@ -5066,12 +5925,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -5080,7 +5939,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:25 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5090,7 +5949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e285a76-846a-4f5b-bf0a-26f326fe7e5c
+      - 45ca11cf-b18e-48c2-bfac-c8e657a7f123
     status: 200 OK
     code: 200
     duration: ""
@@ -5099,12 +5958,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:21.822469Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-01-02T14:21:59.285092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5113,7 +5972,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:26 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5123,7 +5982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fd59583-9d90-4716-b22e-b76148b51b4f
+      - a992cf2a-107b-4491-a87e-e6a331226a61
     status: 200 OK
     code: 200
     duration: ""
@@ -5132,12 +5991,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -5146,7 +6005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:26 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5156,7 +6015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1577346-d72d-4346-9893-fd2665948458
+      - 0131ad07-e7a8-4d53-86c2-16f65f0e687b
     status: 200 OK
     code: 200
     duration: ""
@@ -5165,12 +6024,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -5179,7 +6038,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:27 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5189,7 +6048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2aad265-71ee-4189-bfdb-0d37e7213b7c
+      - aaf41d0d-b666-4bfd-8aed-0a3d5026f96c
     status: 200 OK
     code: 200
     duration: ""
@@ -5198,12 +6057,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5212,7 +6071,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:27 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5222,7 +6081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc069d78-38c3-47fc-b28f-88917af01867
+      - e8d92c07-21cc-4649-89c6-96e632d201d0
     status: 200 OK
     code: 200
     duration: ""
@@ -5231,12 +6090,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:21.822469Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-01-02T14:21:59.285092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5245,7 +6104,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:27 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5255,7 +6114,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3996791b-a6e9-4e38-87f6-ca818ac7ed78
+      - 109672af-4fb4-4d51-b1ff-fa0baa247b62
     status: 200 OK
     code: 200
     duration: ""
@@ -5264,21 +6123,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":2,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:49:21.807115Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null},{"region":"fr-par","id":"54de7a8c-dc9b-4004-be63-63b86f769c80","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:47:08.711464Z","updated_at":"2022-10-25T08:49:21.789999Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-54de7a8cdc9b4004be6","public_ip_v4":"163.172.178.243","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/0e7ce52f-f175-447e-85fb-0094c53f0166","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:21:59.311821Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1266"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:28 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5288,7 +6147,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d09a83ac-ee03-44e3-8107-e7635e9a1ce2
+      - c802c6ef-ee5b-4f26-881d-57366c342b8f
     status: 200 OK
     code: 200
     duration: ""
@@ -5297,21 +6156,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:49:21.856080Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:21:59.250348Z"},{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:19:06.546927Z","error_message":null,"id":"37d3e8b2-dba3-4b2c-8f4c-b2ef51ba5782","name":"scw-poolconfigwait-minimal-37d3e8b2dba34b2c8f4","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/2c13ad1b-6a42-402a-b6b5-e68551926d27","public_ip_v4":"51.15.253.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:21:59.269822Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "688"
+      - "1264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:28 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5321,7 +6180,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 065a251c-21af-4497-9b96-41e58201072a
+      - 09b00e7a-7a3b-476b-9a1b-21e6e1c925a7
     status: 200 OK
     code: 200
     duration: ""
@@ -5330,12 +6189,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -5344,7 +6203,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:29 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5354,7 +6213,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f6754e6-2510-40ca-a290-347d6480870d
+      - df4d25c9-8b60-4ce8-93b9-fc71f2248d6e
     status: 200 OK
     code: 200
     duration: ""
@@ -5363,12 +6222,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -5377,7 +6236,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:29 GMT
+      - Mon, 02 Jan 2023 14:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5387,7 +6246,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ae75164-9459-4b1e-abc1-02672f641d09
+      - 5251a2e6-2a4b-4a96-a03c-d1632093595a
     status: 200 OK
     code: 200
     duration: ""
@@ -5396,12 +6255,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:21.822469Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5410,7 +6269,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:30 GMT
+      - Mon, 02 Jan 2023 14:22:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5420,7 +6279,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc9ac23d-01b2-4add-ad77-097d73f6e4f8
+      - 6f8103b5-bd22-4042-ac1b-1f24ac80918e
     status: 200 OK
     code: 200
     duration: ""
@@ -5429,45 +6288,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"total_count":2,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:49:21.807115Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null},{"region":"fr-par","id":"54de7a8c-dc9b-4004-be63-63b86f769c80","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:47:08.711464Z","updated_at":"2022-10-25T08:49:21.789999Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-54de7a8cdc9b4004be6","public_ip_v4":"163.172.178.243","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/0e7ce52f-f175-447e-85fb-0094c53f0166","error_message":null}]}'
-    headers:
-      Content-Length:
-      - "1266"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:49:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f6752078-889a-456a-aca7-76acbdf2b0a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":2,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-01-02T14:21:59.285092Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5476,7 +6302,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:30 GMT
+      - Mon, 02 Jan 2023 14:22:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5486,7 +6312,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 222cc24d-4bb7-455e-a5f7-5d279e3dc204
+      - c17ca11a-7ccc-43e0-af5d-aa6a618adfec
     status: 200 OK
     code: 200
     duration: ""
@@ -5495,21 +6321,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:49:21.856080Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:21:59.311821Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "688"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:30 GMT
+      - Mon, 02 Jan 2023 14:22:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5519,7 +6345,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4663acbf-88a0-4d8b-a7f4-8e1818784bcd
+      - 9fc81fe1-0128-4b86-a57a-e3d12e4a38dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:21:59.250348Z"},{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:19:06.546927Z","error_message":null,"id":"37d3e8b2-dba3-4b2c-8f4c-b2ef51ba5782","name":"scw-poolconfigwait-minimal-37d3e8b2dba34b2c8f4","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/2c13ad1b-6a42-402a-b6b5-e68551926d27","public_ip_v4":"51.15.253.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:21:59.269822Z"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:22:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4cf64db3-760d-4432-9f45-a42763bcaa47
     status: 200 OK
     code: 200
     duration: ""
@@ -5530,12 +6389,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: PATCH
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:30.948987195Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:22:04.335075245Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "572"
@@ -5544,7 +6403,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:31 GMT
+      - Mon, 02 Jan 2023 14:22:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5554,7 +6413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2af1d09e-ee48-4331-99c8-0fb8099039fa
+      - 504557e4-2273-4c0f-8ba8-cff543b096cb
     status: 200 OK
     code: 200
     duration: ""
@@ -5563,12 +6422,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:30.948987Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-01-02T14:22:04.335075Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "569"
@@ -5577,7 +6436,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:32 GMT
+      - Mon, 02 Jan 2023 14:22:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5587,7 +6446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1018ae9-f72f-47e7-aebe-2a9bae086f9c
+      - 26237800-df90-46de-9607-6bf0e876a1f7
     status: 200 OK
     code: 200
     duration: ""
@@ -5596,78 +6455,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:30.948987Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "569"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:49:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55fef753-b1a1-4369-aee2-0b08a1357234
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:30.948987Z","name":"minimal","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
-    headers:
-      Content-Length:
-      - "569"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:49:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3d627a57-aa6b-489b-b933-30e23c01f648
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
-    method: GET
-  response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:44.513070Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:22:06.420902Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5676,7 +6469,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:48 GMT
+      - Mon, 02 Jan 2023 14:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5686,7 +6479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bd6258b-aca0-44ab-b7ce-c4ad6a290153
+      - d65c2f03-dd88-4bcb-acea-566e1e49ef11
     status: 200 OK
     code: 200
     duration: ""
@@ -5695,12 +6488,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:44.513070Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:22:06.420902Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5709,7 +6502,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:48 GMT
+      - Mon, 02 Jan 2023 14:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5719,7 +6512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3be61c5-4509-4519-8516-f8294e100422
+      - 413870f6-658e-422f-9f4d-202fda5d2b17
     status: 200 OK
     code: 200
     duration: ""
@@ -5728,21 +6521,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:49:36.942157Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-01-02T14:22:05.785035Z"},{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:19:06.546927Z","error_message":null,"id":"37d3e8b2-dba3-4b2c-8f4c-b2ef51ba5782","name":"scw-poolconfigwait-minimal-37d3e8b2dba34b2c8f4","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/2c13ad1b-6a42-402a-b6b5-e68551926d27","public_ip_v4":"51.15.253.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:22:06.270284Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "686"
+      - "1296"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:49 GMT
+      - Mon, 02 Jan 2023 14:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5752,7 +6545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 616c7475-75a2-4cda-9dae-f3e95f1c5438
+      - 673aaef4-d00b-4487-83f2-59052ad84350
     status: 200 OK
     code: 200
     duration: ""
@@ -5761,12 +6554,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -5775,7 +6568,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:49 GMT
+      - Mon, 02 Jan 2023 14:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5785,7 +6578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c5bd7eb-e921-4ffd-b5cd-04b7a3d732ea
+      - 6a62c7cc-7c96-42d8-993b-bc85c9231c25
     status: 200 OK
     code: 200
     duration: ""
@@ -5794,12 +6587,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:44.513070Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:22:06.420902Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5808,7 +6601,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:50 GMT
+      - Mon, 02 Jan 2023 14:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5818,7 +6611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 778b20fc-c12d-4a09-9e77-0ec1874919fd
+      - b8466fcf-dca6-4aa1-aa62-237a9ce908e6
     status: 200 OK
     code: 200
     duration: ""
@@ -5827,12 +6620,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -5841,7 +6634,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:51 GMT
+      - Mon, 02 Jan 2023 14:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5851,7 +6644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eebc6985-a700-45ce-8c0e-0a20233d906a
+      - 6e1af9af-c4b6-42f6-886f-c006f9f27203
     status: 200 OK
     code: 200
     duration: ""
@@ -5860,12 +6653,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -5874,7 +6667,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:51 GMT
+      - Mon, 02 Jan 2023 14:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5884,7 +6677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b444392-184f-4814-a239-f9d5f3ca9b14
+      - 1eff0886-1094-4d03-a2d7-00cf30b968a2
     status: 200 OK
     code: 200
     duration: ""
@@ -5893,12 +6686,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:44.513070Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:22:06.420902Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5907,7 +6700,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:51 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5917,7 +6710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef7faee9-d08e-41c5-a5b2-a52d8d2d3dec
+      - 8d1d18af-dde1-427c-96a6-bbae21224b47
     status: 200 OK
     code: 200
     duration: ""
@@ -5926,12 +6719,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -5940,7 +6733,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:51 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5950,7 +6743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99d32c76-0a5d-4907-ae50-ff5004f9f9aa
+      - ac620add-a998-460f-9bdf-8845996a4952
     status: 200 OK
     code: 200
     duration: ""
@@ -5959,21 +6752,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:49:36.983084Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:22:06.319074Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "688"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:52 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5983,7 +6776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80d25cf4-0f5a-4be8-bf44-2318294a11d8
+      - a8c4cd8c-ddf7-4a3b-aca7-c69ba08ff35b
     status: 200 OK
     code: 200
     duration: ""
@@ -5992,21 +6785,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:49:36.942157Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-01-02T14:22:05.785035Z"},{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:19:06.546927Z","error_message":null,"id":"37d3e8b2-dba3-4b2c-8f4c-b2ef51ba5782","name":"scw-poolconfigwait-minimal-37d3e8b2dba34b2c8f4","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/2c13ad1b-6a42-402a-b6b5-e68551926d27","public_ip_v4":"51.15.253.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:22:06.270284Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "686"
+      - "1296"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:52 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6016,7 +6809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 662081a0-8360-42f7-97ef-ed949862db74
+      - b9659939-4cbd-4f68-bb28-8cd67b47d844
     status: 200 OK
     code: 200
     duration: ""
@@ -6025,12 +6818,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -6039,7 +6832,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:53 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6049,7 +6842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bda77d4e-873d-4254-9764-4ad796fce511
+      - 513e3149-5316-4fa0-b496-1f4db7e07a7f
     status: 200 OK
     code: 200
     duration: ""
@@ -6058,12 +6851,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: GET
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:44.513070Z","name":"minimal","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:22:06.420902Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -6072,7 +6865,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:53 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6082,7 +6875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be56d042-1d09-469c-9c0d-70a25f1fdd91
+      - 61aeb22e-ee4e-4d13-bf4f-ce62956ca9ee
     status: 200 OK
     code: 200
     duration: ""
@@ -6091,21 +6884,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=006f4d52-c9b0-499e-a0de-be5cee971338&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=8ff8c2eb-e265-420c-a48b-37a444b3305c&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"c0ed9d2f-496b-4a94-8f0f-d213f113b93d","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:26.595655Z","updated_at":"2022-10-25T08:49:36.942157Z","pool_id":"006f4d52-c9b0-499e-a0de-be5cee971338","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-minimal-c0ed9d2f496b4a948f0","public_ip_v4":"51.15.227.7","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/de45e3a9-35ea-40f9-b929-9215f2ea2261","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:14:56.435135Z","error_message":null,"id":"02ac2607-30c1-4be4-ba91-02bb62dfd748","name":"scw-poolconfigwait-minimal-02ac260730c14be4ba9","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/49ec1feb-21f4-49b6-b0c7-31c4f5b99015","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-01-02T14:22:05.785035Z"},{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:19:06.546927Z","error_message":null,"id":"37d3e8b2-dba3-4b2c-8f4c-b2ef51ba5782","name":"scw-poolconfigwait-minimal-37d3e8b2dba34b2c8f4","pool_id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","provider_id":"scaleway://instance/fr-par-1/2c13ad1b-6a42-402a-b6b5-e68551926d27","public_ip_v4":"51.15.253.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:22:06.270284Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "686"
+      - "1296"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:53 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6115,7 +6908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 313e06fa-59b8-48c0-ae80-15e95db7fe28
+      - bfd170c3-ef74-48d6-917b-bc52c92cd990
     status: 200 OK
     code: 200
     duration: ""
@@ -6124,12 +6917,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -6138,7 +6931,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:53 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6148,7 +6941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac2c2b7f-c787-44ca-ad67-db5d9b4104ef
+      - 12918531-9219-41a5-b03a-fcea1c791ed9
     status: 200 OK
     code: 200
     duration: ""
@@ -6157,12 +6950,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -6171,7 +6964,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:53 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6181,7 +6974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49acd262-a5ea-480c-940e-9790c61a6042
+      - 6e30f246-219e-49a6-9682-a932b1153050
     status: 200 OK
     code: 200
     duration: ""
@@ -6190,21 +6983,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:49:36.983084Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:22:06.319074Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "688"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:54 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6214,7 +7007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d17ab9b-0b6f-4869-8a66-13cb4b835b5a
+      - 0fca12f7-8d48-46f8-a725-40b7e0c35055
     status: 200 OK
     code: 200
     duration: ""
@@ -6223,12 +7016,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/006f4d52-c9b0-499e-a0de-be5cee971338
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8ff8c2eb-e265-420c-a48b-37a444b3305c
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"006f4d52-c9b0-499e-a0de-be5cee971338","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:44:25.299424Z","updated_at":"2022-10-25T08:49:54.919113941Z","name":"minimal","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:14:55.131039Z","id":"8ff8c2eb-e265-420c-a48b-37a444b3305c","kubelet_args":{},"max_size":1,"min_size":1,"name":"minimal","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-01-02T14:22:11.677149841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "573"
@@ -6237,7 +7030,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:54 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6247,7 +7040,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50724113-acab-4187-8afe-d3e175d18a60
+      - 81230138-3d6f-498e-b318-2cddc8e52319
     status: 200 OK
     code: 200
     duration: ""
@@ -6256,12 +7049,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -6270,7 +7063,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:55 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6280,7 +7073,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd9e8074-ed67-452a-aaf9-272268ba4bf8
+      - a16e18fd-7d2f-4e8c-96be-24057625405e
     status: 200 OK
     code: 200
     duration: ""
@@ -6289,12 +7082,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:40:42.183238Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"ready","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:13:54.173382Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -6303,7 +7096,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:56 GMT
+      - Mon, 02 Jan 2023 14:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6313,7 +7106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 095c3644-78f8-4ad4-9f73-3075a21e4be2
+      - e60527b9-7571-4df6-9ec9-ec49a3e09507
     status: 200 OK
     code: 200
     duration: ""
@@ -6322,12 +7115,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVOUdiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUMFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuQmhDbTEwZUZSWmJWQnRSR1JxUkZoc1dsVlhUamxJUm5GWk4zcG5iSE5qVG1WVGFFOXlUMlJNZGtOTk9WRndiVmd3T0dseFJtaDZLM2RYYWl0aFNYZEdOVW9LYjBaM2NXOXdTemRwWkRjNFMweEtTbXRLTkV0eFEyOVpTR3QyVVhSWk1qUjRWekU1UkUxVlRWZFdPV292TW1JMVpscG5iVmxLUTFsWFQyZzNjM1Z1YlFwRVNFTXlUMHBUVDNwMU5rVlZTM2RWYlRCU0wwdzBabTl2Y0RFdkszZE9OeXN2TUVkQ1VVbHNOUzl6TkRjeFpVczNWWFl3TVZWYWJsaHRiRmN5U21GeUNrcFNVV2RNUkZFMlV5dGpSR0paT1RSYU5FeEhSMlIyU1ZOU1ZqZExjaTloU1d4WkwybFBaMU00Ykd4VE1YTkpNV3N5T0ZkemVXRm1ORGxyZW5wNVVVNEtkWFJSUkZFNVZraFlSVE5LYkV4SVIzQTNSamh0YmpjMVkwVm9ZbTVFVkRoV2NsTmxlVWN2Ym5GcFJIQmpkV1JoWVdWV2VWaDFPVmt2YWtSaE5pdG1RZ3B0TUcwdlMwUkdlRGhDYW1KNFRFSnZhVVpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQYjNWMFJ6TmtOR2REVlV4TVFsUjBSelYxVG5CTk9VNVZiVFJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVmtVNVpuWmtWamMwVFhoc1luTlRlV1JRVURWWVQzWTNTMmhhVmtwYVRVVkZaVzlZV25jdlpXRnBlVzF1TWt0TFlRbzJRa3hWTm10SFpIZDFkVFZ2UlZKQlMxbFVibmxyYm10dk9HcDBXRXB0Ym10S04waGlPRlZKT0RCU09FZzVUVmt5VVdwNlYydHljemxqUkcwdmNXZEpDbG8wUWtKTE4xWk5hMmR0YjJ4TFpHWkRabUpaV2xoeFdrNXFXR3gxZVZKT1NWVlZPR1ZDTkVkSldWZENPWFkzTURjMVF6UnNUa0ZSY0RKQ05uZE5RamtLY0dRNFRtSXJPV2h1VTI5RWNtOVVRakZ1VnpSdGR6WTJObU5HVTFORVkxZDNOa3M0VDBoeVoxQXhPRlI2VkhGaGFraHZkVGR3TnpCMVNraE5UVGxsT1FwTU5ubHFZbWxTUlZCS1RuZHFhRlpUVG1NMFF6Rk1iWEZDT0dkT1QzbElWMWxuUWpKcmJFZGxTWFpsVkZWU1VWcDRZMGxPT1c1eVlqUmtUMGRpVEdoRENtdFpNamR1WjJwWGJHZERWRWQ0TkcxNWRUZFRiU3RSYldWRFIwbEZSR3RwU2t4QmFnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81NmM1OTkzYy04MTJjLTQ0Y2EtOTBiNi0xYzY5MzAyMDE1MDkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBuY1VReW5ReTZsdlVxVXpVbzR2c2p6elhVSldYWmRVV1p3QlJDdlloek5yblhNdDdUTEdkZkNnNA=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInBvb2xjb25maWd3YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrNHhiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyRm5DbkJ0VW1FeFdVZzJNbUZMVDJkd1FWazFaRzl6ZUVSVmQyeDZPR1J2ZUdzNVNrNHhiSEJCUkhaaFRITkZjelZOZDJOTE9UUkhlVlZPYzJvNWVIVXliMm9LVkRaamVHeFNOazF0ZEhCU1NrTkxXblo0ZVhkUGVVWm9RbFIyTlZOemFXZzFOMlJqYlRCUFVWZFdlamcwVmtaak1USTNReXMyUW1sR2QwNVNWVU5FVndweWRHMXlUakZzWWpGS1RYcEpOMkozVFRSeGRVcDJSeTgwVEdoMFZVbFNlRTlrVWxsc1pVRlFSV3N2WjBsWVJYaHFaR0oyUlM5RlRFWmpWSGxUU0VObUNqYzFTMUZ2VDBSeFFqQndRMmxpVUVacGVtZDNSMnRFTkV0dFpIcE5PSEJKWWpGeWQwVllhME42U0dwRVQxQXZSaklyVkc5YVRsZFdNemh2VG1jd2JHVUtjSE5vUmpGcFlsaEpVVkI1ZEV0MU5tSkZZVXBFVVdaUU9HbzNUakFyWVZwWU5VbFNVak5ST1VnNWQyUXhNelZTTjJKbk1rWmpZWFJDYUZGNlVFdHVZZ3BCTUhwVlVsTlNOSGxTYW5WNFdVeHhTRUpOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRVm1GUU1FWkVjbU5WUVVaUlVDOHdlVmt2Y1RJMWRqRXdMM05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWWxkSWNVUk9URkl6VVhGVlVHUkRXVGhYY0U1TFJFaE9kbE0zV201YU9YZEdSbFJ5V21RMlJUWm5RWFpuYkVoWk13b3lTMjlFTmtKNWRXNXNPV2xtVlZCbFRucE9hMW8zVnpkMU0yNU5OMm95UkdScmNrWjZhMUZxT0RkS1FsVk9kbEF3TTIxTUwxVmtObUZSWkRCVVlUSkVDak5pV2toVlREbDFNR0ozVDJSbWJURXdkM2R2TDNZMVlYRmFNV2t2YVhONWJ6TnVVRWgxVTBOU1JXZE9UalJ4YlN0aU5HUlZNa05VZVZoUFdVZzNVVllLUTJwblQzRTVUV0o2WlRSSlZtVk9jREUxYzJKV05FNHdXVFExYUVSSFl6Vm5SVVJDUm0xTVYyeFNVVXBGVmpCMFNHMUpUMHQ1Y2pKNWRYaFJRMDlLWVFweE4yVlVhVU5YUTFkb2VVSkJhbTQyY2pCMmNtaFBZM0J2YWs4eVZuTm1abVIyUTFvM05IQnJXSGhQWm5VMmNucG5XV054UzBZMVdtMUpMM0p2VVZKeENuSmhhblZpZUZkelNVbzRXRUY2TkZGTmFEZzBjMWRUTlRjdk5FRTFka0pqTUVkc1Z3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8wZTE5ZTEwYy1jNTA4LTRlMTgtODIwMi02YWY0ODNhOTlhMDguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcG9vbGNvbmZpZ3dhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInBvb2xjb25maWd3YWl0IgogICAgdXNlcjogcG9vbGNvbmZpZ3dhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwb29sY29uZmlnd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHBvb2xjb25maWd3YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQXJiTFpRNjA4YWZZZFdhR3psNDNCc0F2RUVOWFJyc1dISmQwQlpUdmpVaUQ1dUVmWkxLUXRMWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2604"
@@ -6336,7 +7129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:56 GMT
+      - Mon, 02 Jan 2023 14:22:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6346,7 +7139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f639e41f-dd70-4f7e-9cdc-6dbf9dbc840b
+      - cc92b1f0-18f7-4f20-9db4-ba05037b4775
     status: 200 OK
     code: 200
     duration: ""
@@ -6355,12 +7148,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: GET
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:44:19.287558Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-01-02T14:14:48.828952Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "567"
@@ -6369,7 +7162,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:56 GMT
+      - Mon, 02 Jan 2023 14:22:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6379,7 +7172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9eee0c7-49cc-4180-9160-9c51979547af
+      - ad5c86f5-eb40-409f-a5b9-10abac156a0c
     status: 200 OK
     code: 200
     duration: ""
@@ -6388,21 +7181,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509/nodes?order_by=created_at_asc&page=1&pool_id=bf731f43-fe77-4ee0-8de7-49179a063203&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08/nodes?order_by=created_at_asc&page=1&pool_id=f56a0363-0e43-4a9c-8c31-bf489137a08f&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"8f413aa6-a604-4efd-9fab-69711a420077","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:40:55.024305Z","updated_at":"2022-10-25T08:49:55.549477Z","pool_id":"bf731f43-fe77-4ee0-8de7-49179a063203","status":"ready","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"name":"scw-poolconfigwait-default-8f413aa6a6044efd9fa","public_ip_v4":"51.158.115.98","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-1/57d811d5-4dfe-4d63-ba1f-d71d7122269d","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","conditions":{"DiskPressure":"False","KernelDeadlock":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","ReadonlyFilesystem":"False","Ready":"True"},"created_at":"2023-01-02T14:12:11.144412Z","error_message":null,"id":"dd2c84cb-da61-4af8-9d5b-5d6c53165a5b","name":"scw-poolconfigwait-default-dd2c84cbda614af89d5","pool_id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","provider_id":"scaleway://instance/fr-par-1/de971de6-7508-4c91-82d2-b3d4b4d317d3","public_ip_v4":"51.158.115.5","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:22:06.319074Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "688"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:57 GMT
+      - Mon, 02 Jan 2023 14:22:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6412,7 +7205,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18120c6a-878f-4a59-8c05-e8bfb922b1c1
+      - f504ba8b-5eda-4004-9063-2bbd6ba81181
     status: 200 OK
     code: 200
     duration: ""
@@ -6421,12 +7214,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bf731f43-fe77-4ee0-8de7-49179a063203
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f56a0363-0e43-4a9c-8c31-bf489137a08f
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"bf731f43-fe77-4ee0-8de7-49179a063203","cluster_id":"56c5993c-812c-44ca-90b6-1c6930201509","created_at":"2022-10-25T08:39:31.924882Z","updated_at":"2022-10-25T08:49:58.001306411Z","name":"default","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":[],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-1","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e19e10c-c508-4e18-8202-6af483a99a08","container_runtime":"containerd","created_at":"2023-01-02T14:10:38.922755Z","id":"f56a0363-0e43-4a9c-8c31-bf489137a08f","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-01-02T14:22:12.358813485Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "573"
@@ -6435,7 +7228,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:58 GMT
+      - Mon, 02 Jan 2023 14:22:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6445,7 +7238,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25ad8358-7390-4f22-b301-a2c159baebc5
+      - 6343dbef-b570-4ae1-ab28-096636583050
     status: 200 OK
     code: 200
     duration: ""
@@ -6454,12 +7247,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:49:58.332375823Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:22:12.450967075Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -6468,7 +7261,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:58 GMT
+      - Mon, 02 Jan 2023 14:22:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6478,7 +7271,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4787ac15-42e7-4a0f-af20-b6b7cceb5aa9
+      - 0c7de4f6-d2cb-4a23-85f9-2c1ed4a5b3df
     status: 200 OK
     code: 200
     duration: ""
@@ -6487,12 +7280,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:49:58.332376Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:22:12.450967Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1323"
@@ -6501,7 +7294,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:49:58 GMT
+      - Mon, 02 Jan 2023 14:22:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6511,7 +7304,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3c7d9bb-3dfa-446d-a9e4-e68095feca19
+      - 62926340-8bfa-44ee-9f28-147dba0e76fe
     status: 200 OK
     code: 200
     duration: ""
@@ -6520,12 +7313,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:49:58.332376Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:22:12.450967Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1323"
@@ -6534,7 +7327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:50:03 GMT
+      - Mon, 02 Jan 2023 14:22:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6544,7 +7337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd4fdb79-9b18-4a8f-afd1-4f73f10430c1
+      - 6b48e9be-6c79-4f95-bfe8-bdd0f92526d7
     status: 200 OK
     code: 200
     duration: ""
@@ -6553,12 +7346,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:49:58.332376Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e19e10c-c508-4e18-8202-6af483a99a08.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-01-02T14:10:33.527485Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e19e10c-c508-4e18-8202-6af483a99a08.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e19e10c-c508-4e18-8202-6af483a99a08","ingress":"none","name":"PoolConfigWait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-01-02T14:22:12.450967Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1323"
@@ -6567,7 +7360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:50:08 GMT
+      - Mon, 02 Jan 2023 14:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6577,7 +7370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ad33fa1-1f0c-4283-a8ad-a367f9877e6a
+      - c6e155d2-2d26-486a-a5f6-4bfb2e2a79ba
     status: 200 OK
     code: 200
     duration: ""
@@ -6586,45 +7379,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"region":"fr-par","id":"56c5993c-812c-44ca-90b6-1c6930201509","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.467959Z","updated_at":"2022-10-25T08:49:58.332376Z","type":"kapsule","name":"PoolConfigWait","description":"","status":"deleting","version":"1.24.5","cni":"calico","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"cluster_url":"https://56c5993c-812c-44ca-90b6-1c6930201509.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.56c5993c-812c-44ca-90b6-1c6930201509.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
-    headers:
-      Content-Length:
-      - "1323"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 25 Oct 2022 08:50:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9b586c09-4039-4354-b7b4-cec3d9eea68a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"56c5993c-812c-44ca-90b6-1c6930201509","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0e19e10c-c508-4e18-8202-6af483a99a08","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6633,7 +7393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:50:19 GMT
+      - Mon, 02 Jan 2023 14:22:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6643,7 +7403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 605bab71-ed71-4a70-b9e1-5d1a2b38f9a9
+      - 613fae21-1a1e-4ee8-b3f9-38cd61865232
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6652,12 +7412,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/56c5993c-812c-44ca-90b6-1c6930201509
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e19e10c-c508-4e18-8202-6af483a99a08
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"56c5993c-812c-44ca-90b6-1c6930201509","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0e19e10c-c508-4e18-8202-6af483a99a08","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6666,7 +7426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:50:19 GMT
+      - Mon, 02 Jan 2023 14:22:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6676,7 +7436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49992b84-339d-4d19-a854-675505b7005b
+      - a11e534d-c4e7-4f89-9388-f1c241ddbe50
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-zone.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-zone.cassette.yaml
@@ -6,15 +6,16 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"region":"fr-par","name":"1.24.5","label":"Kubernetes 1.24.5","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.23.11","label":"Kubernetes
-      1.23.11","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.22.14","label":"Kubernetes
-      1.22.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}},{"region":"fr-par","name":"1.21.14","label":"Kubernetes
-      1.21.14","available_cnis":["cilium","calico","weave","flannel"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"}}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.7","name":"1.24.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.13","name":"1.23.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.15","name":"1.22.15","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","ServiceTopology","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.21.14","name":"1.21.14","region":"fr-par"}]}'
     headers:
       Content-Length:
       - "3135"
@@ -23,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:24 GMT
+      - Mon, 02 Jan 2023 14:10:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -33,23 +34,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b304cb8d-c6ec-43a0-b2c5-b7b39c463eec
+      - e28847f3-c22c-4e0a-a90a-1e14dfc7add9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","type":"","name":"K8SPoolConfigZone","description":"","tags":["terraform-test","scaleway_k8s_cluster","zone"],"version":"1.24.5","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"K8SPoolConfigZone","description":"","tags":["terraform-test","scaleway_k8s_cluster","zone"],"version":"1.24.7","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444892645Z","updated_at":"2022-10-25T08:39:25.454744147Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542292Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.538545504Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1329"
@@ -58,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -68,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0804b070-e6d0-4422-833b-68bfd857e8bf
+      - ee0ac32f-ec36-4cb3-ae9e-48a69abb9328
     status: 200 OK
     code: 200
     duration: ""
@@ -77,12 +78,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:39:25.454744Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"creating","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.538546Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1323"
@@ -91,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:25 GMT
+      - Mon, 02 Jan 2023 14:10:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -101,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9305093-ffbf-4e49-a7fa-cb270d3c16bd
+      - 0d0d409a-44f5-40dc-aa02-a8503602d3d5
     status: 200 OK
     code: 200
     duration: ""
@@ -110,12 +111,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:39:28.738896Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:10:33.538546Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1323"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:10:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 91c2c2ba-21a3-4378-abcc-f4534d9f06ae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:10:39.297272Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -124,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -134,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cae7761-16f8-479a-8c00-e2f61ecc0bfa
+      - 67d47926-b0f9-4fb3-99e0-4e0460080f10
     status: 200 OK
     code: 200
     duration: ""
@@ -143,12 +177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:39:28.738896Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:10:39.297272Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -157,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70a9ff15-3c59-46d6-b313-7d5a9808c70d
+      - 142e2f4b-ebae-4cdd-b7b1-05d67a05013d
     status: 200 OK
     code: 200
     duration: ""
@@ -176,12 +210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd6b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVNHhiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMwNDNDa1UwYlVKRGMycHRiRlpaVlROSVJVdFJiazVYUkZaRmMxTjBPVE5uZFdWT1NWQnlOUzlXZDFacFRXdzNkRGRCUTBSbkt6QnRVRkptUVRkSE9DOUtMMUlLTm5oS05sUkhjM1F6TUhaSFlrc3dlbVZIVWtkWE16QndZbXBwTkdsQmFFZE1iMFJQV0U0ck9TdEpibWhvYkV0bWJpdGpUWEpaY205c2FVc3ZRMFpVWlFwUFVuSmpOR0ZTTWsxQk1UQXJjbUZRZUd0c1FrVndVSGhSVjBWVGRTOTRZek5LVFVWNlNEVXJkelZDT0Zka1VtdDJkRFpsUlhaa1prUXhPRnBZU3pBMENtNDNVbXhSYjNwWVVUWlpTa1JxYzJsUGVVMWFUVWxIWldZNFoyeDVZVW81TTJaWFRHTjJkazlRTDAxdloyaHhiV2R6VUZGb1kxa3ZZV1EzUlc1c1dTc0tja1ZCYkc5RGJGWXhVbHBEWmpsaGNYaFBNMDQ0YW1ORlRsZGlNamgwVFVwS1NEUlNSMklyYVVaTGIyMHpVRTF1UWsxT056SkhOMFl2U1hGbU1GZDZZd28yYmxwWlRXdFZkWGhSVm04NWJtUnNPV3RyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOY0hwTU1qRkdiVzU0WTB0dVdEVmFiMVZVYUZrd1YzcEhlWEpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDU2xRMmNHTXpaVXRNZFZGdWMzZGFVVlJUYVZKU2EzTnNSbU5IZFhWeVFtZHFlbkYzWmtoelFXeEhkVTgzTml0S1V3cGpVa3Q0TWpaWE1HZGxTbWhUS3pFeVlubEpRblI2ZUU5dmJVUTVWVk13YjNKWlVVaFdUbkl5WlhwdmFsSnNNbWRYUm5vMFFVZ3dRMjQxTW5Jd1pFMU5Da2RpVVRVMVprTkhObUYyTUVVeVJ6UmtVekJvZEVZM1YwWnlOVFppV1VsVWQyTkRRamxvT0VnemRrVmlRMDFKSzI4M2QwWTNRalE1TW5oQ1NUVlBZWGdLVXpaaVVIQklOM0J5VHpkNlQybDVjVXBuWkV4d00yOTFTVUZZV1d4V1dWVmpSMkV2TUhCak0ycFZSRXhQTkdOQ2RYTlpSVlUwY1N0b1VXVmtibFpQYUFwTWNqSlVUblZCVkVndlQxcEdOVFZuTkVabE4yOXZWRkkwZGpGTVpXVjFZV2hrTXk5RlpIRXdkRE5LWWpsVFQzcHJibVJzVFVKd2VVTlRTR2RLTXpOSkNtOUliRmhyVkROa1NXNWFjMDgzTkN0cVoxUTJhQzkwVTJsSVJGbFNlRVYwVjBaRFRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly84MTFjMzhhYi1kOWMzLTQxNWEtODc2MS1iYTdhYmNmMmE4ZjAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3pvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd6b25lIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3pvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd6b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAwQkxoMWJ0VE9aVHBYYVYzSG5Pd29BTGpRd2FsZ0prZHViOHc2QjM5RmVuenZ2QmhJNVJrZzRyZg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd6b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrOVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQycHFDbE12ZVZkSVZEUk1Nak41T1ZvMVlpdFNZbWRVTlZkbU5qRnVVbWRyVFhsclpHZDFkeXRaTlVOclVGQllZVkZ5ZVdSU1l6aHZNSGxzVDFKQ1NIVlRiRkVLWWtOeFREUm5XRFExY3k5VVJWVmhUek5DZEZCa1RuTmFkSEIzYlV0RFIxSmhXbTVOTkVSYWRVbFBiV0l5WVdzMlRGZENjbmhRWTA1eVZYWlBXa1pJTmdwQ1VFSXdMM1YzU0VKbWJFVlFOQ3MyU1ZRdk1UZDBiMVJ6YUVwWlVYTnhTMEZ0ZVRBeEsyTkxRWE4zTTFKcFRYUXpTMGN2VGxkYVJrWXJMMGRuUWs1UUNuTlBhVlpzZUZNM1pGSk1iMFJhU3k5NVJrbDBieXRJTldwS1VrUnZVVVJ2WjAxTGNtUjVhMWtyWldrdk1FVlFiVVI2VkhnMldEbEVaM2xpYkdsMmRIRUtaMWxyVkVWc1dVWllaRmx5WjFFMlVsVldSVU5JY1hwUlVFZzJTblJMY1RaU1RWTldTaTlpVDNsVVlrbEdZVlI1UkRSMGNrSkJZa2RWUVhWQ2VIRTNZZ3AyV0hZclZtWllNWEV2WlZoVE16ZDNUSFpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIU0hVNWJUVkpWWEJSTjB0TWVuaFNhVk54YmxKd1REZHFUREJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCVmxCWmNtWkRWMU55TjBkbVYyUTVSRWwyVTFscVNVWjRLM1pxUnpRM1kyTmFiSGMxVUhSYVdITTNOM0pWWkU1WGJBcERjR2RSTXpZelFuQjVVQ3QwV1RReWVVUnlWemhOTUU1aWVtNHlRV1pxWlhoNVlsVlpLeXRLY2tSVFlubzJVeXRVVUUxbVNuZHRTamhqTkU5T1JsTnlDalp3UlhCUGJGQjFiR056YUZOQmRXZDFZbk0wYUM5cGJtVktSVUozVVZOelVUTnlVbmhJTVdWQ1lrZHJNRTg0Y1cxb1kwdE9PSFp0VW5OclZEUTFNRkFLTUV0RldHZFdZV1pxTnpBMk0wUk1Sa3ByVTNkU2VGUllaVVJoZEZwSlNVUkpSMEkyUW1WUE0yMUZkbGxtYURFdlpHZHRkM2RHYjFKd2EwVnBNelZtWkFwaFRFdFNXWG8yTkZsVmJYUjBRVWN4UWprcmJWZHVlRk54ZWpoelFYUkphV3hZUm1NcmFXVk9iVzloUzNGclJsUjJhVlozV2tkUFZrSTJlbVZNT1hoekNtbzRhelpqUVcweGFVSjJibXRHWjFZeE1HMTRRbUkzTmpkYWFXNVZlbk0xYUZSVVJBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzAyNDM4NC1lZjRlLTQxMTctYjBjOS00MTJmMTIyYmEzNTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3pvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd6b25lIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3pvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd6b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFbVV1VG93QUJaU2Vsd1hHVEVxcmwzT0hRUVBkWnNOOXdsVndMOFNqUm5Oc2pFVzRCT0JxU2RDaA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2628"
@@ -190,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 132d892d-1938-471c-8795-d32d682f2679
+      - a8050b09-45e0-480e-bff2-5f9705f5f454
     status: 200 OK
     code: 200
     duration: ""
@@ -209,12 +243,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:39:28.738896Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"pool_required","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:10:39.297272Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1328"
@@ -223,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:31 GMT
+      - Mon, 02 Jan 2023 14:10:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0808c034-1e57-47ee-8d68-20d624f3cdf3
+      - 7002e72d-237f-457f-8a86-69d61bf5a9c0
     status: 200 OK
     code: 200
     duration: ""
@@ -244,12 +278,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351/pools
     method: POST
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935836641Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422280718Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "616"
@@ -258,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 14:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -268,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6672f91-359a-42b1-9c33-8c9d917d4efe
+      - ca120ad1-4637-4482-bc58-53895b5bba2b
     status: 200 OK
     code: 200
     duration: ""
@@ -277,12 +311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -291,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:32 GMT
+      - Mon, 02 Jan 2023 14:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -301,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cd0657e-fe22-4ca8-829d-4c8bfec6790f
+      - 249be5bd-7b70-4178-95bd-15d889870aa6
     status: 200 OK
     code: 200
     duration: ""
@@ -310,12 +344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -324,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:38 GMT
+      - Mon, 02 Jan 2023 14:10:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -334,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a307446-c5c0-40b9-a6ba-26c87634ae57
+      - a6a61300-355a-4e0c-bdaf-1f8179af78d6
     status: 200 OK
     code: 200
     duration: ""
@@ -343,12 +377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -357,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:43 GMT
+      - Mon, 02 Jan 2023 14:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -367,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18d986ec-f850-4253-97a3-068e43b31b76
+      - e36123cb-3cf5-414a-9b45-7d1d5ad3f1ce
     status: 200 OK
     code: 200
     duration: ""
@@ -376,12 +410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -390,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:49 GMT
+      - Mon, 02 Jan 2023 14:11:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96305bd5-cd84-4dd7-bac5-613d13bf0a0f
+      - eaf54f3b-7c90-4966-95c5-ccaf9d348a73
     status: 200 OK
     code: 200
     duration: ""
@@ -409,12 +443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -423,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:54 GMT
+      - Mon, 02 Jan 2023 14:11:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -433,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 280c88fb-199a-4e34-a663-38b091ba2e5f
+      - 180b61d1-9f2b-4f0d-a1eb-e5948760e8b6
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -456,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:39:59 GMT
+      - Mon, 02 Jan 2023 14:11:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -466,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e942d51-e563-410f-8082-067315457cb7
+      - b1120d95-df07-4c62-b903-e0245dfcf8a7
     status: 200 OK
     code: 200
     duration: ""
@@ -475,12 +509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -489,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:05 GMT
+      - Mon, 02 Jan 2023 14:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40b8c4e8-0331-4a30-946c-cddfae3c8dec
+      - afc48320-6c4d-416a-87af-9e06ac7209d4
     status: 200 OK
     code: 200
     duration: ""
@@ -508,12 +542,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -522,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:10 GMT
+      - Mon, 02 Jan 2023 14:11:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01ea7b95-9fc1-4297-a33f-c049b61c7f2f
+      - 220d0d8e-1662-483a-a4ea-d08199ed3714
     status: 200 OK
     code: 200
     duration: ""
@@ -541,12 +575,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -555,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:16 GMT
+      - Mon, 02 Jan 2023 14:11:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -565,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 183581b9-ce08-4184-83c3-5958d9a0bef2
+      - a9c0287f-b806-4e2e-8e54-c0a7e9322d96
     status: 200 OK
     code: 200
     duration: ""
@@ -574,12 +608,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -588,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:21 GMT
+      - Mon, 02 Jan 2023 14:11:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d8653bb-e783-4a35-9bc3-4e5ce2965e3b
+      - 3a47764f-e987-4b62-96ca-22505a30cab0
     status: 200 OK
     code: 200
     duration: ""
@@ -607,12 +641,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -621,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:26 GMT
+      - Mon, 02 Jan 2023 14:11:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f84c0f6-fef8-4c56-b7cc-b817ba5a8c0b
+      - a2c11c12-ce3f-40d3-bd38-b377b60dd2e0
     status: 200 OK
     code: 200
     duration: ""
@@ -640,12 +674,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -654,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:32 GMT
+      - Mon, 02 Jan 2023 14:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -664,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a47b7f1-b11c-409f-9840-3cef03b925e1
+      - 8705f473-36ed-4bd6-b7e9-7c2eea08b495
     status: 200 OK
     code: 200
     duration: ""
@@ -673,12 +707,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -687,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:37 GMT
+      - Mon, 02 Jan 2023 14:11:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -697,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6380db23-6b23-4e0e-b184-696e3f2101c9
+      - 27315d02-ae2c-41eb-ba03-15c76a75ed6a
     status: 200 OK
     code: 200
     duration: ""
@@ -706,12 +740,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -720,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:43 GMT
+      - Mon, 02 Jan 2023 14:11:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d42efb2c-802c-4fda-9071-5f21b9b72de7
+      - c9b52b0a-865c-406d-82c6-e537f00a6339
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +773,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -753,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:48 GMT
+      - Mon, 02 Jan 2023 14:11:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cce08093-3a5c-4db3-b339-de6dc10d2c38
+      - a24df8f2-39d1-4909-a730-258739d196c2
     status: 200 OK
     code: 200
     duration: ""
@@ -772,12 +806,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -786,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:53 GMT
+      - Mon, 02 Jan 2023 14:12:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd1aeed4-5029-479e-b9b0-3e5cb708f891
+      - 3ca0fc33-fac4-4e0c-86c9-e1f7686ac8ae
     status: 200 OK
     code: 200
     duration: ""
@@ -805,12 +839,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -819,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:40:59 GMT
+      - Mon, 02 Jan 2023 14:12:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e00b2f2-8c66-4dd6-837a-eb3a60faa31f
+      - a931411a-b16f-47dc-a919-0b6112d83c11
     status: 200 OK
     code: 200
     duration: ""
@@ -838,12 +872,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -852,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:04 GMT
+      - Mon, 02 Jan 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 996fed8f-dd28-4c99-bbb8-16c0874091e2
+      - 574d06c2-fa80-44db-84ba-3a08aea4bd12
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -885,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:10 GMT
+      - Mon, 02 Jan 2023 14:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a04b841-5926-4afe-b258-fe5325280f75
+      - bf9eb0e6-397f-4ff5-abd0-9dd290a6edf2
     status: 200 OK
     code: 200
     duration: ""
@@ -904,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -918,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:15 GMT
+      - Mon, 02 Jan 2023 14:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af49b188-0367-4110-8985-6ccb4f525146
+      - 2bdfddd5-b515-4eb4-8002-ac5d0a24f319
     status: 200 OK
     code: 200
     duration: ""
@@ -937,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -951,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:21 GMT
+      - Mon, 02 Jan 2023 14:12:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e5169a3-ae00-43fc-8f01-e2c2cb91df37
+      - b11e80f0-3ab9-445e-873a-4fd3bc3c68e5
     status: 200 OK
     code: 200
     duration: ""
@@ -970,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -984,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:26 GMT
+      - Mon, 02 Jan 2023 14:12:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 226b2cd2-5aed-457a-a6a7-bae5177091e5
+      - c0306183-ca97-4a40-bba9-51f7f863daad
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1017,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:31 GMT
+      - Mon, 02 Jan 2023 14:12:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8acdb54d-3ea1-4c16-9210-384c3408c3c4
+      - effd2628-ec17-4a91-8050-177c895e8442
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1050,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:36 GMT
+      - Mon, 02 Jan 2023 14:12:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7f9ed37-874c-478c-9531-86acf0e69450
+      - 9a0b01b9-8d10-493b-a101-fe20200547de
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1083,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:42 GMT
+      - Mon, 02 Jan 2023 14:12:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 605f9ee2-7953-4428-b069-1a2dd571c6be
+      - a19441fb-4aad-4dbf-89f1-c85e240b76bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1116,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:47 GMT
+      - Mon, 02 Jan 2023 14:12:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d38d99cc-5744-415f-bda5-2425e44f44a0
+      - 8d6ee6be-ee5f-4c7f-914f-5e0d3450a974
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1149,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:53 GMT
+      - Mon, 02 Jan 2023 14:12:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bb65468-3f3e-4dc0-8a04-5d3b378d1a43
+      - 9c8fd94d-6b29-47b4-a767-8cf18dba2767
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,12 +1202,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1182,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:41:58 GMT
+      - Mon, 02 Jan 2023 14:13:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 641e66c8-4d5f-4370-ac9f-44a68bab8171
+      - 203993d1-224b-4bb2-ab4f-4f429d0576fe
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,12 +1235,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1215,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:03 GMT
+      - Mon, 02 Jan 2023 14:13:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bb3c796-dd3c-4c83-a70e-8897310d8c49
+      - bce2fe73-39d6-481c-890f-bcc76ace92f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,12 +1268,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1248,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:08 GMT
+      - Mon, 02 Jan 2023 14:13:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7849bafb-4be7-4cb5-a6f9-9eeb632e1fb8
+      - 950747c3-1d72-4db7-96f2-fd358ef432e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,12 +1301,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1281,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:13 GMT
+      - Mon, 02 Jan 2023 14:13:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05dea529-cd15-4da2-9a2d-bf06b7bab24b
+      - ba6cce4f-3ebb-461c-baa2-faf7643c1361
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1314,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:19 GMT
+      - Mon, 02 Jan 2023 14:13:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 227218eb-74e3-438e-a1ae-539464cda163
+      - 7e72c3ac-a785-4cc7-b190-f1b5190a3ce4
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1347,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:24 GMT
+      - Mon, 02 Jan 2023 14:13:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2af883d-6b1b-4d57-b261-0dd55507c9f6
+      - e7f0c69f-c003-436e-9052-60d4dd4b9bd4
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,12 +1400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1380,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:30 GMT
+      - Mon, 02 Jan 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b51c065f-cc00-4421-85c5-ae717f6789fe
+      - a5b3c1fe-bb5a-440a-b393-64b89aa5950d
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,12 +1433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1413,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:35 GMT
+      - Mon, 02 Jan 2023 14:13:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aad35a2a-616a-4b59-ae58-de05d2284a69
+      - 39acac4d-29b1-4f1b-a20a-206e5205f4c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,12 +1466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1446,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:41 GMT
+      - Mon, 02 Jan 2023 14:13:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d00e5288-dd01-41bb-a417-e7bd69177621
+      - ad1ed53e-11f1-4aa3-b68b-ed4256a47e79
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,12 +1499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1479,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:46 GMT
+      - Mon, 02 Jan 2023 14:13:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ddd7882-3d3a-4a58-997c-dbaf393dc943
+      - 6e13b3c9-ee23-4961-938c-0a947581dcc2
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,12 +1532,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1512,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:52 GMT
+      - Mon, 02 Jan 2023 14:13:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1124006-af02-43f8-b9a6-8399c4ed8641
+      - d556fadd-b57c-4cbd-a7dd-1052f15854c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,12 +1565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1545,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:42:57 GMT
+      - Mon, 02 Jan 2023 14:13:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d51d622-1dc6-4671-9c28-86aa5c71e62c
+      - 9931a7a9-5ff7-4eb6-8d8d-d0770acfbc08
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,12 +1598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1578,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:02 GMT
+      - Mon, 02 Jan 2023 14:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e72f423-b939-42b0-9f20-fcc8c9053c50
+      - 91c63624-da51-49d4-bb9e-97a320254c9e
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,12 +1631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1611,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:08 GMT
+      - Mon, 02 Jan 2023 14:14:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c42fc69-1f8c-4fff-959b-34aff524458c
+      - 0524642b-0825-4f72-85ae-59177047b65a
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,12 +1664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1644,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:13 GMT
+      - Mon, 02 Jan 2023 14:14:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6056600f-f3d1-430f-bcae-d8e541a05ebb
+      - 45293a89-474f-4227-b80f-083284d83281
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,12 +1697,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1677,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:19 GMT
+      - Mon, 02 Jan 2023 14:14:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b27c382-9079-430c-a5de-85888ecbf944
+      - 4470b36e-c414-4ac0-8f13-14a4e6fcc454
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,12 +1730,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1710,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:24 GMT
+      - Mon, 02 Jan 2023 14:14:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a82b9b90-7f5b-4d9a-9a7a-2f434e92049c
+      - 9074ffe6-aa26-4150-8b4f-6be2ada68fa7
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1763,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1743,7 +1777,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:29 GMT
+      - Mon, 02 Jan 2023 14:14:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e78bbc7c-8c7a-497d-b7e8-72d447e186f5
+      - d204356a-8a6b-4fe0-a09f-582fac95bd86
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,12 +1796,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1776,7 +1810,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:34 GMT
+      - Mon, 02 Jan 2023 14:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edec527a-c565-4761-b946-e243b3d5b081
+      - eecec90b-bd8b-417d-ba94-6b8074da3634
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,12 +1829,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:39:31.935837Z","name":"default","status":"scaling","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "613"
@@ -1809,7 +1843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:40 GMT
+      - Mon, 02 Jan 2023 14:14:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 157cbd5e-0222-4e1d-878e-aa1bea7db490
+      - 5634dffd-b148-4297-8d30-fb1330a6dd04
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,12 +1862,177 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:43:43.419463Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "613"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 27b1c57d-a5f6-4081-bd7b-e73849734b9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "613"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6eb887c8-1c7e-4492-9d8d-eeb98b33082f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "613"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aa2cf437-e193-4412-b5d3-20b445a04984
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "613"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 227fc452-9b14-474d-8e70-9576eb1c3855
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:10:44.422281Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "613"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a8fa2863-3e51-47c4-89e2-6024255522df
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:15:05.509633Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "611"
@@ -1842,7 +2041,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:45 GMT
+      - Mon, 02 Jan 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +2051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - faaa7d2b-7981-4e9f-8790-f63075ddc292
+      - 90fd3f49-f731-4e77-a163-3749f5137d03
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,12 +2060,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:40:33.070338Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:11:45.692989Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -1875,7 +2074,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:46 GMT
+      - Mon, 02 Jan 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +2084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 084c5e30-acd7-4593-abbe-02e0f52828ab
+      - e9c756bd-3c5e-4fce-bd8e-313001b6a59b
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,12 +2093,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:43:43.419463Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:15:05.509633Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "611"
@@ -1908,7 +2107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:46 GMT
+      - Mon, 02 Jan 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b536ccea-9633-44a2-8884-118a7965601a
+      - 91784389-73af-49fb-8db0-2494eeb90005
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,12 +2126,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0/nodes?order_by=created_at_asc&page=1&pool_id=d596f35b-dc33-49f5-8ea7-6b737f8bcdc5&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351/nodes?order_by=created_at_asc&page=1&pool_id=955e96ba-02a1-4252-8514-85479bfb50c2&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"1f32afbf-1678-40b1-9d44-4b18284e58ee","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:41:20.922093Z","updated_at":"2022-10-25T08:43:43.344653Z","pool_id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigzone-default-1f32afbf167840b1","public_ip_v4":"51.159.151.134","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-2/c9ab3a8c-564c-499e-94ca-fd349b12e920","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:35.519507Z","error_message":null,"id":"be8ab660-dd6f-427b-bd1b-b079417a4487","name":"scw-k8spoolconfigzone-default-be8ab660dd6f427b","pool_id":"955e96ba-02a1-4252-8514-85479bfb50c2","provider_id":"scaleway://instance/fr-par-2/b5590358-1914-4990-b055-b3b394cdc918","public_ip_v4":"51.159.166.208","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:05.496514Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -1941,7 +2140,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:46 GMT
+      - Mon, 02 Jan 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1951,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afb6db48-a468-4afd-a3c9-074609fb3ef6
+      - 22931671-f8ea-43e5-b835-9f09e4ccfe38
     status: 200 OK
     code: 200
     duration: ""
@@ -1960,12 +2159,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:40:33.070338Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:11:45.692989Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -1974,7 +2173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:46 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1984,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b9f22ae-f473-4e57-8fb2-f2d2530c91ac
+      - af64624a-e4be-4af2-bdad-9feed1943692
     status: 200 OK
     code: 200
     duration: ""
@@ -1993,12 +2192,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:43:43.419463Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:15:05.509633Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "611"
@@ -2007,7 +2206,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:47 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2017,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e40b5c8-027d-448f-a763-3af0cc8acc2a
+      - 7d21127a-e9ba-427f-9841-c75d07f0a0f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,12 +2225,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:40:33.070338Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"ready","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:11:45.692989Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1320"
@@ -2040,7 +2239,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:48 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2050,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79590a8d-a15b-4dd9-b6a6-8edd03c1e95e
+      - cc2e2a5c-78dd-43b8-a4d4-c94e8e702a15
     status: 200 OK
     code: 200
     duration: ""
@@ -2059,12 +2258,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351/kubeconfig
     method: GET
   response:
-    body: '{"name":"kubeconfig","content_type":"application/octet-stream","content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd6b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYbE9SRUUwVFhwcmVVNHhiMWhFVkUxNVRWUkJlVTVFUVRSTmVtdDVUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMwNDNDa1UwYlVKRGMycHRiRlpaVlROSVJVdFJiazVYUkZaRmMxTjBPVE5uZFdWT1NWQnlOUzlXZDFacFRXdzNkRGRCUTBSbkt6QnRVRkptUVRkSE9DOUtMMUlLTm5oS05sUkhjM1F6TUhaSFlrc3dlbVZIVWtkWE16QndZbXBwTkdsQmFFZE1iMFJQV0U0ck9TdEpibWhvYkV0bWJpdGpUWEpaY205c2FVc3ZRMFpVWlFwUFVuSmpOR0ZTTWsxQk1UQXJjbUZRZUd0c1FrVndVSGhSVjBWVGRTOTRZek5LVFVWNlNEVXJkelZDT0Zka1VtdDJkRFpsUlhaa1prUXhPRnBZU3pBMENtNDNVbXhSYjNwWVVUWlpTa1JxYzJsUGVVMWFUVWxIWldZNFoyeDVZVW81TTJaWFRHTjJkazlRTDAxdloyaHhiV2R6VUZGb1kxa3ZZV1EzUlc1c1dTc0tja1ZCYkc5RGJGWXhVbHBEWmpsaGNYaFBNMDQ0YW1ORlRsZGlNamgwVFVwS1NEUlNSMklyYVVaTGIyMHpVRTF1UWsxT056SkhOMFl2U1hGbU1GZDZZd28yYmxwWlRXdFZkWGhSVm04NWJtUnNPV3RyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOY0hwTU1qRkdiVzU0WTB0dVdEVmFiMVZVYUZrd1YzcEhlWEpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDU2xRMmNHTXpaVXRNZFZGdWMzZGFVVlJUYVZKU2EzTnNSbU5IZFhWeVFtZHFlbkYzWmtoelFXeEhkVTgzTml0S1V3cGpVa3Q0TWpaWE1HZGxTbWhUS3pFeVlubEpRblI2ZUU5dmJVUTVWVk13YjNKWlVVaFdUbkl5WlhwdmFsSnNNbWRYUm5vMFFVZ3dRMjQxTW5Jd1pFMU5Da2RpVVRVMVprTkhObUYyTUVVeVJ6UmtVekJvZEVZM1YwWnlOVFppV1VsVWQyTkRRamxvT0VnemRrVmlRMDFKSzI4M2QwWTNRalE1TW5oQ1NUVlBZWGdLVXpaaVVIQklOM0J5VHpkNlQybDVjVXBuWkV4d00yOTFTVUZZV1d4V1dWVmpSMkV2TUhCak0ycFZSRXhQTkdOQ2RYTlpSVlUwY1N0b1VXVmtibFpQYUFwTWNqSlVUblZCVkVndlQxcEdOVFZuTkVabE4yOXZWRkkwZGpGTVpXVjFZV2hrTXk5RlpIRXdkRE5LWWpsVFQzcHJibVJzVFVKd2VVTlRTR2RLTXpOSkNtOUliRmhyVkROa1NXNWFjMDgzTkN0cVoxUTJhQzkwVTJsSVJGbFNlRVYwVjBaRFRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly84MTFjMzhhYi1kOWMzLTQxNWEtODc2MS1iYTdhYmNmMmE4ZjAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3pvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd6b25lIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3pvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd6b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAwQkxoMWJ0VE9aVHBYYVYzSG5Pd29BTGpRd2FsZ0prZHViOHc2QjM5RmVuenZ2QmhJNVJrZzRyZg=="}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4c3Bvb2xjb25maWd6b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxRVJYZE5WRVV3VFZSQmVrOVdiMWhFVkUxNlRVUkZkMDFVUlRCTlZFRjZUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQycHFDbE12ZVZkSVZEUk1Nak41T1ZvMVlpdFNZbWRVTlZkbU5qRnVVbWRyVFhsclpHZDFkeXRaTlVOclVGQllZVkZ5ZVdSU1l6aHZNSGxzVDFKQ1NIVlRiRkVLWWtOeFREUm5XRFExY3k5VVJWVmhUek5DZEZCa1RuTmFkSEIzYlV0RFIxSmhXbTVOTkVSYWRVbFBiV0l5WVdzMlRGZENjbmhRWTA1eVZYWlBXa1pJTmdwQ1VFSXdMM1YzU0VKbWJFVlFOQ3MyU1ZRdk1UZDBiMVJ6YUVwWlVYTnhTMEZ0ZVRBeEsyTkxRWE4zTTFKcFRYUXpTMGN2VGxkYVJrWXJMMGRuUWs1UUNuTlBhVlpzZUZNM1pGSk1iMFJhU3k5NVJrbDBieXRJTldwS1VrUnZVVVJ2WjAxTGNtUjVhMWtyWldrdk1FVlFiVVI2VkhnMldEbEVaM2xpYkdsMmRIRUtaMWxyVkVWc1dVWllaRmx5WjFFMlVsVldSVU5JY1hwUlVFZzJTblJMY1RaU1RWTldTaTlpVDNsVVlrbEdZVlI1UkRSMGNrSkJZa2RWUVhWQ2VIRTNZZ3AyV0hZclZtWllNWEV2WlZoVE16ZDNUSFpGUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIU0hVNWJUVkpWWEJSTjB0TWVuaFNhVk54YmxKd1REZHFUREJOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCVmxCWmNtWkRWMU55TjBkbVYyUTVSRWwyVTFscVNVWjRLM1pxUnpRM1kyTmFiSGMxVUhSYVdITTNOM0pWWkU1WGJBcERjR2RSTXpZelFuQjVVQ3QwV1RReWVVUnlWemhOTUU1aWVtNHlRV1pxWlhoNVlsVlpLeXRLY2tSVFlubzJVeXRVVUUxbVNuZHRTamhqTkU5T1JsTnlDalp3UlhCUGJGQjFiR056YUZOQmRXZDFZbk0wYUM5cGJtVktSVUozVVZOelVUTnlVbmhJTVdWQ1lrZHJNRTg0Y1cxb1kwdE9PSFp0VW5OclZEUTFNRkFLTUV0RldHZFdZV1pxTnpBMk0wUk1Sa3ByVTNkU2VGUllaVVJoZEZwSlNVUkpSMEkyUW1WUE0yMUZkbGxtYURFdlpHZHRkM2RHYjFKd2EwVnBNelZtWkFwaFRFdFNXWG8yTkZsVmJYUjBRVWN4UWprcmJWZHVlRk54ZWpoelFYUkphV3hZUm1NcmFXVk9iVzloUzNGclJsUjJhVlozV2tkUFZrSTJlbVZNT1hoekNtbzRhelpqUVcweGFVSjJibXRHWjFZeE1HMTRRbUkzTmpkYWFXNVZlbk0xYUZSVVJBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzAyNDM4NC1lZjRlLTQxMTctYjBjOS00MTJmMTIyYmEzNTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AazhzcG9vbGNvbmZpZ3pvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogIms4c3Bvb2xjb25maWd6b25lIgogICAgdXNlcjogazhzcG9vbGNvbmZpZ3pvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBrOHNwb29sY29uZmlnem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IGs4c3Bvb2xjb25maWd6b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFbVV1VG93QUJaU2Vsd1hHVEVxcmwzT0hRUVBkWnNOOXdsVndMOFNqUm5Oc2pFVzRCT0JxU2RDaA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2628"
@@ -2073,7 +2272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:48 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2083,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c73eaa0b-deab-4db1-a16a-a1011b0b1755
+      - 4b29b13c-eb52-4d03-85b5-05f30705d1b9
     status: 200 OK
     code: 200
     duration: ""
@@ -2092,12 +2291,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: GET
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:43:43.419463Z","name":"default","status":"ready","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:15:05.509633Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "611"
@@ -2106,7 +2305,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:48 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2116,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f883253f-587c-4312-94ae-c5265f3cc5d1
+      - bee6b305-2cd6-4020-b058-10b1108965eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2125,12 +2324,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0/nodes?order_by=created_at_asc&page=1&pool_id=d596f35b-dc33-49f5-8ea7-6b737f8bcdc5&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351/nodes?order_by=created_at_asc&page=1&pool_id=955e96ba-02a1-4252-8514-85479bfb50c2&status=unknown
     method: GET
   response:
-    body: '{"total_count":1,"nodes":[{"region":"fr-par","id":"1f32afbf-1678-40b1-9d44-4b18284e58ee","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:41:20.922093Z","updated_at":"2022-10-25T08:43:43.344653Z","pool_id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","status":"ready","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"name":"scw-k8spoolconfigzone-default-1f32afbf167840b1","public_ip_v4":"51.159.151.134","public_ip_v6":null,"provider_id":"scaleway://instance/fr-par-2/c9ab3a8c-564c-499e-94ca-fd349b12e920","error_message":null}]}'
+    body: '{"nodes":[{"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-01-02T14:12:35.519507Z","error_message":null,"id":"be8ab660-dd6f-427b-bd1b-b079417a4487","name":"scw-k8spoolconfigzone-default-be8ab660dd6f427b","pool_id":"955e96ba-02a1-4252-8514-85479bfb50c2","provider_id":"scaleway://instance/fr-par-2/b5590358-1914-4990-b055-b3b394cdc918","public_ip_v4":"51.159.166.208","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-01-02T14:15:05.496514Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "606"
@@ -2139,7 +2338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:49 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb9eba12-bae0-476d-af3c-2e525bcd1890
+      - 656acc19-1e68-4dfb-bb07-42533d910ffb
     status: 200 OK
     code: 200
     duration: ""
@@ -2158,12 +2357,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d596f35b-dc33-49f5-8ea7-6b737f8bcdc5
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/955e96ba-02a1-4252-8514-85479bfb50c2
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"d596f35b-dc33-49f5-8ea7-6b737f8bcdc5","cluster_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","created_at":"2022-10-25T08:39:31.925488Z","updated_at":"2022-10-25T08:43:50.261607627Z","name":"default","status":"deleting","version":"1.24.5","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"placement_group_id":null,"kubelet_args":{},"upgrade_policy":{"max_unavailable":1,"max_surge":0},"zone":"fr-par-2","root_volume_type":"l_ssd","root_volume_size":150000000000}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d3024384-ef4e-4117-b0c9-412f122ba351","container_runtime":"containerd","created_at":"2023-01-02T14:10:44.402775Z","id":"955e96ba-02a1-4252-8514-85479bfb50c2","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-01-02T14:15:10.763463470Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.24.7","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "617"
@@ -2172,7 +2371,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:50 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc44a5e0-fdae-4276-b510-be72cd91e3ba
+      - ff0a0842-db58-45ad-8b67-848779fd4563
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,12 +2390,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:43:50.576063835Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:15:10.824571862Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1326"
@@ -2205,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:50 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2215,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15c0c897-8c13-4a61-a126-82fbff9bd736
+      - 374de875-67cc-4c03-978e-6df34baeb1ed
     status: 200 OK
     code: 200
     duration: ""
@@ -2224,12 +2423,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:43:50.576064Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:15:10.824572Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1323"
@@ -2238,7 +2437,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:50 GMT
+      - Mon, 02 Jan 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2248,7 +2447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b35620e2-463d-42cb-ad05-986705962537
+      - 469b0cd9-2581-493d-9b71-90d8a5871b83
     status: 200 OK
     code: 200
     duration: ""
@@ -2257,12 +2456,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"region":"fr-par","id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","created_at":"2022-10-25T08:39:25.444893Z","updated_at":"2022-10-25T08:43:50.576064Z","type":"kapsule","name":"K8SPoolConfigZone","description":"","status":"deleting","version":"1.24.5","cni":"cilium","tags":["terraform-test","scaleway_k8s_cluster","zone"],"cluster_url":"https://811c38ab-d9c3-415a-8761-ba7abcf2a8f0.api.k8s.fr-par.scw.cloud:6443","dns_wildcard":"*.811c38ab-d9c3-415a-8761-ba7abcf2a8f0.nodes.k8s.fr-par.scw.cloud","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":"10m","estimator":"binpacking","expander":"random","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5,"max_graceful_termination_sec":0},"dashboard_enabled":false,"ingress":"none","auto_upgrade":{"enabled":false,"maintenance_window":{"start_hour":0,"day":"any"}},"upgrade_available":false,"feature_gates":[],"admission_plugins":[],"open_id_connect_config":{"issuer_url":"","client_id":"","username_claim":"","username_prefix":"","groups_claim":[],"groups_prefix":"","required_claim":[]},"apiserver_cert_sans":[]}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:15:10.824572Z","upgrade_available":false,"version":"1.24.7"}'
     headers:
       Content-Length:
       - "1323"
@@ -2271,7 +2470,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:43:56 GMT
+      - Mon, 02 Jan 2023 14:15:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2281,7 +2480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98c759de-e5f6-49fc-a52c-0be03be3e1b8
+      - 4104bc98-270b-471b-b637-085d1b5aba1d
     status: 200 OK
     code: 200
     duration: ""
@@ -2290,12 +2489,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d3024384-ef4e-4117-b0c9-412f122ba351.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-01-02T14:10:33.532542Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d3024384-ef4e-4117-b0c9-412f122ba351.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d3024384-ef4e-4117-b0c9-412f122ba351","ingress":"none","name":"K8SPoolConfigZone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-01-02T14:15:10.824572Z","upgrade_available":false,"version":"1.24.7"}'
+    headers:
+      Content-Length:
+      - "1323"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 02 Jan 2023 14:15:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b8c53de2-5382-442d-9517-7554b9eae4ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d3024384-ef4e-4117-b0c9-412f122ba351","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2304,7 +2536,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:01 GMT
+      - Mon, 02 Jan 2023 14:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e68409fc-8046-45ce-970f-620738a4fb90
+      - b906ecf1-4508-45f8-affc-08a09f4824fc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2323,12 +2555,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/811c38ab-d9c3-415a-8761-ba7abcf2a8f0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d3024384-ef4e-4117-b0c9-412f122ba351
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"811c38ab-d9c3-415a-8761-ba7abcf2a8f0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d3024384-ef4e-4117-b0c9-412f122ba351","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2337,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Oct 2022 08:44:02 GMT
+      - Mon, 02 Jan 2023 14:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db4f740b-2024-4382-b238-73e045c227d0
+      - 3090fb1d-cf66-4b69-80cc-1198a14b646a
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
As suggested in issue [#959](https://github.com/scaleway/terraform-provider-scaleway/issues/959), the cluster attribute "delete_additional_resources" is now required instead of optional.