### PR TITLE
fix(k8s): fix K8SCluster_PrivateNetwork test 2

### DIFF
--- a/scaleway/resource_k8s_cluster_test.go
+++ b/scaleway/resource_k8s_cluster_test.go
@@ -2,7 +2,6 @@ package scaleway
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -516,16 +515,16 @@ func testAccCheckScalewayK8sClusterPrivateNetworkID(tt *TestTools, clusterName, 
 			return fmt.Errorf("resource not found: %s", pnName)
 		}
 
-		_, zone, pnID, err := vpcAPIWithZoneAndID(tt.Meta, rs.Primary.ID)
+		_, _, pnID, err := vpcAPIWithZoneAndID(tt.Meta, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
 		if clusterPNID == nil {
-			return fmt.Errorf("expected %s private_network_id to be %s, got nil", clusterName, strings.TrimLeft(pnID, zone.String()+"/"))
+			return fmt.Errorf("expected %s private_network_id to be %s, got nil", clusterName, pnID)
 		}
-		if *clusterPNID != strings.TrimLeft(pnID, zone.String()+"/") {
-			return fmt.Errorf("expected %s private_network_id to be %s, got %s", clusterName, strings.TrimLeft(pnID, zone.String()+"/"), *clusterPNID)
+		if *clusterPNID != pnID {
+			return fmt.Errorf("expected %s private_network_id to be %s, got %s", clusterName, pnID, *clusterPNID)
 		}
 
 		return nil

--- a/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
@@ -19,13 +19,13 @@ interactions:
       1.22.16","name":"1.22.16","region":"fr-par"}]}'
     headers:
       Content-Length:
-      - "3703"
+      - "3835"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:37 GMT
+      - Fri, 07 Apr 2023 09:44:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -35,7 +35,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44172d9f-46de-44b5-9e8b-1d0ceef0712e
+      - ad6cd2c0-d89b-4637-a6fa-008477b0630a
     status: 200 OK
     code: 200
     duration: ""
@@ -51,16 +51,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-04-04T10:01:37.575273Z","id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[],"tags":[],"updated_at":"2023-04-04T10:01:37.575273Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-04-07T09:44:02.981601Z","id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:30dc::/64"],"tags":[],"updated_at":"2023-04-07T09:44:02.981601Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "310"
+      - "361"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:37 GMT
+      - Fri, 07 Apr 2023 09:44:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -70,7 +70,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61d59c7d-636f-460e-92fe-339522807c56
+      - bde8b10e-6493-4a5a-955c-8d18ff647c70
     status: 200 OK
     code: 200
     duration: ""
@@ -81,19 +81,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/41126bcf-11c3-415a-8a6c-99caa15bf1f2
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b
     method: GET
   response:
-    body: '{"created_at":"2023-04-04T10:01:37.575273Z","id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[],"tags":[],"updated_at":"2023-04-04T10:01:37.575273Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-04-07T09:44:02.981601Z","id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:30dc::/64"],"tags":[],"updated_at":"2023-04-07T09:44:02.981601Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "310"
+      - "361"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:37 GMT
+      - Fri, 07 Apr 2023 09:44:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -103,12 +103,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5d6c6dd-d070-4f78-aa3c-a95ad208af11
+      - dece01d1-a0fe-4251-8bc1-e30cef46ce55
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.26.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2"}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.26.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b"}'
     form: {}
     headers:
       Content-Type:
@@ -119,16 +119,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398087864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:38.419075676Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430092Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:03.440416133Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1410"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:38 GMT
+      - Fri, 07 Apr 2023 09:44:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -138,7 +138,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39ff4a73-9116-40c1-8896-6183e1bf256a
+      - 1967f237-0dcd-4025-85fb-5fe81ed5a666
     status: 200 OK
     code: 200
     duration: ""
@@ -149,19 +149,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398088Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:38.419076Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:03.440416Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1404"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:38 GMT
+      - Fri, 07 Apr 2023 09:44:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -171,7 +171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d2d3623-24d9-4e5e-ba05-4c0141b53177
+      - a22b9f5e-a6ab-46cc-903f-8c2d1b9f2f11
     status: 200 OK
     code: 200
     duration: ""
