### PR TITLE
tests: change region in tests that require registry ns deletion

### DIFF
--- a/scaleway/data_source_registry_namespace_test.go
+++ b/scaleway/data_source_registry_namespace_test.go
@@ -18,14 +18,17 @@ func TestAccScalewayDataSourceRegistryNamespace_Basic(t *testing.T) {
 			{
 				Config: `
 					resource "scaleway_registry_namespace" "reg00" {
+						region = "pl-waw"
 						name = "test-cr-data"
 					}
 					
 					data "scaleway_registry_namespace" "regData01" {
+						region = "pl-waw"
 						name = scaleway_registry_namespace.reg00.name
 					}
 					
 					data "scaleway_registry_namespace" "regData02" {
+						region = "pl-waw"
 						namespace_id = scaleway_registry_namespace.reg00.id
 					}
 				`,
@@ -47,15 +50,18 @@ func TestAccScalewayDataSourceRegistryNamespace_Basic(t *testing.T) {
 			{
 				Config: `
 					resource "scaleway_registry_namespace" "reg00" {
+						region = "pl-waw"
 						name = "test-cr-data"
 						is_public = "true"
 					}
 					
 					data "scaleway_registry_namespace" "regData01" {
+						region = "pl-waw"
 						name = scaleway_registry_namespace.reg00.name
 					}
 					
 					data "scaleway_registry_namespace" "regData02" {
+						region = "pl-waw"
 						namespace_id = scaleway_registry_namespace.reg00.id
 					}
 				`,

--- a/scaleway/resource_container_namespace_test.go
+++ b/scaleway/resource_container_namespace_test.go
@@ -176,6 +176,7 @@ func TestAccScalewayContainerNamespace_DestroyRegistry(t *testing.T) {
 			{
 				Config: `
 					resource scaleway_container_namespace main {
+						region = "pl-waw"
 						name = "test-cr-ns-01"
 						destroy_registry = true
 					}

--- a/scaleway/resource_registry_namespace_test.go
+++ b/scaleway/resource_registry_namespace_test.go
@@ -55,6 +55,7 @@ func TestAccScalewayRegistryNamespace_Basic(t *testing.T) {
 			{
 				Config: `
 					resource scaleway_registry_namespace cr01 {
+						region = "pl-waw"
 						name = "test-cr-ns-01"
 					}
 				`,
@@ -67,6 +68,7 @@ func TestAccScalewayRegistryNamespace_Basic(t *testing.T) {
 			{
 				Config: `
 					resource scaleway_registry_namespace cr01 {
+						region = "pl-waw"
 						name = "test-cr-ns-01"
 						description = "test registry namespace 01"
 						is_public = true

--- a/scaleway/testdata/container-namespace-destroy-registry.cassette.yaml
+++ b/scaleway/testdata/container-namespace-destroy-registry.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":null}'
+    body: '{"name":"test-cr-ns-01","environment_variables":{},"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","description":null,"secret_environment_variables":[]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces
     method: POST
   response:
-    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    body: '{"description":"","environment_variables":{},"error_message":null,"id":"bb2ee806-26e6-446a-8252-cb1af94fe215","name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
     headers:
       Content-Length:
       - "363"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:50 GMT
+      - Mon, 23 Jan 2023 09:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3918770b-2ef6-4646-acdf-311c7ddb54cf
+      - 580e83c0-fcb0-4235-b17e-3c28c297bb5d
     status: 200 OK
     code: 200
     duration: ""
@@ -41,12 +41,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: GET
   response:
-    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"pending","registry_namespace_id":"","error_message":null,"registry_endpoint":"","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    body: '{"description":"","environment_variables":{},"error_message":null,"id":"bb2ee806-26e6-446a-8252-cb1af94fe215","name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","registry_endpoint":"","registry_namespace_id":"","secret_environment_variables":[],"status":"pending"}'
     headers:
       Content-Length:
       - "363"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:51 GMT
+      - Mon, 23 Jan 2023 09:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f01b1c14-a077-4ed1-a793-064152f7a879
+      - 1be6097e-ccf6-4985-9b24-34004c48df66
     status: 200 OK
     code: 200
     duration: ""
@@ -74,12 +74,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: GET
   response:
-    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    body: '{"description":"","environment_variables":{},"error_message":null,"id":"bb2ee806-26e6-446a-8252-cb1af94fe215","name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01vkgqc4qe","registry_namespace_id":"c1a87f29-c3a3-4f68-bd43-2859a701426f","secret_environment_variables":[],"status":"ready"}'
     headers:
       Content-Length:
       - "442"
@@ -88,7 +88,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:56 GMT
+      - Mon, 23 Jan 2023 09:57:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b56b750-2e37-40e4-9125-8a3d9a07c1e7
+      - 02973fda-91e7-45eb-b4a1-0963182a5e1c
     status: 200 OK
     code: 200
     duration: ""
@@ -107,12 +107,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: GET
   response:
-    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    body: '{"description":"","environment_variables":{},"error_message":null,"id":"bb2ee806-26e6-446a-8252-cb1af94fe215","name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01vkgqc4qe","registry_namespace_id":"c1a87f29-c3a3-4f68-bd43-2859a701426f","secret_environment_variables":[],"status":"ready"}'
     headers:
       Content-Length:
       - "442"
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:56 GMT
+      - Mon, 23 Jan 2023 09:57:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dda9cde2-2106-4af5-918b-cb054c17beb8
+      - 46e52892-0d84-4abb-afad-61870a8bf7f8
     status: 200 OK
     code: 200
     duration: ""
@@ -140,12 +140,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: GET
   response:
-    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    body: '{"description":"","environment_variables":{},"error_message":null,"id":"bb2ee806-26e6-446a-8252-cb1af94fe215","name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01vkgqc4qe","registry_namespace_id":"c1a87f29-c3a3-4f68-bd43-2859a701426f","secret_environment_variables":[],"status":"ready"}'
     headers:
       Content-Length:
       - "442"
@@ -154,7 +154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:57 GMT
+      - Mon, 23 Jan 2023 09:57:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7de0eee6-a39f-47d0-aa97-bf811a459258
+      - d7da4d77-3a95-4279-afb2-5d2bbc69677a
     status: 200 OK
     code: 200
     duration: ""
@@ -173,12 +173,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: GET
   response:
-    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    body: '{"description":"","environment_variables":{},"error_message":null,"id":"bb2ee806-26e6-446a-8252-cb1af94fe215","name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01vkgqc4qe","registry_namespace_id":"c1a87f29-c3a3-4f68-bd43-2859a701426f","secret_environment_variables":[],"status":"ready"}'
     headers:
       Content-Length:
       - "442"
@@ -187,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:57 GMT
+      - Mon, 23 Jan 2023 09:57:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0ec1dd6-d17b-4b8a-9e25-5ab8c134ebb2
+      - 0f581ffa-78f5-4ffd-856f-08aaa2b94e8a
     status: 200 OK
     code: 200
     duration: ""
@@ -206,12 +206,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: GET
   response:
-    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"ready","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    body: '{"description":"","environment_variables":{},"error_message":null,"id":"bb2ee806-26e6-446a-8252-cb1af94fe215","name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01vkgqc4qe","registry_namespace_id":"c1a87f29-c3a3-4f68-bd43-2859a701426f","secret_environment_variables":[],"status":"ready"}'
     headers:
       Content-Length:
       - "442"
@@ -220,7 +220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:58 GMT
+      - Mon, 23 Jan 2023 09:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83bd04c4-b0a6-49ce-bace-868a3785ccad
+      - 9f1017da-42ed-403a-ae00-34cf81591f55
     status: 200 OK
     code: 200
     duration: ""
@@ -239,12 +239,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: DELETE
   response:
-    body: '{"id":"fd8f6d15-ac79-4cab-a179-59374da13f49","name":"test-cr-ns-01","environment_variables":{},"organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","registry_namespace_id":"242f44d4-1c0f-40dd-904c-85ab829f502c","error_message":null,"registry_endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","description":"","secret_environment_variables":[],"region":"fr-par"}'
+    body: '{"description":"","environment_variables":{},"error_message":null,"id":"bb2ee806-26e6-446a-8252-cb1af94fe215","name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","registry_endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01vkgqc4qe","registry_namespace_id":"c1a87f29-c3a3-4f68-bd43-2859a701426f","secret_environment_variables":[],"status":"deleting"}'
     headers:
       Content-Length:
       - "445"
@@ -253,7 +253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:58 GMT
+      - Mon, 23 Jan 2023 09:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -263,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0895b36-cca2-4719-a18e-fe5222bc3561
+      - 622e64d2-8f4e-4a57-a6be-05d93814be86
     status: 200 OK
     code: 200
     duration: ""
@@ -272,9 +272,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: GET
   response:
     body: '{"message":"Namespace was not found"}'
@@ -286,7 +286,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:58 GMT
+      - Mon, 23 Jan 2023 09:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -296,7 +296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f4bf057-ea7e-4731-b7a1-5c598a545f9e
+      - b628c047-0645-4baa-a2c8-25170a3844d9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -305,12 +305,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/242f44d4-1c0f-40dd-904c-85ab829f502c
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/c1a87f29-c3a3-4f68-bd43-2859a701426f
     method: DELETE
   response:
-    body: '{"id":"242f44d4-1c0f-40dd-904c-85ab829f502c","name":"funcscwtestcrns01sgxelf14","description":"","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","status":"deleting","status_message":"","endpoint":"rg.fr-par.scw.cloud/funcscwtestcrns01sgxelf14","is_public":false,"size":0,"created_at":"2022-06-06T13:59:55.618276Z","updated_at":"2022-06-06T13:59:58.693160161Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:57:39.738187Z","description":"","endpoint":"rg.pl-waw.scw.cloud/funcscwtestcrns01vkgqc4qe","id":"c1a87f29-c3a3-4f68-bd43-2859a701426f","image_count":0,"is_public":false,"name":"funcscwtestcrns01vkgqc4qe","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"deleting","status_message":"","updated_at":"2023-01-23T09:57:43.454420715Z"}'
     headers:
       Content-Length:
       - "455"
@@ -319,7 +319,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:58 GMT
+      - Mon, 23 Jan 2023 09:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,7 +329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7295833-82a6-4922-a5c9-625f3f820558
+      - f2e1e7fc-b749-43a2-9235-486a698cd979
     status: 200 OK
     code: 200
     duration: ""
@@ -338,9 +338,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/242f44d4-1c0f-40dd-904c-85ab829f502c
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/c1a87f29-c3a3-4f68-bd43-2859a701426f
     method: GET
   response:
     body: '{"message":"Namespace was not found"}'
@@ -352,7 +352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:58 GMT
+      - Mon, 23 Jan 2023 09:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -362,7 +362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a405ac2-1fd7-46bf-b671-56a3ee48ab94
+      - afa3a7ab-b97a-4c84-a8af-ed0af32d5d61
     status: 404 Not Found
     code: 404
     duration: ""
@@ -371,9 +371,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/containers/v1beta1/regions/fr-par/namespaces/fd8f6d15-ac79-4cab-a179-59374da13f49
+    url: https://api.scaleway.com/containers/v1beta1/regions/pl-waw/namespaces/bb2ee806-26e6-446a-8252-cb1af94fe215
     method: DELETE
   response:
     body: '{"message":"Namespace was not found"}'
@@ -385,7 +385,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:58 GMT
+      - Mon, 23 Jan 2023 09:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -395,7 +395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19725d8f-ef4d-4cd1-9e0f-5d1450399d9e
+      - a1ecb753-6730-409b-a066-22f7d707b0e5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -404,9 +404,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.2; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/242f44d4-1c0f-40dd-904c-85ab829f502c
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/c1a87f29-c3a3-4f68-bd43-2859a701426f
     method: DELETE
   response:
     body: '{"message":"Namespace was not found"}'
@@ -418,7 +418,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Jun 2022 13:59:58 GMT
+      - Mon, 23 Jan 2023 09:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -428,7 +428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f24ec8be-441f-418f-b8f4-cbfcda129235
+      - 65ace3ba-f827-4b9d-b8d2-86fedfe1950b
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-registry-namespace-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-registry-namespace-basic.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"test-cr-data","description":"","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","is_public":false}'
+    body: '{"name":"test-cr-data","description":"","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","is_public":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces
     method: POST
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301091Z","updated_at":"2022-04-12T09:26:08.996301091Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134241856Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134241856Z"}'
     headers:
       Content-Length:
       - "429"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:09 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19e9e907-d819-4adf-a5c0-60eedf8ea7bd
+      - a056a527-dba2-4366-8a12-af5036f5a60c
     status: 200 OK
     code: 200
     duration: ""
@@ -41,12 +41,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:09 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ebb2d2b-ecb0-4b91-b56a-2361e6725234
+      - e98de99b-fc16-41b1-8568-d9921f931e2c
     status: 200 OK
     code: 200
     duration: ""
@@ -74,12 +74,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -88,7 +88,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:09 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4041fc55-660e-4592-8668-8549124c22bf
+      - d533b4d7-71c4-410d-ab04-275257404887
     status: 200 OK
     code: 200
     duration: ""
@@ -107,12 +107,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"namespaces":[{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}],"total_count":1}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
+    headers:
+      Content-Length:
+      - "423"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Jan 2023 09:55:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25f88f14-b4e6-481d-b016-6af9a3434e59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"namespaces":[{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "456"
@@ -121,7 +154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:09 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1628c1b2-b5b2-459d-9287-ff08d0963b43
+      - ec3e4091-9597-40e7-a8ad-fba32eb583b2
     status: 200 OK
     code: 200
     duration: ""
@@ -140,12 +173,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -154,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:09 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75f53a8d-19ff-4691-8428-192b8b5b7c13
+      - a2b2a984-5196-4071-ba42-d9e7d3134b0a
     status: 200 OK
     code: 200
     duration: ""
@@ -173,12 +206,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -187,7 +220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:09 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbb2ebc0-b1d3-4539-8792-fad449e8a04d
+      - 9f433276-24fa-4a99-9104-a0b51a7207c8
     status: 200 OK
     code: 200
     duration: ""
@@ -206,12 +239,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -220,7 +253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:09 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59868e6d-d7a8-4f3a-88da-1c881ee2638a
+      - 58dc1bf2-2f67-48ce-9e64-6bd17dbf3fb1
     status: 200 OK
     code: 200
     duration: ""
@@ -239,45 +272,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "423"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e083cbb5-84d8-44b9-8796-7fd7f6c48dfe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"namespaces":[{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}],"total_count":1}'
+    body: '{"namespaces":[{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "456"
@@ -286,7 +286,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -296,7 +296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a299e761-83ce-4e48-b18d-2199863e1d63
+      - 64853b45-7fc9-4a07-9788-d8579d9ec81e
     status: 200 OK
     code: 200
     duration: ""
@@ -305,12 +305,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -319,7 +319,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,7 +329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35ec6f9f-665a-4d5e-ae3a-5b1e691e3008
+      - 57b21517-fd1d-409f-98b8-62506438ccce
     status: 200 OK
     code: 200
     duration: ""
@@ -338,12 +338,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -352,7 +352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -362,7 +362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e38fa220-abdb-4512-8a13-dcbaa58d85c7
+      - e73f7304-be97-493b-a043-3e54158ba095
     status: 200 OK
     code: 200
     duration: ""
@@ -371,12 +371,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"namespaces":[{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}],"total_count":1}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
+    headers:
+      Content-Length:
+      - "423"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Jan 2023 09:55:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c3565b12-ebf3-48b1-bb7a-959243123a46
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"namespaces":[{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "456"
@@ -385,7 +418,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -395,7 +428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46432a89-6bf5-4da1-81c0-38e47d894c3a
+      - 95e69fa8-96ae-4285-9abd-1f7a8587c4a8
     status: 200 OK
     code: 200
     duration: ""
@@ -404,12 +437,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -418,7 +451,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -428,7 +461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 840a693d-33fe-471f-a448-4d1a4ee454d3
+      - f1d8ba80-ee0f-455b-9fc8-7133f4fedd8a
     status: 200 OK
     code: 200
     duration: ""
@@ -437,12 +470,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -451,7 +484,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -461,7 +494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54cc6393-cd07-4e3a-af8f-89fe335b6c41
+      - 7a3d8405-823a-4076-a379-a269c88245fb
     status: 200 OK
     code: 200
     duration: ""
@@ -470,45 +503,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "423"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 20a14bce-be95-41aa-bc03-80168f8b1ce1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"namespaces":[{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}],"total_count":1}'
+    body: '{"namespaces":[{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "456"
@@ -517,7 +517,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -527,7 +527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e182be58-2aa5-48e1-8a50-ecd111ba1fef
+      - d95b7e3c-341f-4b65-aef5-b5186921f61e
     status: 200 OK
     code: 200
     duration: ""
@@ -536,12 +536,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -550,7 +550,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:10 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -560,7 +560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d79479fc-4225-4877-a209-108b755be4c0
+      - d0526aed-45c9-4683-a7d8-937ffb3fb334
     status: 200 OK
     code: 200
     duration: ""
@@ -569,12 +569,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -583,7 +583,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:11 GMT
+      - Mon, 23 Jan 2023 09:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -593,7 +593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f21dd77c-ec4f-49f1-ab0a-695f628912a6
+      - 087738e8-4641-485b-ad38-c938867be17a
     status: 200 OK
     code: 200
     duration: ""
@@ -602,12 +602,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":false,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:08.996301Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":false,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.134242Z"}'
     headers:
       Content-Length:
       - "423"
@@ -616,7 +616,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:11 GMT
+      - Mon, 23 Jan 2023 09:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -626,23 +626,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6d7c351-07da-4924-83bd-937cd6295d72
+      - d5272439-637d-4cf0-9bcd-235ac45fe7e8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"description":null,"is_public":true}'
+    body: '{"description":"","is_public":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: PATCH
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638114Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549479950Z"}'
     headers:
       Content-Length:
       - "425"
@@ -651,7 +651,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:11 GMT
+      - Mon, 23 Jan 2023 09:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -661,7 +661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3daebdc6-1f2f-4565-8e24-f7e56e73bd5e
+      - 63f140ad-4ade-4357-99cd-14e130bece36
     status: 200 OK
     code: 200
     duration: ""
@@ -670,12 +670,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -684,7 +684,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:11 GMT
+      - Mon, 23 Jan 2023 09:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -694,7 +694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17afecf9-b91f-4c9a-bf40-9b2325c2f56c
+      - 2151eeed-5c05-4377-b4cf-8e91935dce68
     status: 200 OK
     code: 200
     duration: ""
@@ -703,12 +703,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"namespaces":[{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}],"total_count":1}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
+    headers:
+      Content-Length:
+      - "422"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Jan 2023 09:55:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9e770152-eb61-46d5-bcab-9319650bd78f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"namespaces":[{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "455"
@@ -717,7 +750,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:11 GMT
+      - Mon, 23 Jan 2023 09:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -727,7 +760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55057166-c814-48f9-a928-c215a8a941c1
+      - 499ec79f-905f-4743-8629-ec621d4e9506
     status: 200 OK
     code: 200
     duration: ""
@@ -736,12 +769,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -750,7 +783,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:11 GMT
+      - Mon, 23 Jan 2023 09:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -760,7 +793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f22f2dab-6f82-4742-b805-879df1372114
+      - 61dbe9a3-3e1d-4895-9eea-4a3955d3ceb8
     status: 200 OK
     code: 200
     duration: ""
@@ -769,12 +802,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -783,7 +816,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:11 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -793,7 +826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5e4526c-b047-457e-8b85-2fa4ac657305
+      - 5c38517c-9f3c-409c-8adc-51e43e73a94f
     status: 200 OK
     code: 200
     duration: ""
@@ -802,12 +835,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -816,7 +849,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:12 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -826,7 +859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11c3ddc7-6668-4201-b281-b54f3baf1f48
+      - 6f5cb5fa-c4eb-4dd4-a91f-43a30dde653f
     status: 200 OK
     code: 200
     duration: ""
@@ -835,45 +868,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "422"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 12 Apr 2022 09:26:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 926dc267-8678-45a2-a305-6e077bfd2e4f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"namespaces":[{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}],"total_count":1}'
+    body: '{"namespaces":[{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "455"
@@ -882,7 +882,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:12 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -892,7 +892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95176c89-0ff1-4482-9594-c0ba48a0db41
+      - 29980d6c-e8a1-4f51-8d54-9cb327c821b3
     status: 200 OK
     code: 200
     duration: ""
@@ -901,12 +901,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -915,7 +915,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:12 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -925,7 +925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f7fa7fb-64bd-4aef-bc09-cc58e7c9f587
+      - 31f04ed6-ed6e-4370-9dd5-13e89178c2ff
     status: 200 OK
     code: 200
     duration: ""
@@ -934,12 +934,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -948,7 +948,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:12 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -958,7 +958,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bb42783-4be7-47b8-aa64-30514976e69d
+      - faa80a14-298a-4e0c-9327-0e4b77410d2a
     status: 200 OK
     code: 200
     duration: ""
@@ -967,12 +967,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -981,7 +981,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:12 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -991,7 +991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b03e95f4-564a-43c8-8b5b-6da90cfd3939
+      - 61eab47a-1f36-4ffb-a6aa-5f98708fa16c
     status: 200 OK
     code: 200
     duration: ""
@@ -1000,12 +1000,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
     method: GET
   response:
-    body: '{"namespaces":[{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}],"total_count":1}'
+    body: '{"namespaces":[{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "455"
@@ -1014,7 +1014,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:12 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1024,7 +1024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7788fc9-b1e6-4d12-9a86-3f42148d5a5c
+      - 90e3b4ec-ec10-4da0-bc17-4c35d5af6fad
     status: 200 OK
     code: 200
     duration: ""
@@ -1033,12 +1033,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -1047,7 +1047,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:12 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1057,7 +1057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7481ef5-8a44-4ea6-bf0b-23b4c9f7286e
+      - e034514c-b906-4616-9a32-828f74e7db65
     status: 200 OK
     code: 200
     duration: ""
@@ -1066,12 +1066,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces?name=test-cr-data&order_by=created_at_asc
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces?name=test-cr-data&order_by=created_at_asc
     method: GET
   response:
-    body: '{"namespaces":[{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}],"total_count":1}'
+    body: '{"namespaces":[{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "455"
@@ -1080,7 +1080,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:13 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1090,7 +1090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d8e2358-fb6d-4dc5-a163-c69a9fb82a00
+      - dd2b4abc-209b-4341-92df-b5e4ca24be30
     status: 200 OK
     code: 200
     duration: ""
@@ -1099,12 +1099,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -1113,7 +1113,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:13 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1123,7 +1123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3e0d9aa-f505-444f-879d-4c00cc3eb16f
+      - f6978ac4-ffa6-414c-b968-22d96ce9018c
     status: 200 OK
     code: 200
     duration: ""
@@ -1132,12 +1132,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -1146,7 +1146,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:13 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1156,7 +1156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12de10e7-8f1a-4dab-8a8f-d799a87d10cd
+      - 0acf1bb3-523b-4849-96d2-e57a80998985
     status: 200 OK
     code: 200
     duration: ""
@@ -1165,12 +1165,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:11.554638Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:48.549480Z"}'
     headers:
       Content-Length:
       - "422"
@@ -1179,7 +1179,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:13 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1189,7 +1189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f183302-3de9-4b29-bdd8-944eb30529c5
+      - 6ca24db3-eb84-4273-94ea-f07d6d8aa9cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1198,12 +1198,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: DELETE
   response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"deleting","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:13.577980185Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.134242Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-data","id":"923504a0-d154-48c2-a586-c020c4e33fa8","image_count":0,"is_public":true,"name":"test-cr-data","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"deleting","status_message":"","updated_at":"2023-01-23T09:55:50.629237244Z"}'
     headers:
       Content-Length:
       - "428"
@@ -1212,7 +1212,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:13 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1222,7 +1222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2694a0af-0499-4f1f-84c7-821412500ba2
+      - bf7b01fb-de9a-4727-aad5-54cb8678484e
     status: 200 OK
     code: 200
     duration: ""
@@ -1231,42 +1231,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
-    method: GET
-  response:
-    body: '{"id":"6b0cba4d-ecb7-421e-9871-91f6c7f6b67e","name":"test-cr-data","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"deleting","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-data","is_public":true,"size":0,"created_at":"2022-04-12T09:26:08.996301Z","updated_at":"2022-04-12T09:26:13.577980Z","image_count":0,"region":"fr-par"}'
-    headers:
-      Content-Length:
-      - "425"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 12 Apr 2022 09:26:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b4416f22-789c-4d88-8898-189763d629ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: GET
   response:
     body: '{"message":"Namespace was not found"}'
@@ -1278,7 +1245,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:18 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1288,7 +1255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f4e0430-e807-42d2-a31c-a1cc0f9712a8
+      - 95420a4d-b6b9-4a68-abc0-94d942db5938
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1297,9 +1264,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: DELETE
   response:
     body: '{"message":"Namespace was not found"}'
@@ -1311,7 +1278,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:18 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1321,7 +1288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60763e99-3303-4731-a166-0b24cda8d604
+      - 2de16439-0126-4432-bc01-43d194fb2ab0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1330,9 +1297,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: DELETE
   response:
     body: '{"message":"Namespace was not found"}'
@@ -1344,7 +1311,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:18 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1354,7 +1321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4f0b9d7-5e25-46a8-920f-69e170968f28
+      - 414cac2e-e67a-4684-a7fa-473c0d0c10c7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1363,9 +1330,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/6b0cba4d-ecb7-421e-9871-91f6c7f6b67e
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/923504a0-d154-48c2-a586-c020c4e33fa8
     method: DELETE
   response:
     body: '{"message":"Namespace was not found"}'
@@ -1377,7 +1344,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:26:18 GMT
+      - Mon, 23 Jan 2023 09:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1387,7 +1354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85a240e2-cd07-445b-885f-92dfe3cfd033
+      - b5586ad0-50c7-4da1-b278-48d3b08deb17
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/registry-namespace-basic.cassette.yaml
+++ b/scaleway/testdata/registry-namespace-basic.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"test-cr-ns-01","description":"","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","is_public":false}'
+    body: '{"name":"test-cr-ns-01","description":"","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","is_public":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces
     method: POST
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":false,"size":0,"created_at":"2022-04-12T09:25:24.248253559Z","updated_at":"2022-04-12T09:25:24.248253559Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949366Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.133949366Z"}'
     headers:
       Content-Length:
       - "431"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:24 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d5a0fdd-f5e7-4ea2-87e5-c856591f6f96
+      - 23ba6989-2075-4b77-924c-ba89ad5f3668
     status: 200 OK
     code: 200
     duration: ""
@@ -41,12 +41,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":false,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:24.248254Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.133949Z"}'
     headers:
       Content-Length:
       - "425"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:24 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe0c71e2-6233-491a-8057-9abc9ca959ce
+      - 7ce22018-3e1e-49c8-bb6d-e4d6b75f7044
     status: 200 OK
     code: 200
     duration: ""
@@ -74,12 +74,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":false,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:24.248254Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.133949Z"}'
     headers:
       Content-Length:
       - "425"
@@ -88,7 +88,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:24 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fde1223f-780b-48fe-a2b3-3fe681ff4745
+      - 544ce427-bc1c-4b1a-b092-0455ca9a092f
     status: 200 OK
     code: 200
     duration: ""
@@ -107,12 +107,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":false,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:24.248254Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.133949Z"}'
     headers:
       Content-Length:
       - "425"
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:24 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5421ff3-f755-4a9e-93bd-98626d55b599
+      - 01fde522-6795-4b42-818d-882fb47db804
     status: 200 OK
     code: 200
     duration: ""
@@ -140,12 +140,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":false,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:24.248254Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.133949Z"}'
     headers:
       Content-Length:
       - "425"
