### PR TITLE
feat(k8s): add k8s version data source

### DIFF
--- a/docs/data-sources/k8s_version.md
+++ b/docs/data-sources/k8s_version.md
@@ -1,0 +1,34 @@
+---
+page_title: "Scaleway: scaleway_k8s_version"
+description: |-
+  Gets information about a Kubernetes version.
+---
+
+# scaleway_k8s_version
+
+Gets information about a Kubernetes version.
+For more information, see [the documentation](https://developers.scaleway.com/en/products/k8s/api).
+
+You can also use the [scaleway-cli](https://github.com/scaleway/scaleway-cli) with `scw k8s version list` to list all available versions.
+
+## Example Usage
+
+```hcl
+# Get info by os name 
+data "scaleway_k8s_version" "by_name" {
+  name = "1.26.0"
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) The name of the Kubernetes version.
+- `region` - (Defaults to [provider](../index.md) `region`) The [region](../guides/regions_and_zones.md#regions) in which the version exists.
+
+## Attributes Reference
+
+In addition to all above arguments, the following attributes are exported:
+
+- `available_cnis` - The list of supported Container Network Interface (CNI) plugins for this version.
+- `available_container_runtimes` - The list of supported container runtimes for this version.
+- `available_feature_gates` - The list of supported feature gates for this version.

--- a/scaleway/data_source_k8s_version.go
+++ b/scaleway/data_source_k8s_version.go
@@ -1,0 +1,77 @@
+package scaleway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func dataSourceScalewayK8SVersion() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceScalewayK8SVersionRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the Kubernetes version",
+			},
+			"available_cnis": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "The list of supported Container Network Interface (CNI) plugins for this version",
+			},
+			"available_container_runtimes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "The list of supported container runtimes for this version",
+			},
+			"available_feature_gates": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "The list of supported feature gates for this version",
+			},
+			"region": regionSchema(),
+		},
+	}
+}
+
+func dataSourceScalewayK8SVersionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	k8sAPI, region, err := k8sAPIWithRegion(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name, ok := d.GetOk("name")
+	if !ok {
+		return diag.FromErr(fmt.Errorf("could not find version %q", name))
+	}
+	res, err := k8sAPI.GetVersion(&k8s.GetVersionRequest{
+		Region:      region,
+		VersionName: name.(string),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", region, res.Name))
+	_ = d.Set("name", res.Name)
+	_ = d.Set("available_cnis", res.AvailableCnis)
+	_ = d.Set("available_container_runtimes", res.AvailableContainerRuntimes)
+	_ = d.Set("available_feature_gates", res.AvailableFeatureGates)
+	_ = d.Set("region", region)
+
+	return nil
+}

--- a/scaleway/data_source_k8s_version_test.go
+++ b/scaleway/data_source_k8s_version_test.go
@@ -1,0 +1,70 @@
+package scaleway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
+)
+
+func TestAccScalewayDataSourceK8SVersion_Basic(t *testing.T) {
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					data "scaleway_k8s_version" "by_name" {
+						name = "1.26.0"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayK8SVersionExists(tt, "data.scaleway_k8s_version.by_name"),
+					resource.TestCheckResourceAttrSet("data.scaleway_k8s_version.by_name", "name"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_cnis.#", "2"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_cnis.0", "cilium"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_cnis.1", "calico"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_container_runtimes.#", "1"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_container_runtimes.0", "containerd"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_feature_gates.#", "3"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_feature_gates.0", "HPAScaleToZero"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_feature_gates.1", "GRPCContainerProbe"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_feature_gates.2", "ReadWriteOncePod"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckScalewayK8SVersionExists(tt *TestTools, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		region, name, err := parseRegionalID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		k8sAPI := k8s.NewAPI(tt.Meta.scwClient)
+		_, err = k8sAPI.GetVersion(&k8s.GetVersionRequest{
+			Region:      region,
+			VersionName: name,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -187,6 +187,7 @@ func Provider(config *ProviderConfig) plugin.ProviderFunc {
 				"scaleway_iot_device":                          dataSourceScalewayIotDevice(),
 				"scaleway_k8s_cluster":                         dataSourceScalewayK8SCluster(),
 				"scaleway_k8s_pool":                            dataSourceScalewayK8SPool(),
+				"scaleway_k8s_version":                         dataSourceScalewayK8SVersion(),
 				"scaleway_lb":                                  dataSourceScalewayLb(),
 				"scaleway_lb_certificate":                      dataSourceScalewayLbCertificate(),
 				"scaleway_lb_ip":                               dataSourceScalewayLbIP(),

--- a/scaleway/testdata/data-source-k8s-version-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-version-basic.cassette.yaml
@@ -1,0 +1,207 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    method: GET
+  response:
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.0","name":"1.26.0","region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "690"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Feb 2023 15:00:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c5626d2e-e056-49b4-9843-f4181f5d5177
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    method: GET
+  response:
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.0","name":"1.26.0","region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "690"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Feb 2023 15:00:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d3ab3e01-7493-45a7-b363-00a63e050cb5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    method: GET
+  response:
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.0","name":"1.26.0","region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "690"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Feb 2023 15:00:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d42f298f-04d5-48b3-bcca-d37a4ec5a43d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    method: GET
+  response:
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.0","name":"1.26.0","region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "690"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Feb 2023 15:00:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73ca5518-edec-4396-aa9a-95547e1c44ae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    method: GET
+  response:
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.0","name":"1.26.0","region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "690"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Feb 2023 15:00:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22097e7e-5824-4c72-b53f-b9393a7075cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    method: GET
+  response:
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.0","name":"1.26.0","region":"fr-par"}'
+    headers:
+      Content-Length:
+      - "690"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Feb 2023 15:00:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4ea3ea0e-64fe-43ab-a188-f222b1276498
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
This PR adds the datasource `scaleway_k8s_version`
Closes #1762 