@@ -182,19 +182,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398088Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:40.387538Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1409"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:43 GMT
+      - Fri, 07 Apr 2023 09:44:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -204,7 +204,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09f10b5a-c220-47c4-b4e5-bdb9661083b4
+      - c1fb5e05-de4b-4445-af4a-55cf209041d2
     status: 200 OK
     code: 200
     duration: ""
@@ -215,19 +215,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398088Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:40.387538Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1409"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:43 GMT
+      - Fri, 07 Apr 2023 09:44:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -237,7 +237,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51d6e9ac-b24d-429a-9691-2c4f25010fdb
+      - 92608ada-f065-4519-b6b5-493b43f94bcf
     status: 200 OK
     code: 200
     duration: ""
@@ -248,19 +248,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGROZWtWM1RVUkZlazlXYjFoRVZFMTZUVVJSZDAxNlJYZE5SRVY2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXh0Q25KbmIwSndjMXB2YjJveVdYcHNXbmR5WkZaT05FcHhiMXB0ZFV0WFIwTkxUblZCTVhobWRtNXpiSE4xTmpOeFF6RlhkbHBMY0V4bWMzZDBSSGhFVTFBS1pGbFBlVVYwUjJ4Q1VtZHJkREowVnpkWWJEVkNOM3ByYVZWUlNVTnFibGQyVFUxcU4wVlZUVlUwVjNGMlRuTm5jVEpZVnpoSmNrMXBXRWwwYURWUWF3cENPV0ZTWTJGV1ptUlBjWFJoTkRSeVoyNHZXWEp5YVVOUE1ITlRTSEl5ZEdWalR5dHNkMlpaUVVKUVJIZDZRaTlRVUUxdGEzUkJMMnRsU0VaR1QzQktDbU5OT1dreWNGa3dkVXMxZFhoaGFrbHZPR2hQUVZJd09XUkxaMlk0YldwNGJuSndkMFJQUkdSelNVaFBibTlDVG1JM1VEWllURWxtVFVKUE5tbFNOR0lLT0RsQ1pWSkViV1JhVW1NM2FYY3dVbEZsVlZCelZsVTNWRE5DVlROT05YbEhSRVozWml0Mk0zRm1PRzg1YVV4a01WUkdNMk5YYmxSbVpYWTJUMVl2YndwdmFGSTNVRXRHTTJveGMyNXBhSEJVTTJWTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2RFSXliVE5UYjFKQlVuTm9XVWt3TkVSWFZYWnBkMkp4ZFROTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1pqTmlWa2RtVkd0bFNYQnBORFYzUm5jeU1reE1NMmx4YjJwUVVteEJObWRIYlZGTlkyNXlNRzl2ZEZwcWVVZ3hjUXBWUVdOc1drVldMMlZVVDBwMloxQkVhalpsWTBjeVkzQjBkbTlyTm01aVowNHdRbTFGWms5SEsycFZLemR3UW5kS01XWlFWMDFzVUV4VU9HUmhkR3A1Q21SSFREQmtlV0pZV1RGSFdFTnZUVFFyWnpSTFJuSjFLMjVuV0ZFMFkyUlhNeTlPTm5kamRtZGtNRGsyUjFCUldUTjVPVU0yUm1selEyUnJiSFE1V2pRS1QxbHlWMFZEYkhVd1NIbEdZMUY1WjFsTlYzWkZiVEoxTDBRMWNtOHlhRkZxV0VzME1taE9PRW93ZG5wbVRFTldVM0JaZGpCNU1pOXFRVkZMYzFWdFFRcEVZakJMYnpsbVVGQXdhVmhLTjBGSGEwVnhRbk4xYUZKelFteEZlbEZEZFhocGNDOHllbEUxUm5CMGMyWTJNRlJTVDJSWWMyWk9lVWxSTHpOak9FaHBDa1JrVlZZclluZFJOMFJzZFZwUFpHVXdWWGhXZW5oMWQxZHBOREIzWnpOU2MwZHFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2NhYmNjYjctMmY0MC00NzgxLWI4MDMtYmVmY2EwYWVhYTJjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0RXV6eVUyY1dqWjFCcWR6MUZBQVR2cUtzUUJxeHJoYlVqOXhseHp0NGRUb3lXRlZQaDZKZ1pDcg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGRPYWtFMVRrUlJkMDVHYjFoRVZFMTZUVVJSZDA1cVFUVk9SRkYzVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkIwQ25OclRtWlRWemcxTDJaNFZqUkZXWEZUVlRCNWExZE1VVnBGZVVOb1lWRkhlbUZtV1ZVeloyRmhiVFJGTVRsQlpGbzRhemxUVHpKNE0weGlSRW8xTTFVS01VNVlhR2hzVG1nd1YyTjBja0pZTlRWd2FHTjZhbmRVWVZobWVtTlRhbGhJVlZjNFVFNTVUV2xvUWpoeUszUnJPVzFNYTFsVU4xTkdRamRMY0RKS1dRcEpTa0ptYms5dFpWVXZkR0l3TVhOS1VGWmlTa3BOYXpkbFlXTXZWUzlPY1NzMWRESkZiSFo0WXpoaVIwZ3dUbFpLYmpaVWIzWXpRa1pzTTJWcFZrTlJDbmRFVUVnNU5FRk9OMUV2WTJRNWIxVkNTMVZVTlRaRlFXYzNiV3RIUjBkU2Myb3pNazVNVVd4U1pFbDVhRGw0U2s5NVdqWTViMHR3VURsQk1rRmxWRW9LVVZOekwwSkROazE0ZVcwNGJHdHRZM0ZOTjA1TFEwNVNVMFJaZGtkTWVsaGlUamRLY0haWFRFYzFVVWh6ZG5weU1EQmpSRkJ3S3l0eVRtdDZSekprVlFwcmVtNUhWM0pEVkZSYU1rUlJiVm92Tm1Nd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRU0yOUlkMklySzNWYWFITktjVzB6VGxOR05ucEpPRmQ2ZFZOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmNGZGxVMjFNZVZVMk5rUXZUa1JUVFhGQ1lUbDZaRkJpUjBKVVZsaHlhRVl4UkVseFFXTlNhMGd5YTNjelZGSlllZ3BvY1dwMVQxWjBVR2g0VWpKaU1raDJVbk5aZW1abVNqbEdVRXM0ZFdOYVNXSllPRlpDUm0xWmFXTnhaV3hCZUhrMVZqTlNhMWRqWld0bmNUWkZSMkV6Q21sdWVtaFBaRkpLYTFGM1JWUlFUMnhoUjFWNlVHNXBiV3QyUWtONGVHNVJSa1k0VEROQlJsbHdhRXhCZFVsNVoxbEdWbnBvUmpoTk16SlhSVmhvUWk4S09WSm5VM1ZRZVdKblZqSkdVSEpCYlRsUVVFUmhSbWhtTUVkNGFUQkhXRXh5TlRGM09HTlliMk4wUkc4ME9URnVNMDFaYlZGa1IzaFJOV1Z1WVhkdWFRcGxVRlJuVG1aVlNIRnhkVXhIT0UxMFVWTlVkVUV3Y0U1c1NrZ3lTbEpKVm5JeWNXSkxlazAxTldWbU5ITXdOMWxEVmtvMWNsZHFVMHQxT0RFNFNVSldDbVF2ZEZVeUwzSk5XRzh2UzFodFpEWXZZVEY2VlRNMlRYWXlOVTF5UWpnMGFXdE1TUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDEyODJmNTUtMzQ5MC00YmVmLWI3MjUtNTk5NjM0MzA0M2E2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpRnF0RzJnRnF2QVdkT3JJc1FoQzBLMmJVSUFLMHlweDNoTm1wajFoaEpxMHdpeGtTb0hoYnJVZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:43 GMT
+      - Fri, 07 Apr 2023 09:44:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -270,7 +270,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04d7621d-4c97-4fac-b2e2-54a21db392a7
+      - 2333ae2a-f8a1-4e7e-8d17-b0c07dce0c01
     status: 200 OK
     code: 200
     duration: ""