@@ -154,7 +154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:25 GMT
+      - Mon, 23 Jan 2023 09:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2943fd12-10ae-4083-80ef-0135a8e006cf
+      - 13d968d8-14c9-4839-8070-406a09705695
     status: 200 OK
     code: 200
     duration: ""
@@ -173,12 +173,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":false,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:24.248254Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.133949Z"}'
     headers:
       Content-Length:
       - "425"
@@ -187,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:25 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97d34eee-bda3-427a-ab6d-ec6aabaabd36
+      - dd99f596-5fb6-400d-8ff8-233d978bac37
     status: 200 OK
     code: 200
     duration: ""
@@ -206,12 +206,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":false,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:24.248254Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":false,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:46.133949Z"}'
     headers:
       Content-Length:
       - "425"
@@ -220,7 +220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:26 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29e12873-ba4c-4c3a-a58b-07d6a6be142e
+      - 00178177-921c-4e09-a617-66aab8f3d401
     status: 200 OK
     code: 200
     duration: ""
@@ -241,13 +241,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: PATCH
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"test
-      registry namespace 01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":true,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:26.082449312Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"test registry
+      namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:47.839251401Z"}'
     headers:
       Content-Length:
       - "453"
@@ -256,7 +256,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:26 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -266,7 +266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28b77d8e-4284-4689-b7fc-2954cd6f56bd
+      - 7529b4a1-e1c2-4006-af21-a931bdd1c4b3
     status: 200 OK
     code: 200
     duration: ""
