### PR TITLE
docs(bucket): make acl deprecation message clearer

### DIFF
--- a/docs/resources/object_bucket.md
+++ b/docs/resources/object_bucket.md
@@ -116,7 +116,7 @@ The following arguments are supported:
 * `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 * `force_destroy` - (Optional) Enable deletion of objects in bucket before destroying, locked objects or under legal hold are also deleted and **not** recoverable
 
-The `acl` attribute is deprecated. See [scaleway_object_bucket_acl](object_bucket_acl) resource documentation.
+The `acl` attribute is deprecated. See [scaleway_object_bucket_acl](object_bucket_acl.md) resource documentation.
 Please check the [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl_overview.html#canned-acl) documentation for supported values.
 
 The `CORS` object supports the following:

--- a/docs/resources/object_bucket.md
+++ b/docs/resources/object_bucket.md
@@ -14,7 +14,6 @@ For more information, see [the documentation](https://www.scaleway.com/en/docs/o
 ```hcl
 resource "scaleway_object_bucket" "some_bucket" {
   name = "some-unique-name"
-  acl  = "private"
   tags = {
     key = "value"
   }
@@ -27,7 +26,6 @@ resource "scaleway_object_bucket" "some_bucket" {
 resource "scaleway_object_bucket" "main"{
   name = "mybuckectid"
   region = "fr-par"
-  acl = "private"
   
   # This lifecycle configuration rule will make that all objects that got a filter key that start with (path1/) be transferred
   # from their default storage class (STANDARD, ONEZONE_IA) to GLACIER after 120 days counting 
@@ -112,15 +110,14 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the bucket.
 * `tags` - (Optional) A list of tags (key / value) for the bucket.
-* `acl` - (Optional) The canned ACL you want to apply to the bucket.
+* `acl` - (Optional)(Deprecated) The canned ACL you want to apply to the bucket.
 * `region` - (Optional) The [region](https://developers.scaleway.com/en/quickstart/#region-definition) in which the bucket should be created.
 * `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
 * `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 * `force_destroy` - (Optional) Enable deletion of objects in bucket before destroying, locked objects or under legal hold are also deleted and **not** recoverable
 
-## The ACL
-
-Please check the [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl_overview.html#canned-acl)
+The `acl` attribute is deprecated. See [scaleway_object_bucket_acl](object_bucket_acl) resource documentation.
+Please check the [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl_overview.html#canned-acl) documentation for supported values.
 
 The `CORS` object supports the following:
 

--- a/docs/resources/object_bucket_acl.md
+++ b/docs/resources/object_bucket_acl.md
@@ -4,7 +4,7 @@ description: |-
 Manages Scaleway object storage bucket ACL resource.
 ---
 
-# scaleway_object_bucket
+# scaleway_object_bucket_acl
 
 Creates and manages Scaleway object storage bucket ACL.
 For more information, see [the documentation](https://www.scaleway.com/en/docs/storage/object/concepts/#access-control-list-(acl)).

--- a/scaleway/resource_object_bucket.go
+++ b/scaleway/resource_object_bucket.go
@@ -54,7 +54,7 @@ func resourceScalewayObjectBucket() *schema.Resource {
 					s3.ObjectCannedACLPublicReadWrite,
 					s3.ObjectCannedACLAuthenticatedRead,
 				}, false),
-				Deprecated: "ACL is deprecated. Please use resource_bucket_acl instead.",
+				Deprecated: "ACL attribute is deprecated. Please use the resource scaleway_object_bucket_acl instead.",
 			},
 			"tags": {
 				Type: schema.TypeMap,


### PR DESCRIPTION
The previous deprecation message was not clear from a user point of view. Update it for users to be clearer.

Also update the docs of the provider.