@@ -281,19 +281,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398088Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:40.387538Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1409"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:43 GMT
+      - Fri, 07 Apr 2023 09:44:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -303,7 +303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f439fce-f5bc-42e5-b4cf-a9b28d6a4343
+      - 1d03f1e2-66bf-43b8-8d85-53ef193fcbb0
     status: 200 OK
     code: 200
     duration: ""
@@ -314,19 +314,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/41126bcf-11c3-415a-8a6c-99caa15bf1f2
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b
     method: GET
   response:
-    body: '{"created_at":"2023-04-04T10:01:37.575273Z","id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[],"tags":[],"updated_at":"2023-04-04T10:01:37.575273Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-04-07T09:44:02.981601Z","id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:30dc::/64"],"tags":[],"updated_at":"2023-04-07T09:44:02.981601Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "310"
+      - "361"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:43 GMT
+      - Fri, 07 Apr 2023 09:44:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -336,7 +336,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c2af73c-9714-404a-a5fa-b522778d645d
+      - 76f35082-d710-4f31-97a6-9444fd6eab64
     status: 200 OK
     code: 200
     duration: ""
@@ -347,19 +347,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398088Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:40.387538Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1409"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:43 GMT
+      - Fri, 07 Apr 2023 09:44:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -369,7 +369,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30c8ea3c-9011-4636-9272-5084093c5357
+      - 2caf2205-2b91-481d-9f2e-5ff7ba419079
     status: 200 OK
     code: 200
     duration: ""