@@ -275,13 +275,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"test
-      registry namespace 01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":true,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:26.082449Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"test registry
+      namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:47.839251Z"}'
     headers:
       Content-Length:
       - "450"
@@ -290,7 +290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:26 GMT
+      - Mon, 23 Jan 2023 09:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8029e07-70d5-4e93-bd60-487dd6d8c206
+      - 358c9305-594c-4d9a-9d7f-031311f6e17c
     status: 200 OK
     code: 200
     duration: ""
@@ -309,13 +309,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"test
-      registry namespace 01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":true,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:26.082449Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"test registry
+      namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:47.839251Z"}'
     headers:
       Content-Length:
       - "450"
@@ -324,7 +324,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:26 GMT
+      - Mon, 23 Jan 2023 09:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -334,7 +334,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05e0b5e1-0772-4044-b83b-cf2bc4774867
+      - 31734db8-5d5c-4aba-a126-2152778a16e2
     status: 200 OK
     code: 200
     duration: ""
@@ -343,13 +343,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"test
-      registry namespace 01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":true,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:26.082449Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"test registry
+      namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:47.839251Z"}'
     headers:
       Content-Length:
       - "450"
@@ -358,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:26 GMT
+      - Mon, 23 Jan 2023 09:55:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65693d7f-bb27-4a91-a619-ae60307fa7ca
+      - 50b58416-4040-41c3-b459-cc7de4cd36eb
     status: 200 OK
     code: 200
     duration: ""
