### PR TITLE
Fix scaleway_rdb_instance using name as a pattern instead of an exact match

### DIFF
--- a/scaleway/data_source_rdb_instance.go
+++ b/scaleway/data_source_rdb_instance.go
@@ -46,13 +46,17 @@ func dataSourceScalewayRDBInstanceRead(ctx context.Context, d *schema.ResourceDa
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if len(res.Instances) == 0 {
-			return diag.FromErr(fmt.Errorf("no instances found with the name %s", d.Get("name")))
+		for _, instance := range res.Instances {
+			if instance.Name == d.Get("name").(string) {
+				if instanceID != "" {
+					return diag.FromErr(fmt.Errorf("more than 1 instance found with the same name %s", d.Get("name")))
+				}
+				instanceID = instance.ID
+			}
 		}
-		if len(res.Instances) > 1 {
-			return diag.FromErr(fmt.Errorf("%d instances found with the same name %s", len(res.Instances), d.Get("name")))
+		if instanceID == "" {
+			return diag.FromErr(fmt.Errorf("no instance found with the name %s", d.Get("name")))
 		}
-		instanceID = res.Instances[0].ID
 	}
 
 	regionalID := datasourceNewRegionalizedID(instanceID, region)


### PR DESCRIPTION
When trying to import a RDB instance, the name parameter is directly passed to the API which treat it as a pattern instead of an exact match leading to a multiple instance with the name error if other instance contains the name of the searched instance.

This PR adds an additional step of matching to ensure only exact match are returned.

The code is heavily inspired by what is donne inside the `scaleway_instance_server` data source.