@@ -380,19 +380,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/41126bcf-11c3-415a-8a6c-99caa15bf1f2
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b
     method: GET
   response:
-    body: '{"created_at":"2023-04-04T10:01:37.575273Z","id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":[],"tags":[],"updated_at":"2023-04-04T10:01:37.575273Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-04-07T09:44:02.981601Z","id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:30dc::/64"],"tags":[],"updated_at":"2023-04-07T09:44:02.981601Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "310"
+      - "361"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:44 GMT
+      - Fri, 07 Apr 2023 09:44:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -402,7 +402,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45dead23-5a78-4c10-ba28-3186d4064be1
+      - 08b3b545-ec6d-4565-841d-a751c8277ea5
     status: 200 OK
     code: 200
     duration: ""
@@ -413,19 +413,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398088Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:40.387538Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1409"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:44 GMT
+      - Fri, 07 Apr 2023 09:44:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -435,7 +435,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29a550ba-492b-447a-ab98-405931568bf0
+      - 4623219f-b7e5-4b4a-8e09-055ee45af0c8
     status: 200 OK
     code: 200
     duration: ""
@@ -446,19 +446,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGROZWtWM1RVUkZlazlXYjFoRVZFMTZUVVJSZDAxNlJYZE5SRVY2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXh0Q25KbmIwSndjMXB2YjJveVdYcHNXbmR5WkZaT05FcHhiMXB0ZFV0WFIwTkxUblZCTVhobWRtNXpiSE4xTmpOeFF6RlhkbHBMY0V4bWMzZDBSSGhFVTFBS1pGbFBlVVYwUjJ4Q1VtZHJkREowVnpkWWJEVkNOM3ByYVZWUlNVTnFibGQyVFUxcU4wVlZUVlUwVjNGMlRuTm5jVEpZVnpoSmNrMXBXRWwwYURWUWF3cENPV0ZTWTJGV1ptUlBjWFJoTkRSeVoyNHZXWEp5YVVOUE1ITlRTSEl5ZEdWalR5dHNkMlpaUVVKUVJIZDZRaTlRVUUxdGEzUkJMMnRsU0VaR1QzQktDbU5OT1dreWNGa3dkVXMxZFhoaGFrbHZPR2hQUVZJd09XUkxaMlk0YldwNGJuSndkMFJQUkdSelNVaFBibTlDVG1JM1VEWllURWxtVFVKUE5tbFNOR0lLT0RsQ1pWSkViV1JhVW1NM2FYY3dVbEZsVlZCelZsVTNWRE5DVlROT05YbEhSRVozWml0Mk0zRm1PRzg1YVV4a01WUkdNMk5YYmxSbVpYWTJUMVl2YndwdmFGSTNVRXRHTTJveGMyNXBhSEJVTTJWTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2RFSXliVE5UYjFKQlVuTm9XVWt3TkVSWFZYWnBkMkp4ZFROTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1pqTmlWa2RtVkd0bFNYQnBORFYzUm5jeU1reE1NMmx4YjJwUVVteEJObWRIYlZGTlkyNXlNRzl2ZEZwcWVVZ3hjUXBWUVdOc1drVldMMlZVVDBwMloxQkVhalpsWTBjeVkzQjBkbTlyTm01aVowNHdRbTFGWms5SEsycFZLemR3UW5kS01XWlFWMDFzVUV4VU9HUmhkR3A1Q21SSFREQmtlV0pZV1RGSFdFTnZUVFFyWnpSTFJuSjFLMjVuV0ZFMFkyUlhNeTlPTm5kamRtZGtNRGsyUjFCUldUTjVPVU0yUm1selEyUnJiSFE1V2pRS1QxbHlWMFZEYkhVd1NIbEdZMUY1WjFsTlYzWkZiVEoxTDBRMWNtOHlhRkZxV0VzME1taE9PRW93ZG5wbVRFTldVM0JaZGpCNU1pOXFRVkZMYzFWdFFRcEVZakJMYnpsbVVGQXdhVmhLTjBGSGEwVnhRbk4xYUZKelFteEZlbEZEZFhocGNDOHllbEUxUm5CMGMyWTJNRlJTVDJSWWMyWk9lVWxSTHpOak9FaHBDa1JrVlZZclluZFJOMFJzZFZwUFpHVXdWWGhXZW5oMWQxZHBOREIzWnpOU2MwZHFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2NhYmNjYjctMmY0MC00NzgxLWI4MDMtYmVmY2EwYWVhYTJjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0RXV6eVUyY1dqWjFCcWR6MUZBQVR2cUtzUUJxeHJoYlVqOXhseHp0NGRUb3lXRlZQaDZKZ1pDcg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGRPYWtFMVRrUlJkMDVHYjFoRVZFMTZUVVJSZDA1cVFUVk9SRkYzVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkIwQ25OclRtWlRWemcxTDJaNFZqUkZXWEZUVlRCNWExZE1VVnBGZVVOb1lWRkhlbUZtV1ZVeloyRmhiVFJGTVRsQlpGbzRhemxUVHpKNE0weGlSRW8xTTFVS01VNVlhR2hzVG1nd1YyTjBja0pZTlRWd2FHTjZhbmRVWVZobWVtTlRhbGhJVlZjNFVFNTVUV2xvUWpoeUszUnJPVzFNYTFsVU4xTkdRamRMY0RKS1dRcEpTa0ptYms5dFpWVXZkR0l3TVhOS1VGWmlTa3BOYXpkbFlXTXZWUzlPY1NzMWRESkZiSFo0WXpoaVIwZ3dUbFpLYmpaVWIzWXpRa1pzTTJWcFZrTlJDbmRFVUVnNU5FRk9OMUV2WTJRNWIxVkNTMVZVTlRaRlFXYzNiV3RIUjBkU2Myb3pNazVNVVd4U1pFbDVhRGw0U2s5NVdqWTViMHR3VURsQk1rRmxWRW9LVVZOekwwSkROazE0ZVcwNGJHdHRZM0ZOTjA1TFEwNVNVMFJaZGtkTWVsaGlUamRLY0haWFRFYzFVVWh6ZG5weU1EQmpSRkJ3S3l0eVRtdDZSekprVlFwcmVtNUhWM0pEVkZSYU1rUlJiVm92Tm1Nd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRU0yOUlkMklySzNWYWFITktjVzB6VGxOR05ucEpPRmQ2ZFZOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmNGZGxVMjFNZVZVMk5rUXZUa1JUVFhGQ1lUbDZaRkJpUjBKVVZsaHlhRVl4UkVseFFXTlNhMGd5YTNjelZGSlllZ3BvY1dwMVQxWjBVR2g0VWpKaU1raDJVbk5aZW1abVNqbEdVRXM0ZFdOYVNXSllPRlpDUm0xWmFXTnhaV3hCZUhrMVZqTlNhMWRqWld0bmNUWkZSMkV6Q21sdWVtaFBaRkpLYTFGM1JWUlFUMnhoUjFWNlVHNXBiV3QyUWtONGVHNVJSa1k0VEROQlJsbHdhRXhCZFVsNVoxbEdWbnBvUmpoTk16SlhSVmhvUWk4S09WSm5VM1ZRZVdKblZqSkdVSEpCYlRsUVVFUmhSbWhtTUVkNGFUQkhXRXh5TlRGM09HTlliMk4wUkc4ME9URnVNMDFaYlZGa1IzaFJOV1Z1WVhkdWFRcGxVRlJuVG1aVlNIRnhkVXhIT0UxMFVWTlVkVUV3Y0U1c1NrZ3lTbEpKVm5JeWNXSkxlazAxTldWbU5ITXdOMWxEVmtvMWNsZHFVMHQxT0RFNFNVSldDbVF2ZEZVeUwzSk5XRzh2UzFodFpEWXZZVEY2VlRNMlRYWXlOVTF5UWpnMGFXdE1TUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDEyODJmNTUtMzQ5MC00YmVmLWI3MjUtNTk5NjM0MzA0M2E2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpRnF0RzJnRnF2QVdkT3JJc1FoQzBLMmJVSUFLMHlweDNoTm1wajFoaEpxMHdpeGtTb0hoYnJVZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2708"
+      - "2710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:44 GMT
+      - Fri, 07 Apr 2023 09:44:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -468,7 +468,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01d5b1b3-66ca-4c0b-b860-0c1549ba1c3b
+      - f9d39a44-f87b-47ef-990b-a6285a87ba4e
     status: 200 OK
     code: 200
     duration: ""