@@ -377,13 +377,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"test
-      registry namespace 01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"ready","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":true,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:26.082449Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"test registry
+      namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"ready","status_message":"","updated_at":"2023-01-23T09:55:47.839251Z"}'
     headers:
       Content-Length:
       - "450"
@@ -392,7 +392,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:26 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -402,7 +402,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c85418ee-2434-4473-9c42-64858f163800
+      - 46832637-3eb8-4398-8ed1-f448bc569025
     status: 200 OK
     code: 200
     duration: ""
@@ -411,13 +411,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: DELETE
   response:
-    body: '{"id":"4e3ea8f9-fdcc-4523-8ba5-f371399e60a1","name":"test-cr-ns-01","description":"test
-      registry namespace 01","organization_id":"951df375-e094-4d26-97c1-ba548eeb9c42","project_id":"951df375-e094-4d26-97c1-ba548eeb9c42","status":"deleting","status_message":"","endpoint":"rg.fr-par.scw.cloud/test-cr-ns-01","is_public":true,"size":0,"created_at":"2022-04-12T09:25:24.248254Z","updated_at":"2022-04-12T09:25:27.067019215Z","image_count":0,"region":"fr-par"}'
+    body: '{"created_at":"2023-01-23T09:55:46.133949Z","description":"test registry
+      namespace 01","endpoint":"rg.pl-waw.scw.cloud/test-cr-ns-01","id":"3d3ab82b-29b6-4a47-9cbf-060b9c44c359","image_count":0,"is_public":true,"name":"test-cr-ns-01","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","region":"pl-waw","size":0,"status":"deleting","status_message":"","updated_at":"2023-01-23T09:55:49.061585715Z"}'
     headers:
       Content-Length:
       - "456"
@@ -426,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:27 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da391aa3-9f33-4f6a-8e95-248b6ced3034
+      - 5283717f-167b-4585-9ca8-0c7cd97a3f2c
     status: 200 OK
     code: 200
     duration: ""
@@ -445,9 +445,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: GET
   response:
     body: '{"message":"Namespace was not found"}'
@@ -459,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:27 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5fdfae6-614d-4ebd-b01e-363c0f9ceb70
+      - 61595f45-3600-4bb5-b915-d5882462863f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -478,9 +478,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/registry/v1/regions/fr-par/namespaces/4e3ea8f9-fdcc-4523-8ba5-f371399e60a1
+    url: https://api.scaleway.com/registry/v1/regions/pl-waw/namespaces/3d3ab82b-29b6-4a47-9cbf-060b9c44c359
     method: DELETE
   response:
     body: '{"message":"Namespace was not found"}'
@@ -492,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Apr 2022 09:25:27 GMT
+      - Mon, 23 Jan 2023 09:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10a2ed28-de1a-4dad-aa06-6aca4491db4d
+      - e3d67c92-9e63-41e5-a238-d45f5bb03c95
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
Registry is currently slow to delete namespaces, set region to pl-waw as a workaround while waiting for it to be fixed