@@ -479,19 +479,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398088Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:44.489808247Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:09.534634693Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1407"
+      - "1450"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:44 GMT
+      - Fri, 07 Apr 2023 09:44:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -501,7 +501,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdee14e7-e43c-49f6-8952-4c3975beed97
+      - b028380c-e01f-4fb5-8f5d-7ecfad6e60af
     status: 200 OK
     code: 200
     duration: ""
@@ -512,19 +512,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ccabccb7-2f40-4781-b803-befca0aeaa2c.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-04T10:01:38.398088Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ccabccb7-2f40-4781-b803-befca0aeaa2c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"41126bcf-11c3-415a-8a6c-99caa15bf1f2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-04T10:01:44.489808Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:09.534635Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
-      - "1404"
+      - "1447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:44 GMT
+      - Fri, 07 Apr 2023 09:44:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -534,7 +534,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed50f168-b2ed-4abc-ba8d-fac635cb6da2
+      - 9dae1019-7d9d-4839-a5e7-e3b1cbcc6fbe
     status: 200 OK
     code: 200
     duration: ""
@@ -545,10 +545,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d1282f55-3490-4bef-b725-5996343043a6","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -557,7 +557,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:49 GMT
+      - Fri, 07 Apr 2023 09:44:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -567,7 +567,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a4ac0dd-f180-456e-931c-75f8cec773f1
+      - 4a6597a5-4a9e-4867-95d1-2872f2c34e64
     status: 404 Not Found
     code: 404
     duration: ""
@@ -578,7 +578,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/41126bcf-11c3-415a-8a6c-99caa15bf1f2
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b
     method: DELETE
   response:
     body: ""
@@ -588,7 +588,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:49 GMT
+      - Fri, 07 Apr 2023 09:44:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +598,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f37baa7b-383e-4f0e-ad9c-ed6376f86d47
+      - 747bac9e-ac4a-45f2-acb7-34860d2aeb71
     status: 204 No Content
     code: 204
     duration: ""
@@ -609,10 +609,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ccabccb7-2f40-4781-b803-befca0aeaa2c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ccabccb7-2f40-4781-b803-befca0aeaa2c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d1282f55-3490-4bef-b725-5996343043a6","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -621,7 +621,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 04 Apr 2023 10:01:50 GMT
+      - Fri, 07 Apr 2023 09:44:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +631,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d45b20c-316d-4b2d-bbec-5989299ea2a2
+      - 1bb5d4d7-bfaf-433d-b039-ab2441a9e95b
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
The use of the TrimLeft function was causing some issues in the tests, and it turned out that the ID didn't even have to be trimmed.