### PR TITLE
test(k8s): fixed expected cnis + duplicate name in tests

### DIFF
--- a/scaleway/data_source_k8s_version_test.go
+++ b/scaleway/data_source_k8s_version_test.go
@@ -21,15 +21,16 @@ func TestAccScalewayDataSourceK8SVersion_Basic(t *testing.T) {
 			{
 				Config: `
 					data "scaleway_k8s_version" "by_name" {
-						name = "1.26.0"
+						name = "1.26.2"
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayK8SVersionExists(tt, "data.scaleway_k8s_version.by_name"),
 					resource.TestCheckResourceAttrSet("data.scaleway_k8s_version.by_name", "name"),
-					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_cnis.#", "2"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_cnis.#", "3"),
 					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_cnis.0", "cilium"),
 					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_cnis.1", "calico"),
+					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_cnis.2", "kilo"),
 					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_container_runtimes.#", "1"),
 					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_container_runtimes.0", "containerd"),
 					resource.TestCheckResourceAttr("data.scaleway_k8s_version.by_name", "available_feature_gates.#", "3"),

--- a/scaleway/resource_k8s_pool_test.go
+++ b/scaleway/resource_k8s_pool_test.go
@@ -378,22 +378,22 @@ func TestAccScalewayK8SCluster_PoolPrivateNetwork(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-				resource "scaleway_vpc_private_network" "private_network" {
+				resource "scaleway_vpc_private_network" "pn" {
 				  name       = "k8s-private-network"
 				}
 
-				resource "scaleway_k8s_cluster" "private_network" {
+				resource "scaleway_k8s_cluster" "cluster_with_pn" {
 				  name = "k8s-private-network-cluster"
 				  version = "%s"
 				  cni     = "cilium"
-				  private_network_id = scaleway_vpc_private_network.private_network.id
+				  private_network_id = scaleway_vpc_private_network.pn.id
 				  tags = [ "terraform-test", "scaleway_k8s_cluster", "private_network" ]
 				  delete_additional_resources = true
-				  depends_on = [scaleway_vpc_private_network.private_network]
+				  depends_on = [scaleway_vpc_private_network.pn]
 				}
 
-				resource "scaleway_k8s_pool" "private_network" {
-				  cluster_id          = scaleway_k8s_cluster.private_network.id
+				resource "scaleway_k8s_pool" "pool_with_pn" {
+				  cluster_id          = scaleway_k8s_cluster.cluster_with_pn.id
 				  name                = "pool"
 				  node_type           = "gp1_xs"
 				  size                = 2
@@ -402,11 +402,11 @@ func TestAccScalewayK8SCluster_PoolPrivateNetwork(t *testing.T) {
 				  wait_for_pool_ready = true
 				}`, latestK8SVersion),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayK8SClusterExists(tt, "scaleway_k8s_cluster.private_network"),
-					testAccCheckScalewayVPCPrivateNetworkExists(tt, "scaleway_vpc_private_network.private_network"),
-					testAccCheckScalewayK8SPoolExists(tt, "scaleway_k8s_pool.private_network"),
-					testAccCheckScalewayK8sClusterPrivateNetworkID(tt, "scaleway_k8s_cluster.private_network", "scaleway_vpc_private_network.private_network"),
-					testAccCheckScalewayK8SPoolServersAreInPrivateNetwork(tt, "scaleway_k8s_cluster.private_network", "scaleway_k8s_pool.private_network", "scaleway_vpc_private_network.private_network"),
+					testAccCheckScalewayK8SClusterExists(tt, "scaleway_k8s_cluster.cluster_with_pn"),
+					testAccCheckScalewayVPCPrivateNetworkExists(tt, "scaleway_vpc_private_network.pn"),
+					testAccCheckScalewayK8SPoolExists(tt, "scaleway_k8s_pool.pool_with_pn"),
+					testAccCheckScalewayK8sClusterPrivateNetworkID(tt, "scaleway_k8s_cluster.cluster_with_pn", "scaleway_vpc_private_network.pn"),
+					testAccCheckScalewayK8SPoolServersAreInPrivateNetwork(tt, "scaleway_k8s_cluster.cluster_with_pn", "scaleway_k8s_pool.pool_with_pn", "scaleway_vpc_private_network.pn"),
 				),
 			},
 		},

--- a/scaleway/testdata/data-source-k8s-version-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-version-basic.cassette.yaml
@@ -8,20 +8,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.2
     method: GET
   response:
-    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.26.0","name":"1.26.0","region":"fr-par"}'
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.2","name":"1.26.2","region":"fr-par"}'
     headers:
       Content-Length:
-      - "690"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Feb 2023 15:00:00 GMT
+      - Tue, 11 Apr 2023 12:15:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -31,7 +31,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5626d2e-e056-49b4-9843-f4181f5d5177
+      - 87bbbfcf-5057-4f05-a7b7-d985245f7f42
     status: 200 OK
     code: 200
     duration: ""
@@ -42,20 +42,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.2
     method: GET
   response:
-    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.26.0","name":"1.26.0","region":"fr-par"}'
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.2","name":"1.26.2","region":"fr-par"}'
     headers:
       Content-Length:
-      - "690"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Feb 2023 15:00:00 GMT
+      - Tue, 11 Apr 2023 12:15:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3ab3e01-7493-45a7-b363-00a63e050cb5
+      - 7add0f0d-3568-4d73-887c-b79d928b0362
     status: 200 OK
     code: 200
     duration: ""
@@ -76,20 +76,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.2
     method: GET
   response:
-    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.26.0","name":"1.26.0","region":"fr-par"}'
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.2","name":"1.26.2","region":"fr-par"}'
     headers:
       Content-Length:
-      - "690"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Feb 2023 15:00:00 GMT
+      - Tue, 11 Apr 2023 12:15:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -99,7 +99,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d42f298f-04d5-48b3-bcca-d37a4ec5a43d
+      - 06af0745-efb2-4b2e-9622-554b31342034
     status: 200 OK
     code: 200
     duration: ""
@@ -110,20 +110,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.2
     method: GET
   response:
-    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.26.0","name":"1.26.0","region":"fr-par"}'
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.2","name":"1.26.2","region":"fr-par"}'
     headers:
       Content-Length:
-      - "690"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Feb 2023 15:00:00 GMT
+      - Tue, 11 Apr 2023 12:15:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73ca5518-edec-4396-aa9a-95547e1c44ae
+      - 1b0f0b59-b500-4722-b6d3-595f03f0fc77
     status: 200 OK
     code: 200
     duration: ""
@@ -144,20 +144,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.2
     method: GET
   response:
-    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.26.0","name":"1.26.0","region":"fr-par"}'
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.2","name":"1.26.2","region":"fr-par"}'
     headers:
       Content-Length:
-      - "690"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Feb 2023 15:00:00 GMT
+      - Tue, 11 Apr 2023 12:15:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -167,7 +167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22097e7e-5824-4c72-b53f-b9393a7075cd
+      - 0ccc6050-7924-4849-82a3-e05cf55b4c27
     status: 200 OK
     code: 200
     duration: ""
@@ -178,20 +178,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions/1.26.2
     method: GET
   response:
-    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.26.0","name":"1.26.0","region":"fr-par"}'
+    body: '{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.2","name":"1.26.2","region":"fr-par"}'
     headers:
       Content-Length:
-      - "690"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Feb 2023 15:00:00 GMT
+      - Tue, 11 Apr 2023 12:15:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ea3ea0e-64fe-43ab-a188-f222b1276498
+      - 3f0a4210-6487-4f5f-b0a4-57c7e6e1ca0a
     status: 200 OK
     code: 200
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-private-network.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-private-network.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:28 GMT
+      - Tue, 11 Apr 2023 12:34:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -35,7 +35,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fae7a34d-d466-4da7-9bcb-f6c71de48c3a
+      - 95c728c3-18b2-4df4-a206-39e5337feb7e
     status: 200 OK
     code: 200
     duration: ""
@@ -51,7 +51,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-04-07T13:50:29.248847Z","id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:80b8::/64"],"tags":[],"updated_at":"2023-04-07T13:50:29.248847Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-04-11T12:35:27.884073Z","id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:54c6::/64"],"tags":[],"updated_at":"2023-04-11T12:35:27.884073Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "361"
@@ -60,7 +60,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:29 GMT
+      - Tue, 11 Apr 2023 12:35:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -70,7 +70,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31e801f2-824e-490c-9e76-e72bcd8f3b61
+      - 4a589509-f4c9-4b6e-b6a0-b14ddeeef65c
     status: 200 OK
     code: 200
     duration: ""
@@ -81,10 +81,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/c39faed2-bc4b-440e-8502-4cc37bbb2cda
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/96fcec8a-1f37-4e89-b3f3-5bec370bd3a3
     method: GET
   response:
-    body: '{"created_at":"2023-04-07T13:50:29.248847Z","id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:80b8::/64"],"tags":[],"updated_at":"2023-04-07T13:50:29.248847Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-04-11T12:35:27.884073Z","id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:54c6::/64"],"tags":[],"updated_at":"2023-04-11T12:35:27.884073Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "361"
@@ -93,7 +93,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:29 GMT
+      - Tue, 11 Apr 2023 12:35:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -103,12 +103,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5d9a74b-89dd-41c6-a4a4-c55bb70fec4e
+      - 500de2ed-c395-4a74-8610-3b08bef58ecd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.26.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda"}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.26.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3"}'
     form: {}
     headers:
       Content-Type:
@@ -119,7 +119,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602120667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:50:29.611293298Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259666540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:35:28.268563656Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1453"
@@ -128,7 +128,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:29 GMT
+      - Tue, 11 Apr 2023 12:35:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -138,7 +138,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 194a54d2-95b3-4b58-8bdf-72ba4eee93d7
+      - 0e36b76e-f875-4b14-94c0-6bfe5f38217c
     status: 200 OK
     code: 200
     duration: ""
@@ -149,10 +149,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:50:29.611293Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:35:28.268564Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1447"
@@ -161,7 +161,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:29 GMT
+      - Tue, 11 Apr 2023 12:35:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -171,7 +171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8db0c7de-87aa-4c80-b368-7f53b2597af0
+      - 3c15fcaf-93a0-4d13-aff0-7c68a9886600
     status: 200 OK
     code: 200
     duration: ""
@@ -182,10 +182,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:50:31.863971Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:35:29.963516Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1452"
@@ -194,7 +194,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:34 GMT
+      - Tue, 11 Apr 2023 12:35:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -204,7 +204,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 160a278e-8ffd-4c29-9ea1-f7cefcdb7c23
+      - eaa6c9ae-9769-463e-aa5c-c56a06e932fb
     status: 200 OK
     code: 200
     duration: ""
@@ -215,10 +215,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:50:31.863971Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:35:29.963516Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1452"
@@ -227,7 +227,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:34 GMT
+      - Tue, 11 Apr 2023 12:35:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -237,7 +237,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 848fee9a-c841-45ba-87c6-4d15295ab855
+      - 9a9528d3-44b5-4a47-8707-b17cbc6fd0f8
     status: 200 OK
     code: 200
     duration: ""
@@ -248,10 +248,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGRPYWtWNlRsUkJlazFXYjFoRVZFMTZUVVJSZDA1cVJYcE9WRUY2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMjl3Q2tSbk9HNXVaWEUzUzNJNGFGSkVOREYzV0drck5IaFRZbXh4ZWtVMWMxSlZjVmQyUVZWaWFuZFVUVVpTVTI1SlRHNHhhMEZwWkZoRFZuVk1Vbk5GTVV3S0szcG5VekF3VmpCVFVESmFUazFZUlROd1MwNW1abGwzTWtGSk1VNTVNMUJqYzNkRlZHSnRaVTFvVGtSa2EzTlZNa1p3VkZkUWIyeGlLMmRqZFRoMWNncFVNakpDVW1ONlQxZDFjMkpIWXpZelF6RjJURzlSTlZZMFFtOVlaRzVsZGtSUVdWVm9Meko1YjNSUmJHeEVORU14WVZoblYydE9VM2szVjNsMVNFMUtDalJqZEVrMmMydFJNV3hQYWtSMGJVbGFLMFIxYkc5SU1tdHBWSE0zUkVOb1JURlBNVEZpWjBkNFpIQnpkbVJaVG1aRWRYSlFOMjlLTURSWllrMTRMMkVLUWxSaVZXVlZLelZWY0hGblRsbHBTRmRpWVZWT1VFODJZM2hZU1VrMFJteFFUbWxTV0RJMU0yOTZiRlZJV0dGdmMwbG9TemxQTDNGT00ybGxNWEptVXdwNlJqRmtWbU5LWm1wbWJpdFZaMmxTVXpGalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTWFUVlVNVXNyZDNaSk4yMDNRUzlTWkN0Q1oycFNRMVI2Um5oTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFQwMVljbGt6VFZkeFlYZG9kWE5RUWxwTFRHdGlaVll3UTAxdlMxZExSbFJ3WldzM2JYcHdLMEY2SzNsUmJVNVdkd28wV1N0cVpUZEljMkVyY1N0VVkwWXlTR2RtV1ZCbFlWbHZRMFZCWWpWaGVIcDVWbmxVVVZaRFNVMVJNekV4V2tWbk1FTlVhMEV4Vm5nM1NEQlFSME5NQ2pNM1FpdFFTVTk2U2pndmNtSXJTVlZLTHlzNFMyaGtVbXBWVVc0dmFWaHNhVzUzYTJsYWJXdzFiMnhaZGxsVmVEbFlNbHBTVlcxUWEwbHBaRnBXWm5VS05XaGtRM3BpV1dsdU1GSk1iMncyUzBaemRUVnhTRzFUVmpGMFoxbFlTVFpXYUZCNFIxQkdlVTE1SzBwNlVUSmpkakE0Y0d0U2VuZHVhV3BJUW05eWFncHNRMk0wTDBWT05FOHdPSE5FVFdGb0wzaDRjMFJFYjBsbUwyeE1ibUp3TjFKdVlWSTNlbEl3ZVZSNFF6Wktaa3RaTlRWMk9VMVdVa2QwTlRrelJERlZDbFZsT0RFelZXbFplbTl2U0dwSFIzUjJNVTgyT0U5cWJWUm5UamxXVmpoWWJsVkZhQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjA5NTg4NmEtNmY4MC00MjQ3LTgxNTEtZTNkOTY5OTk4NTA2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCZ0RqanhjUjJlbGZzSkIyWHA0RWM1Vm12ZnFqbVdPN1JzV29lZVVVZVUxRjBVbnZUM2ZTUDFyZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGhOUkVWNVRYcFZlVTlXYjFoRVZFMTZUVVJSZUUxRVJYbE5lbFY1VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbUZaQ2pkTmRXMVNaVE1yUWtkR1ZYVjRSVk5ET0hKb1ozaHlWalJsVFUxT1F5dFpMMVZVVDFwWFR5OHhkblpDTjJWWE16VXpSVFY2YUZCMWVYQnFlVEY2Y1VFS2NGSTFZalpKY0VOaGJrdFRVM0pIY21SaFYzUkdOV1JsVlRkT2VWWm5abTQzTUdaR2NTdHNZVVZ3Ym1kdFZYRmlNbGxoWmxWU1NEQjJXVUZRTWxCaVNBcHBaMUJsVUdwdFVHeG9SR1J1SzBZMGNqZHhhVmxYUW5OV2NIQXZTak5pWTFSd1YzVmFMMmR4YzJwa1ZrUm9NREZTTnpsVVlXRnFSM3BRTlV0M04yaGhDbHBDZGpWa1kzVnlURlYzYUhOU0x6SnhWVmwyZWxGcVRrSnpSVGd3Ukc1SVZ6UkRXVmh4ZWxGRFRUSkpObEZaVmxweE5WTnZTbmRKVWxJd2RrOW9WelFLYVhWT1dtcExkMDVMTkROVWFUTmtSMnBOWXpkRVZIQlNWRGg2WW14YU5EbHdaRkp6YUhkTlJYaFhWazlhV21wWFppdEVZVmxWYjJWclRsWTRTV1I0UVFwTWJXRlpOWFY0VFZOUWEzVndTVWc1T1Zjd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1dsVnBWbEl6YkU5RlRUTnNWRlZ3T0M5WFJuSjJiQzlNUkU5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmVrZG1VMnB0UjJONVJIVndZMU16WkVSQ2JrZGphRE01TmtRMVRHMXFiMFV6UVdaV2VtUk1SV0p4WWpaeU5tMXpUQXA0WTNCRWJVUTJjMjh5ZUVWaWNtNVphVFIzTDNKTlVrZEpVemRTWTFoVlVGaDZPRlZRYzNZMllYazVibkV5WlRWaFltZFFaVmxuT0ZOcFUxSnJVbGN3Q205V1FqTjVVVmgwTlRoMEsySlhXbUZWUWs1TmFVSm5Xamg1YlU0cmN6Wm1VaXRKY21kalJrWmxkVkZHT0hwNllrNW1NR1VyWW1OM01HcFpNeTluY3pnS1NUbEVUV1JCVUhoM05uUjFWbVJhTlVWaU1rRkdVQ3RJYVZGcFZXNVFlR2RNWXpZclZpOVBTVGxyZFU5Wk1UQjZURk14TWtoS1RWQllWU3REYzNOcVVncEtNWHBxU1dKd2VrNTRSemN4UTJ3MU5VSkpURzFuTUhwdU4ySm9SRUZzY2sxYU0xZHhhSEpoU21aMmNqQTBVRVIyZG5oQmEwRjRVSEY2UTBWWmVsaFpDbk01Ym10eFNGaDBTaTgwWWxkVlJXMDJjaTlOU0ZORlFrMUZXWEpwUmpKcFVUaHZkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTk4MDhhMjEtMjEzMC00YmI2LTg0NTEtODhhNWIyZjE5NGUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMUE1hdFZFZVR3OXNKRkc0c0ZoU29mU3FPeVhUNEcwQTE2WlNWcTVsSHZzZXdKNFhKYXVWVGVKMA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -260,7 +260,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:34 GMT
+      - Tue, 11 Apr 2023 12:35:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -270,7 +270,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76b2825a-7f52-41c1-b773-f4462adc1df5
+      - f5a37512-8f82-4417-9419-0c485239e343
     status: 200 OK
     code: 200
     duration: ""
@@ -281,10 +281,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:50:31.863971Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:35:29.963516Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1452"
@@ -293,7 +293,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:35 GMT
+      - Tue, 11 Apr 2023 12:35:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -303,7 +303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaa619ff-bf77-4bdb-8a75-b677e41d3b64
+      - 44305ad7-2662-4d79-8dfc-05b00f052901
     status: 200 OK
     code: 200
     duration: ""
@@ -316,10 +316,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253266Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670234840Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "590"
@@ -328,7 +328,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:35 GMT
+      - Tue, 11 Apr 2023 12:35:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -338,7 +338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d60af7f-642d-4f6d-8583-a9253d61d356
+      - 21612594-54a5-4196-9f6d-84c331989f02
     status: 200 OK
     code: 200
     duration: ""
@@ -349,10 +349,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -361,7 +361,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:35 GMT
+      - Tue, 11 Apr 2023 12:35:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -371,7 +371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a6deb74-5683-4440-aa6a-4fe6fcab435b
+      - 6dd351a7-983e-4a0d-ae39-b8fb41195cc2
     status: 200 OK
     code: 200
     duration: ""
@@ -382,10 +382,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -394,7 +394,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:40 GMT
+      - Tue, 11 Apr 2023 12:35:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -404,7 +404,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2dbcabcb-21c9-4102-9b2a-503ba196c1b3
+      - cf51cdd9-25f2-4630-aa81-8a9a7efd9d92
     status: 200 OK
     code: 200
     duration: ""
@@ -415,10 +415,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -427,7 +427,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:45 GMT
+      - Tue, 11 Apr 2023 12:35:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -437,7 +437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 172ea29b-8143-4554-bf05-3538beab8691
+      - 14de4cd9-e0ed-47ba-afa6-15f0b33203ad
     status: 200 OK
     code: 200
     duration: ""
@@ -448,10 +448,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -460,7 +460,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:50 GMT
+      - Tue, 11 Apr 2023 12:35:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -470,7 +470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f703c75-6ccb-43cb-9d69-c18abee19623
+      - 9a48b420-df99-46da-8056-d1cde24d68cd
     status: 200 OK
     code: 200
     duration: ""
@@ -481,10 +481,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -493,7 +493,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:50:55 GMT
+      - Tue, 11 Apr 2023 12:35:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -503,7 +503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b1a81d1-4108-4bb4-97ae-206758185470
+      - cefd11d9-abd2-43ce-92aa-27fa8bf0afa9
     status: 200 OK
     code: 200
     duration: ""
@@ -514,10 +514,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -526,7 +526,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:00 GMT
+      - Tue, 11 Apr 2023 12:35:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -536,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79dda18f-6203-4853-a211-1a476db55d94
+      - 68f33522-1595-4202-baf1-90e04c826e9c
     status: 200 OK
     code: 200
     duration: ""
@@ -547,10 +547,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -559,7 +559,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:05 GMT
+      - Tue, 11 Apr 2023 12:36:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -569,7 +569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaa6800a-5390-4ef8-8c96-f083a4f59eb1
+      - 3bbb99d9-3962-4f2d-bf6b-4b1f297c0a2b
     status: 200 OK
     code: 200
     duration: ""
@@ -580,10 +580,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -592,7 +592,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:10 GMT
+      - Tue, 11 Apr 2023 12:36:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -602,7 +602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92778d2b-67e4-4bf1-8d8a-859fc0ce3bbf
+      - 54628baa-5f07-4fb0-9b02-0ecdd6bcd051
     status: 200 OK
     code: 200
     duration: ""
@@ -613,10 +613,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -625,7 +625,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:15 GMT
+      - Tue, 11 Apr 2023 12:36:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -635,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e6ad8f4-d10d-401b-9e02-ab719b608e7a
+      - c1b9ec66-63eb-4115-b853-346a460f8d78
     status: 200 OK
     code: 200
     duration: ""
@@ -646,10 +646,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -658,7 +658,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:21 GMT
+      - Tue, 11 Apr 2023 12:36:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -668,7 +668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89efc157-22e6-4925-b2c4-584793c01998
+      - c1e32550-4e70-4da6-bd50-33989c512253
     status: 200 OK
     code: 200
     duration: ""
@@ -679,10 +679,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -691,7 +691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:26 GMT
+      - Tue, 11 Apr 2023 12:36:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -701,7 +701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ac958d0-c5cb-44e4-8fa1-f6fe9fc86862
+      - 153a5474-cbba-427a-9cd7-811dbbfe9daf
     status: 200 OK
     code: 200
     duration: ""
@@ -712,10 +712,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -724,7 +724,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:31 GMT
+      - Tue, 11 Apr 2023 12:36:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -734,7 +734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05ebe2f1-8253-4824-bbfa-fb2f884f630c
+      - d3c3defd-cc00-44b5-9300-faf362ab4dac
     status: 200 OK
     code: 200
     duration: ""
@@ -745,10 +745,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -757,7 +757,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:36 GMT
+      - Tue, 11 Apr 2023 12:36:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -767,7 +767,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86be609b-4a7f-4008-802e-7cb6fc5633b0
+      - 31432a7e-10d8-410d-81c9-c0c2b0fc1dc6
     status: 200 OK
     code: 200
     duration: ""
@@ -778,10 +778,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -790,7 +790,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:41 GMT
+      - Tue, 11 Apr 2023 12:36:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -800,7 +800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c269dd19-8648-43ea-a209-3d9d16786620
+      - 4abb054e-f551-49fb-84b3-b61422a41fc1
     status: 200 OK
     code: 200
     duration: ""
@@ -811,10 +811,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -823,7 +823,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:46 GMT
+      - Tue, 11 Apr 2023 12:36:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -833,7 +833,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3e42e38-f292-40aa-969e-44bd51bf7882
+      - d6f2c867-02c1-48d2-a5bb-b8d0bf0d5279
     status: 200 OK
     code: 200
     duration: ""
@@ -844,10 +844,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:51 GMT
+      - Tue, 11 Apr 2023 12:36:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -866,7 +866,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c577a899-da79-4fa4-9476-a6cbd9a3d8f6
+      - a1e0a44f-aebd-48c1-8f8f-1933da79fd62
     status: 200 OK
     code: 200
     duration: ""
@@ -877,10 +877,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -889,7 +889,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:51:56 GMT
+      - Tue, 11 Apr 2023 12:36:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -899,7 +899,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baebbfef-f090-4f9c-9219-d01814dace85
+      - df681812-86af-4582-92a4-b5d7cf6565c0
     status: 200 OK
     code: 200
     duration: ""
@@ -910,10 +910,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -922,7 +922,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:01 GMT
+      - Tue, 11 Apr 2023 12:37:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 055d04f6-288c-4954-9817-ccd43f164045
+      - 7073d541-97da-4766-b526-77385b278e1e
     status: 200 OK
     code: 200
     duration: ""
@@ -943,10 +943,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -955,7 +955,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:06 GMT
+      - Tue, 11 Apr 2023 12:37:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -965,7 +965,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba01f860-3544-4615-ac86-81690d219980
+      - c13a41bf-b32e-4601-9788-8f5614087642
     status: 200 OK
     code: 200
     duration: ""
@@ -976,10 +976,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -988,7 +988,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:11 GMT
+      - Tue, 11 Apr 2023 12:37:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -998,7 +998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8ed2aaa-95ed-4b56-915a-326e1f84311d
+      - 1ccca3cf-4e1c-4aaa-9177-8d68a16823d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1009,10 +1009,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1021,7 +1021,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:16 GMT
+      - Tue, 11 Apr 2023 12:37:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1031,7 +1031,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2509d5ba-01f4-472a-8d45-04d5c10ac21c
+      - 1b3eb347-415e-47f1-9f5c-8681e489ddfa
     status: 200 OK
     code: 200
     duration: ""
@@ -1042,10 +1042,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1054,7 +1054,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:21 GMT
+      - Tue, 11 Apr 2023 12:37:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1064,7 +1064,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9be6680d-8c0d-4d84-b221-98335fc5250a
+      - dcc1bca0-7421-43b7-89d6-0526927e5587
     status: 200 OK
     code: 200
     duration: ""
@@ -1075,10 +1075,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1087,7 +1087,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:26 GMT
+      - Tue, 11 Apr 2023 12:37:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1097,7 +1097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ab4d03f-04c5-412e-9ff1-2c750b137057
+      - d1ac9352-1e7c-4f7e-8e7b-5cdbb707243f
     status: 200 OK
     code: 200
     duration: ""
@@ -1108,10 +1108,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1120,7 +1120,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:31 GMT
+      - Tue, 11 Apr 2023 12:37:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1130,7 +1130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d786718f-063a-445c-85a5-ed3c9774065e
+      - e03aa7f4-ced8-41dd-bed8-00a5a634b830
     status: 200 OK
     code: 200
     duration: ""
@@ -1141,10 +1141,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1153,7 +1153,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:36 GMT
+      - Tue, 11 Apr 2023 12:37:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1163,7 +1163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5234c72b-4878-42f3-90e4-ba48475ae9d3
+      - cbaa61be-97ad-40a0-bd0f-1737db41f699
     status: 200 OK
     code: 200
     duration: ""
@@ -1174,10 +1174,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1186,7 +1186,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:42 GMT
+      - Tue, 11 Apr 2023 12:37:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1196,7 +1196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d970fc6d-1004-4f4e-8401-d1edd6546a0c
+      - 96514467-b824-405e-b389-41f74346b323
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,10 +1207,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1219,7 +1219,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:47 GMT
+      - Tue, 11 Apr 2023 12:37:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1229,7 +1229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa0d714f-11a4-432f-b516-e015b19bd589
+      - 04b72a8e-a465-42f1-bec7-33c4975a8d5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1240,10 +1240,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1252,7 +1252,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:52 GMT
+      - Tue, 11 Apr 2023 12:37:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1262,7 +1262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49a08bde-f9f1-494e-b232-4f914f206163
+      - 065591b9-619b-45f5-907d-65132768e069
     status: 200 OK
     code: 200
     duration: ""
@@ -1273,10 +1273,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1285,7 +1285,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:52:57 GMT
+      - Tue, 11 Apr 2023 12:37:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2f056e4-5f5f-4d89-a8c4-1350d424d98a
+      - d658189d-90fd-4d8a-ab29-b8c82dc89d8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1306,10 +1306,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1318,7 +1318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:02 GMT
+      - Tue, 11 Apr 2023 12:38:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1328,7 +1328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caf0101f-1c11-49fc-a257-bebe4b3920db
+      - bb7fe6d9-8053-4968-80a9-ee3926d577ff
     status: 200 OK
     code: 200
     duration: ""
@@ -1339,10 +1339,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1351,7 +1351,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:07 GMT
+      - Tue, 11 Apr 2023 12:38:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1361,7 +1361,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02adadcf-80c1-455b-957b-d3a807f5e15a
+      - 6ba03f03-4456-41a7-aad0-f104a969b50e
     status: 200 OK
     code: 200
     duration: ""
@@ -1372,10 +1372,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1384,7 +1384,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:12 GMT
+      - Tue, 11 Apr 2023 12:38:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1394,7 +1394,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29a5f23d-57b3-463c-a9ff-7878b732865a
+      - 579fcdd6-f5e7-4301-92c2-a19811869304
     status: 200 OK
     code: 200
     duration: ""
@@ -1405,10 +1405,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1417,7 +1417,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:17 GMT
+      - Tue, 11 Apr 2023 12:38:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1427,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19d7ea6d-bf14-4251-b334-2a71d550615c
+      - e3bffe70-ea1f-432a-8b6d-f8f3b5420a84
     status: 200 OK
     code: 200
     duration: ""
@@ -1438,10 +1438,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1450,7 +1450,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:22 GMT
+      - Tue, 11 Apr 2023 12:38:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bd8843c-9596-40ec-a34f-4f16195f2b6e
+      - 3f7e68d6-13d3-4994-b194-bb8197cadda1
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,10 +1471,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1483,7 +1483,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:27 GMT
+      - Tue, 11 Apr 2023 12:38:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a71b855a-c40d-4853-967e-cc22151c80d4
+      - 596c3c00-8a80-4f66-915c-2ce42799cd21
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,10 +1504,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1516,7 +1516,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:32 GMT
+      - Tue, 11 Apr 2023 12:38:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4097b857-b916-4ad7-ab2b-bb433afdc6f2
+      - ba5e0874-7893-4078-9fc7-b4f4c7b5ff6d
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,10 +1537,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1549,7 +1549,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:37 GMT
+      - Tue, 11 Apr 2023 12:38:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 467fdcac-41d1-4745-9e27-f6097999ee82
+      - a88f6018-902b-4758-bed7-24a1ad566370
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,10 +1570,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1582,7 +1582,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:42 GMT
+      - Tue, 11 Apr 2023 12:38:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 729dcc22-727e-44ee-b7e3-806540395d2b
+      - f1b90cf4-5a97-4a38-afae-65d1c4957600
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,10 +1603,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1615,7 +1615,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:47 GMT
+      - Tue, 11 Apr 2023 12:38:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a92d834-1ef1-4841-937a-a7ed26c895a3
+      - 58404f58-232f-4770-a4b9-df6c6a0e7dd4
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,10 +1636,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1648,7 +1648,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:52 GMT
+      - Tue, 11 Apr 2023 12:38:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26ac31e0-e417-479a-afc7-6f5a75c0e903
+      - 9a3203d6-37a4-44d3-8648-58f776b5ce99
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,10 +1669,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1681,7 +1681,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:53:57 GMT
+      - Tue, 11 Apr 2023 12:38:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5c3da0d-ac4c-43ca-87c9-46f2dd5047fa
+      - a81d84e0-1c8d-4e05-9d0f-1f556e115e03
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,10 +1702,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1714,7 +1714,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:02 GMT
+      - Tue, 11 Apr 2023 12:39:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05e79d77-7627-4abd-be5f-ebbe456eb78f
+      - bc326124-c071-4032-8414-16dec3e5fa82
     status: 200 OK
     code: 200
     duration: ""
@@ -1735,10 +1735,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1747,7 +1747,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:08 GMT
+      - Tue, 11 Apr 2023 12:39:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1757,7 +1757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 322302d1-e001-49d0-9c5e-258e396bce0e
+      - df6b1854-ed18-4fd8-9063-28cc2b687a56
     status: 200 OK
     code: 200
     duration: ""
@@ -1768,10 +1768,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1780,7 +1780,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:13 GMT
+      - Tue, 11 Apr 2023 12:39:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1790,7 +1790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b656b122-4ac5-478c-8f4f-c53584dc22f8
+      - d5aa5cb1-6b17-4122-85e9-32b5b6e64bba
     status: 200 OK
     code: 200
     duration: ""
@@ -1801,10 +1801,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1813,7 +1813,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:18 GMT
+      - Tue, 11 Apr 2023 12:39:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1823,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5858349f-6c12-4dec-98f2-e73cbd352b57
+      - ffb6484f-069d-4251-9f40-5ee0a0033cbd
     status: 200 OK
     code: 200
     duration: ""
@@ -1834,10 +1834,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1846,7 +1846,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:23 GMT
+      - Tue, 11 Apr 2023 12:39:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1856,7 +1856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e9b3870-eb2b-409a-8238-af26ae735aef
+      - 4b2b6e5e-c032-45eb-8f79-90134efe4fb7
     status: 200 OK
     code: 200
     duration: ""
@@ -1867,10 +1867,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1879,7 +1879,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:28 GMT
+      - Tue, 11 Apr 2023 12:39:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1889,7 +1889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 206201d6-148d-43e6-b099-3523f10d7341
+      - 07c150eb-82b6-4171-bf75-7917287c27b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1900,10 +1900,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1912,7 +1912,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:33 GMT
+      - Tue, 11 Apr 2023 12:39:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1922,7 +1922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60c8f938-2de9-4e64-91ae-35ffac306a14
+      - ffc3b72a-65df-45fd-9d36-9aa86a17ddaf
     status: 200 OK
     code: 200
     duration: ""
@@ -1933,10 +1933,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1945,7 +1945,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:38 GMT
+      - Tue, 11 Apr 2023 12:39:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1955,7 +1955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a29790b0-8aa2-4c33-a890-3e2d631f7da7
+      - 6166e204-4e85-420e-9b4c-eeb8f2fdd5c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1966,10 +1966,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -1978,7 +1978,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:43 GMT
+      - Tue, 11 Apr 2023 12:39:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1988,7 +1988,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d62a4cc-b22f-42c4-aea8-296fd33bd456
+      - 91fef83e-c734-4732-a132-a0621040ed0e
     status: 200 OK
     code: 200
     duration: ""
@@ -1999,10 +1999,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2011,7 +2011,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:48 GMT
+      - Tue, 11 Apr 2023 12:39:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2021,7 +2021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aa1316f-c9b3-428f-b8ff-9459d88e34a6
+      - 15062f02-f674-483a-9f5f-6a6dd928e1d2
     status: 200 OK
     code: 200
     duration: ""
@@ -2032,10 +2032,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2044,7 +2044,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:53 GMT
+      - Tue, 11 Apr 2023 12:39:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2054,7 +2054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64e2922e-5a65-47f2-99c8-df068dd23490
+      - 148485cd-bc8a-477e-968e-120f968abe79
     status: 200 OK
     code: 200
     duration: ""
@@ -2065,10 +2065,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2077,7 +2077,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:54:58 GMT
+      - Tue, 11 Apr 2023 12:39:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2087,7 +2087,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 040e087c-8203-4404-adfd-4210d5064f29
+      - b30da032-2dc9-4973-ab3c-ffcabdafaa38
     status: 200 OK
     code: 200
     duration: ""
@@ -2098,10 +2098,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2110,7 +2110,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:03 GMT
+      - Tue, 11 Apr 2023 12:40:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2120,7 +2120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2098af54-50e3-44a7-9ead-e07e802cb3f3
+      - 7976c015-5607-4466-adb5-51d77c08e20b
     status: 200 OK
     code: 200
     duration: ""
@@ -2131,10 +2131,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2143,7 +2143,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:08 GMT
+      - Tue, 11 Apr 2023 12:40:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2153,7 +2153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 975f1c8c-694f-482e-a182-7b3aec346ccc
+      - 5d3a4ef0-661e-403d-b25e-5573a005027c
     status: 200 OK
     code: 200
     duration: ""
@@ -2164,10 +2164,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2176,7 +2176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:13 GMT
+      - Tue, 11 Apr 2023 12:40:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2186,7 +2186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e5c2d22-ac3c-4385-9249-ca6c7a06c82b
+      - cf62fddd-c2b9-4ac1-ba7d-18776dbbdb45
     status: 200 OK
     code: 200
     duration: ""
@@ -2197,10 +2197,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2209,7 +2209,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:18 GMT
+      - Tue, 11 Apr 2023 12:40:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2219,7 +2219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0e713d6-367d-45b4-8127-85f3eac79403
+      - 9b06243e-7ab3-4314-8e08-b1a9159f992a
     status: 200 OK
     code: 200
     duration: ""
@@ -2230,10 +2230,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2242,7 +2242,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:23 GMT
+      - Tue, 11 Apr 2023 12:40:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2252,7 +2252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e2ba4f4-bb40-4a7a-a3a0-7ed101e1bd95
+      - 483367e1-9936-473f-9fc7-1a82007130a6
     status: 200 OK
     code: 200
     duration: ""
@@ -2263,10 +2263,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2275,7 +2275,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:29 GMT
+      - Tue, 11 Apr 2023 12:40:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2285,7 +2285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 003ac59f-53cf-46fa-8f52-0e6134b2e63a
+      - 14cffb25-3948-420d-9c81-c172b220788c
     status: 200 OK
     code: 200
     duration: ""
@@ -2296,10 +2296,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2308,7 +2308,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:34 GMT
+      - Tue, 11 Apr 2023 12:40:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2318,7 +2318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1295486-941b-4487-80a2-56333999f44c
+      - 1ec72ccd-99d0-44aa-97ec-de2a9246bcf8
     status: 200 OK
     code: 200
     duration: ""
@@ -2329,10 +2329,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2341,7 +2341,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:39 GMT
+      - Tue, 11 Apr 2023 12:40:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2351,7 +2351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3e9fd4d-26b7-4576-9dc1-10485199c58a
+      - 964225ed-c841-4470-b349-39703e6a37b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2362,10 +2362,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2374,7 +2374,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:44 GMT
+      - Tue, 11 Apr 2023 12:40:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2384,7 +2384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e13168a-34ec-48c4-a13f-c12a9de2ff83
+      - 7d6486cb-203b-492c-be60-e01b666be8a3
     status: 200 OK
     code: 200
     duration: ""
@@ -2395,10 +2395,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2407,7 +2407,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:49 GMT
+      - Tue, 11 Apr 2023 12:40:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2417,7 +2417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d116d2d4-2e81-4403-a5d4-8d83b60cca7e
+      - 5034ed35-e044-40fc-bfc0-2549ec51df17
     status: 200 OK
     code: 200
     duration: ""
@@ -2428,10 +2428,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2440,7 +2440,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:54 GMT
+      - Tue, 11 Apr 2023 12:40:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2450,7 +2450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 251b92cd-87ff-4ff9-b145-967eb0560520
+      - f839b7a7-27be-4db5-918f-5662500e7386
     status: 200 OK
     code: 200
     duration: ""
@@ -2461,10 +2461,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2473,7 +2473,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:55:59 GMT
+      - Tue, 11 Apr 2023 12:40:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2483,7 +2483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4e3a967-0766-4f9d-8fca-5c0398185a08
+      - b2a41e54-8d6d-400a-8bdc-ba3a7c1645ed
     status: 200 OK
     code: 200
     duration: ""
@@ -2494,10 +2494,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2506,7 +2506,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:04 GMT
+      - Tue, 11 Apr 2023 12:41:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2516,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8a8bf44-f7a3-4038-ba81-10b1c10dad26
+      - 7a0ca196-d75d-4066-8af7-c7a19f0fd785
     status: 200 OK
     code: 200
     duration: ""
@@ -2527,10 +2527,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2539,7 +2539,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:09 GMT
+      - Tue, 11 Apr 2023 12:41:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2549,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f33882b8-de31-482b-9dcb-ed989adc153e
+      - e8879fcc-749f-4aa1-80fa-7ae7a2501393
     status: 200 OK
     code: 200
     duration: ""
@@ -2560,10 +2560,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2572,7 +2572,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:14 GMT
+      - Tue, 11 Apr 2023 12:41:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2582,7 +2582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a613903-3ffe-4e1b-a7b9-e8026fad0435
+      - fd174a0d-6f17-43d9-bfe9-c5a5d3e84984
     status: 200 OK
     code: 200
     duration: ""
@@ -2593,10 +2593,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2605,7 +2605,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:19 GMT
+      - Tue, 11 Apr 2023 12:41:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2615,7 +2615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d8cc218-d9e1-4a60-b8b7-409e11764945
+      - 9119dd6e-24a3-47e6-8f9f-257cd790791b
     status: 200 OK
     code: 200
     duration: ""
@@ -2626,10 +2626,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2638,7 +2638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:24 GMT
+      - Tue, 11 Apr 2023 12:41:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2648,7 +2648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d17834b1-e70d-4db3-95c3-b5d9795daa86
+      - 252c3974-b308-478b-bc72-b1da0027a38c
     status: 200 OK
     code: 200
     duration: ""
@@ -2659,10 +2659,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2671,7 +2671,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:29 GMT
+      - Tue, 11 Apr 2023 12:41:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2681,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a3a8ac0-dc8d-4a93-9caa-fa5dee2c9a9e
+      - 5e3473ce-c6d6-44c2-9b9f-24dc736b7a27
     status: 200 OK
     code: 200
     duration: ""
@@ -2692,10 +2692,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2704,7 +2704,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:34 GMT
+      - Tue, 11 Apr 2023 12:41:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2714,7 +2714,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43ffd8ee-a700-4113-b69c-ea7524909910
+      - 4f54ce9d-4929-434a-b21a-ecee7cc36825
     status: 200 OK
     code: 200
     duration: ""
@@ -2725,10 +2725,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2737,7 +2737,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:39 GMT
+      - Tue, 11 Apr 2023 12:41:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2747,7 +2747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1d01e8a-78f1-4c71-a013-f00f65145298
+      - 78c8c7db-f280-498c-b842-4e384ad82be7
     status: 200 OK
     code: 200
     duration: ""
@@ -2758,10 +2758,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2770,7 +2770,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:45 GMT
+      - Tue, 11 Apr 2023 12:41:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2780,7 +2780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d774437-23b6-465a-93f9-95eebdb843a3
+      - 566eae7a-3f22-480b-a322-44c0a03f2606
     status: 200 OK
     code: 200
     duration: ""
@@ -2791,10 +2791,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2803,7 +2803,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:50 GMT
+      - Tue, 11 Apr 2023 12:41:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2813,7 +2813,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 263e020e-9ba1-4729-b332-4f4bf33ff59b
+      - c4465227-8343-4b05-83fd-77a060f5db0d
     status: 200 OK
     code: 200
     duration: ""
@@ -2824,10 +2824,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2836,7 +2836,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:56:55 GMT
+      - Tue, 11 Apr 2023 12:41:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2846,7 +2846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a8939bb-37b2-455b-bc75-7e67bda517e9
+      - 8da1a880-cd18-475b-bdb3-ef13fb30912c
     status: 200 OK
     code: 200
     duration: ""
@@ -2857,10 +2857,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2869,7 +2869,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:00 GMT
+      - Tue, 11 Apr 2023 12:41:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2879,7 +2879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adf441f3-2366-4fc7-8bed-f96d9d81f339
+      - 4812cb4a-d6c6-4409-9119-e3a3b00534f5
     status: 200 OK
     code: 200
     duration: ""
@@ -2890,10 +2890,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2902,7 +2902,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:05 GMT
+      - Tue, 11 Apr 2023 12:42:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2912,7 +2912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a1884b4-5a6d-4c50-bb7a-f8d111d9e5fd
+      - 5eacea86-05c2-43ab-a916-fefe672d7345
     status: 200 OK
     code: 200
     duration: ""
@@ -2923,10 +2923,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2935,7 +2935,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:10 GMT
+      - Tue, 11 Apr 2023 12:42:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2945,7 +2945,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89553f2d-550b-43cb-9e28-c37ab055e77e
+      - 9cfd3e0e-94ae-4e08-9941-0f5c4cca15fe
     status: 200 OK
     code: 200
     duration: ""
@@ -2956,10 +2956,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -2968,7 +2968,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:15 GMT
+      - Tue, 11 Apr 2023 12:42:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2978,7 +2978,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15579e28-2861-44a8-82ea-ba3da3a53c7f
+      - 4fb06444-96c9-4bdf-8fab-36abed7007d9
     status: 200 OK
     code: 200
     duration: ""
@@ -2989,10 +2989,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3001,7 +3001,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:20 GMT
+      - Tue, 11 Apr 2023 12:42:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3011,7 +3011,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1aa801c-07f4-4bdd-9782-a95ca4ddc88b
+      - 3fa9ebaa-f358-4a10-9e3f-95cf0172b0f2
     status: 200 OK
     code: 200
     duration: ""
@@ -3022,10 +3022,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3034,7 +3034,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:25 GMT
+      - Tue, 11 Apr 2023 12:42:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3044,7 +3044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80bb0e83-36ab-4b27-aafb-36ab29eb3ec0
+      - 63da899a-89fa-4127-8e82-03f2811f84bb
     status: 200 OK
     code: 200
     duration: ""
@@ -3055,10 +3055,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3067,7 +3067,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:30 GMT
+      - Tue, 11 Apr 2023 12:42:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3077,7 +3077,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c246d552-e74b-49b8-be14-763521559fde
+      - b66f61e1-9111-4e03-9f61-b195dca6f65d
     status: 200 OK
     code: 200
     duration: ""
@@ -3088,10 +3088,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3100,7 +3100,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:35 GMT
+      - Tue, 11 Apr 2023 12:42:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3110,7 +3110,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9df06b4d-71a0-4d88-98a5-bc63b1276da9
+      - b514c247-9502-4a5d-8eae-54d1d2c1ed7e
     status: 200 OK
     code: 200
     duration: ""
@@ -3121,10 +3121,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3133,7 +3133,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:40 GMT
+      - Tue, 11 Apr 2023 12:42:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3143,7 +3143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb233b43-6cb2-4357-a30d-9f89ec9a8cc7
+      - 0b956ceb-9fd7-4b02-b639-dd86bae103bc
     status: 200 OK
     code: 200
     duration: ""
@@ -3154,10 +3154,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3166,7 +3166,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:45 GMT
+      - Tue, 11 Apr 2023 12:42:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3176,7 +3176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33fd3b20-8d6a-4d72-a913-205c753591b8
+      - e30f4737-12ff-454c-afca-4b7d9f746e2a
     status: 200 OK
     code: 200
     duration: ""
@@ -3187,10 +3187,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3199,7 +3199,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:50 GMT
+      - Tue, 11 Apr 2023 12:42:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3209,7 +3209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a3271da-5d46-4299-81fd-231cbd59ea99
+      - b34d9728-d998-4fa9-b0b3-921c249080b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3220,10 +3220,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3232,7 +3232,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:57:55 GMT
+      - Tue, 11 Apr 2023 12:42:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3242,7 +3242,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca1d1c71-7561-41d2-8725-13074b3af40d
+      - aa5d4ac8-b872-4a21-9714-8dd19258723f
     status: 200 OK
     code: 200
     duration: ""
@@ -3253,10 +3253,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3265,7 +3265,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:00 GMT
+      - Tue, 11 Apr 2023 12:43:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3275,7 +3275,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e015e74-a803-4d9a-bd1f-88fbf5e526d3
+      - 8bf36008-c716-4ecb-a109-f05a5b953769
     status: 200 OK
     code: 200
     duration: ""
@@ -3286,10 +3286,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3298,7 +3298,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:05 GMT
+      - Tue, 11 Apr 2023 12:43:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3308,7 +3308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5405125d-2915-4f36-b8b3-79e0735554e8
+      - 87a67807-e4ff-4a43-9418-701dfba2c315
     status: 200 OK
     code: 200
     duration: ""
@@ -3319,10 +3319,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3331,7 +3331,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:11 GMT
+      - Tue, 11 Apr 2023 12:43:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3341,7 +3341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9810cef-5e30-448f-9bb5-1b52e1da8200
+      - 16c1cd9a-f6d1-4f06-977c-1d804072eb35
     status: 200 OK
     code: 200
     duration: ""
@@ -3352,10 +3352,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3364,7 +3364,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:16 GMT
+      - Tue, 11 Apr 2023 12:43:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3374,7 +3374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 734c8338-ff1e-48d0-ad75-6aca609e20c0
+      - 66bd2ca3-2c7d-460b-a4fc-f9e2b20d737f
     status: 200 OK
     code: 200
     duration: ""
@@ -3385,10 +3385,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3397,7 +3397,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:21 GMT
+      - Tue, 11 Apr 2023 12:43:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3407,7 +3407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9d22192-bbce-4e71-93e9-56ff22881ae7
+      - ac6c8a4b-289b-445f-bacb-5eefdb45340a
     status: 200 OK
     code: 200
     duration: ""
@@ -3418,10 +3418,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3430,7 +3430,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:26 GMT
+      - Tue, 11 Apr 2023 12:43:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3440,7 +3440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9c3e7a7-609a-4d28-b76c-e39d03490837
+      - 88e0435e-11b3-40f9-acdd-fd23a210818d
     status: 200 OK
     code: 200
     duration: ""
@@ -3451,10 +3451,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3463,7 +3463,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:31 GMT
+      - Tue, 11 Apr 2023 12:43:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3473,7 +3473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9d4c17c-e36f-49d6-942c-5a1405a9c775
+      - ce98a2bb-41df-4914-b8ab-51bfaa88fcf9
     status: 200 OK
     code: 200
     duration: ""
@@ -3484,10 +3484,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3496,7 +3496,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:36 GMT
+      - Tue, 11 Apr 2023 12:43:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3506,7 +3506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d4656e7-9073-4618-9c3f-b070bc6e8fd2
+      - 1f98e28a-2d52-48f6-8fde-db6c0f853afb
     status: 200 OK
     code: 200
     duration: ""
@@ -3517,10 +3517,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3529,7 +3529,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:41 GMT
+      - Tue, 11 Apr 2023 12:43:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3539,7 +3539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b28bb545-fdd1-46e7-9b15-e26939b59c1e
+      - 3038e27d-3840-4001-ab5c-ecab476e7e7f
     status: 200 OK
     code: 200
     duration: ""
@@ -3550,10 +3550,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-07T13:50:35.090253Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "587"
@@ -3562,7 +3562,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:46 GMT
+      - Tue, 11 Apr 2023 12:43:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3572,7 +3572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e09d5d5c-5e68-4e13-aca4-e77317ecc4b4
+      - 526096c9-993d-42e9-98bf-a9a9d426e6a1
     status: 200 OK
     code: 200
     duration: ""
@@ -3583,10 +3583,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-04-07T13:58:46.534372Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-04-11T12:35:33.670235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "587"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 11 Apr 2023 12:43:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0feae60a-1355-47b6-ba9d-46f3a5a1f4af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-04-11T12:43:55.488898Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "585"
@@ -3595,7 +3628,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3605,7 +3638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0b620de-f774-4a10-868d-b5065443a590
+      - dfe34e79-112e-4a55-b56e-d16d0686a360
     status: 200 OK
     code: 200
     duration: ""
@@ -3616,10 +3649,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:51:43.619966Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:36:25.495131Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1444"
@@ -3628,7 +3661,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3638,7 +3671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d204b32f-271e-4a84-a125-14214c46e4c9
+      - 6c66f38c-9012-41bf-a32f-59d30377355a
     status: 200 OK
     code: 200
     duration: ""
@@ -3649,10 +3682,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-04-07T13:58:46.534372Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-04-11T12:43:55.488898Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "585"
@@ -3661,7 +3694,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3671,7 +3704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec4a2278-d7c9-4356-8145-038e48d5dee9
+      - 91c31f29-605a-4c09-97ad-8b18f06ba046
     status: 200 OK
     code: 200
     duration: ""
@@ -3682,19 +3715,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506/nodes?order_by=created_at_asc&page=1&pool_id=d07f8661-59da-4bf6-b63c-d964fec920dc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0/nodes?order_by=created_at_asc&page=1&pool_id=3f1c2316-0865-45fe-aa8e-8b83cb18a53d&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-07T13:52:11.393337Z","error_message":null,"id":"2b99bd67-f9af-49de-9068-74e16f3e70e8","name":"scw-k8s-private-network-cluster-pool-2b99bd67f","pool_id":"d07f8661-59da-4bf6-b63c-d964fec920dc","provider_id":"scaleway://instance/fr-par-1/73b656a0-ab4d-4938-a47a-b0e32c5f1722","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-07T13:58:46.492791Z"},{"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-07T13:53:19.651718Z","error_message":null,"id":"f3247c3d-959a-4bca-b6cb-bbefc876e8b7","name":"scw-k8s-private-network-cluster-pool-f3247c3d9","pool_id":"d07f8661-59da-4bf6-b63c-d964fec920dc","provider_id":"scaleway://instance/fr-par-1/c2b09629-cf19-483b-b1d4-2883d199eb5b","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-07T13:58:46.518088Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-11T12:38:17.924628Z","error_message":null,"id":"75e81d92-e967-4691-a040-3673abc215fe","name":"scw-k8s-private-network-cluster-pool-75e81d92e","pool_id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","provider_id":"scaleway://instance/fr-par-1/6f3a3563-b5c3-4e11-b18d-de21299843a4","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-11T12:43:55.465283Z"},{"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-11T12:40:30.151116Z","error_message":null,"id":"d4bb720e-4a23-4109-b247-103e9fbac3d1","name":"scw-k8s-private-network-cluster-pool-d4bb720e4","pool_id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","provider_id":"scaleway://instance/fr-par-1/0028ebb8-6688-4082-8350-295a3c4fa20c","public_ip_v4":"163.172.176.167","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-11T12:43:55.479087Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1214"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3704,7 +3737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bf9cc42-df26-438b-9ff8-2e2c5a0cea68
+      - 0e7cbbd1-bf8d-4b94-ad41-264be0fa4172
     status: 200 OK
     code: 200
     duration: ""
@@ -3715,10 +3748,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:51:43.619966Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:36:25.495131Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1444"
@@ -3727,7 +3760,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3737,7 +3770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65566661-1815-4e02-8394-13589ec3a617
+      - 7d212db7-5f43-4504-b75f-9394a95eed4c
     status: 200 OK
     code: 200
     duration: ""
@@ -3748,10 +3781,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/c39faed2-bc4b-440e-8502-4cc37bbb2cda
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/96fcec8a-1f37-4e89-b3f3-5bec370bd3a3
     method: GET
   response:
-    body: '{"created_at":"2023-04-07T13:50:29.248847Z","id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:80b8::/64"],"tags":[],"updated_at":"2023-04-07T13:50:29.248847Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-04-11T12:35:27.884073Z","id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:54c6::/64"],"tags":[],"updated_at":"2023-04-11T12:35:27.884073Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "361"
@@ -3760,7 +3793,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3770,7 +3803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfc39f8c-2fd3-445e-b98c-c1d4c43267f9
+      - 12bfd97e-2797-42bc-a34c-44d5bdd912f2
     status: 200 OK
     code: 200
     duration: ""
@@ -3781,10 +3814,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-04-07T13:58:46.534372Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-04-11T12:43:55.488898Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "585"
@@ -3793,7 +3826,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3803,7 +3836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80c917ab-408e-44fa-a20d-e397fdfc2a41
+      - 1eec5599-8fe7-43f5-a8e6-7e5224344701
     status: 200 OK
     code: 200
     duration: ""
@@ -3814,10 +3847,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:51:43.619966Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:36:25.495131Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1444"
@@ -3826,7 +3859,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3836,7 +3869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a27c46e5-20ee-4392-b4ea-37387fa6c52d
+      - 99060c55-9275-4589-83af-5628e106e4c7
     status: 200 OK
     code: 200
     duration: ""
@@ -3847,19 +3880,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506/nodes?order_by=created_at_asc&pool_id=d07f8661-59da-4bf6-b63c-d964fec920dc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0/nodes?order_by=created_at_asc&pool_id=3f1c2316-0865-45fe-aa8e-8b83cb18a53d&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-07T13:52:11.393337Z","error_message":null,"id":"2b99bd67-f9af-49de-9068-74e16f3e70e8","name":"scw-k8s-private-network-cluster-pool-2b99bd67f","pool_id":"d07f8661-59da-4bf6-b63c-d964fec920dc","provider_id":"scaleway://instance/fr-par-1/73b656a0-ab4d-4938-a47a-b0e32c5f1722","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-07T13:58:46.492791Z"},{"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-07T13:53:19.651718Z","error_message":null,"id":"f3247c3d-959a-4bca-b6cb-bbefc876e8b7","name":"scw-k8s-private-network-cluster-pool-f3247c3d9","pool_id":"d07f8661-59da-4bf6-b63c-d964fec920dc","provider_id":"scaleway://instance/fr-par-1/c2b09629-cf19-483b-b1d4-2883d199eb5b","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-07T13:58:46.518088Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-11T12:38:17.924628Z","error_message":null,"id":"75e81d92-e967-4691-a040-3673abc215fe","name":"scw-k8s-private-network-cluster-pool-75e81d92e","pool_id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","provider_id":"scaleway://instance/fr-par-1/6f3a3563-b5c3-4e11-b18d-de21299843a4","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-11T12:43:55.465283Z"},{"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-11T12:40:30.151116Z","error_message":null,"id":"d4bb720e-4a23-4109-b247-103e9fbac3d1","name":"scw-k8s-private-network-cluster-pool-d4bb720e4","pool_id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","provider_id":"scaleway://instance/fr-par-1/0028ebb8-6688-4082-8350-295a3c4fa20c","public_ip_v4":"163.172.176.167","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-11T12:43:55.479087Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1214"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:51 GMT
+      - Tue, 11 Apr 2023 12:43:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3869,7 +3902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9976b6e3-603b-4211-8869-e30a50dc55fe
+      - bdac883a-8b09-43f0-b2eb-fef1b3783044
     status: 200 OK
     code: 200
     duration: ""
@@ -3880,15 +3913,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/73b656a0-ab4d-4938-a47a-b0e32c5f1722
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6f3a3563-b5c3-4e11-b18d-de21299843a4
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-04-07T13:52:12.034034+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-k8s-private-network-cluster-pool-2b99bd67f","id":"73b656a0-ab4d-4938-a47a-b0e32c5f1722","image":{"arch":"x86_64","creation_date":"2021-04-12T11:08:57.473796+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"39a71c71-bb3e-4ba9-b550-e45f491cf6a7","modification_date":"2021-04-12T11:08:59.914868+00:00","name":"Kubernetes
-      base node 94cae785 20210412-1103","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"b2b0cd24-b0c2-4806-92cc-edb58a1fdfb0","name":"k8s_base_node_2021-04-12_11:03","size":10000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:610:4804::1","gateway":"2001:bc8:610:4804::","netmask":"64"},"location":{"cluster_id":"50","hypervisor_id":"1402","node_id":"5","platform_id":"14","zone_id":"par1"},"maintenances":[],"modification_date":"2023-04-07T13:55:54.402635+00:00","name":"scw-k8s-private-network-cluster-pool-2b99bd67f","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.194.72.201","private_nics":[{"creation_date":"2023-04-07T13:52:12.590287+00:00","id":"6ce8863a-075f-4136-a5b9-6fd532800aa6","mac_address":"02:00:00:12:a6:5c","modification_date":"2023-04-07T13:52:13.556794+00:00","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","server_id":"73b656a0-ab4d-4938-a47a-b0e32c5f1722","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.15.211.1","dynamic":true,"id":"d3970f1f-ac85-4434-904d-760f78fef8f8"},"security_group":{"id":"c32f80e2-f8a7-485b-ae97-5bdc16c3694e","name":"kubernetes
-      6095886a-6f80-4247-8151-e3d969998506"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=6095886a-6f80-4247-8151-e3d969998506","pool=d07f8661-59da-4bf6-b63c-d964fec920dc","pool-name=pool","runtime=containerd","managed=true","node=2b99bd67-f9af-49de-9068-74e16f3e70e8"],"volumes":{"0":{"boot":false,"creation_date":"2023-04-07T13:52:12.034034+00:00","export_uri":null,"id":"9718b321-f184-4fcd-a8aa-775a5ecdc924","modification_date":"2023-04-07T13:52:12.034034+00:00","name":"k8s_base_node_2021-04-12_11:03","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"73b656a0-ab4d-4938-a47a-b0e32c5f1722","name":"scw-k8s-private-network-cluster-pool-2b99bd67f"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-04-11T12:38:18.810585+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-k8s-private-network-cluster-pool-75e81d92e","id":"6f3a3563-b5c3-4e11-b18d-de21299843a4","image":{"arch":"x86_64","creation_date":"2021-04-12T11:08:57.473796+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"39a71c71-bb3e-4ba9-b550-e45f491cf6a7","modification_date":"2021-04-12T11:08:59.914868+00:00","name":"Kubernetes
+      base node 94cae785 20210412-1103","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"b2b0cd24-b0c2-4806-92cc-edb58a1fdfb0","name":"k8s_base_node_2021-04-12_11:03","size":10000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:700:1800::1","gateway":"2001:bc8:700:1800::","netmask":"64"},"location":{"cluster_id":"57","hypervisor_id":"701","node_id":"1","platform_id":"14","zone_id":"par1"},"maintenances":[],"modification_date":"2023-04-11T12:41:37.087814+00:00","name":"scw-k8s-private-network-cluster-pool-75e81d92e","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.194.184.1","private_nics":[{"creation_date":"2023-04-11T12:38:19.471057+00:00","id":"e1e0a55a-01dc-4da9-b8af-342de3a6def6","mac_address":"02:00:00:12:ae:e3","modification_date":"2023-04-11T12:38:20.414437+00:00","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","server_id":"6f3a3563-b5c3-4e11-b18d-de21299843a4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.15.140.177","dynamic":true,"id":"43aa5f62-be0f-464e-aba6-6d247bd1974e"},"security_group":{"id":"9a8ad09c-41ef-4666-9b21-95565ea6243c","name":"kubernetes
+      99808a21-2130-4bb6-8451-88a5b2f194e0"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=99808a21-2130-4bb6-8451-88a5b2f194e0","pool=3f1c2316-0865-45fe-aa8e-8b83cb18a53d","pool-name=pool","runtime=containerd","managed=true","node=75e81d92-e967-4691-a040-3673abc215fe"],"volumes":{"0":{"boot":false,"creation_date":"2023-04-11T12:38:18.810585+00:00","export_uri":null,"id":"d1981fab-6022-4bb6-9df9-4a281ed43e3f","modification_date":"2023-04-11T12:38:18.810585+00:00","name":"k8s_base_node_2021-04-12_11:03","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"6f3a3563-b5c3-4e11-b18d-de21299843a4","name":"scw-k8s-private-network-cluster-pool-75e81d92e"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "3554"
@@ -3897,7 +3930,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:52 GMT
+      - Tue, 11 Apr 2023 12:43:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3907,7 +3940,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5949f5bc-3222-4194-b53a-4e80b4e10e58
+      - c06b6ce8-b8d2-46a8-aa0c-ea73bc3e767d
     status: 200 OK
     code: 200
     duration: ""
@@ -3918,24 +3951,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c2b09629-cf19-483b-b1d4-2883d199eb5b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0028ebb8-6688-4082-8350-295a3c4fa20c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-04-07T13:53:20.025533+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-k8s-private-network-cluster-pool-f3247c3d9","id":"c2b09629-cf19-483b-b1d4-2883d199eb5b","image":{"arch":"x86_64","creation_date":"2021-04-12T11:08:57.473796+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"39a71c71-bb3e-4ba9-b550-e45f491cf6a7","modification_date":"2021-04-12T11:08:59.914868+00:00","name":"Kubernetes
-      base node 94cae785 20210412-1103","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"b2b0cd24-b0c2-4806-92cc-edb58a1fdfb0","name":"k8s_base_node_2021-04-12_11:03","size":10000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:700:e03::1","gateway":"2001:bc8:700:e03::","netmask":"64"},"location":{"cluster_id":"57","hypervisor_id":"403","node_id":"4","platform_id":"14","zone_id":"par1"},"maintenances":[],"modification_date":"2023-04-07T13:55:52.784697+00:00","name":"scw-k8s-private-network-cluster-pool-f3247c3d9","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.194.181.135","private_nics":[{"creation_date":"2023-04-07T13:53:20.541690+00:00","id":"0fa32a7a-2a3e-4c63-ada1-e37ca8281946","mac_address":"02:00:00:12:a6:5d","modification_date":"2023-04-07T13:53:21.167084+00:00","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","server_id":"c2b09629-cf19-483b-b1d4-2883d199eb5b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"212.47.247.189","dynamic":true,"id":"7248555e-5f71-49cb-9117-abeea9ccbc58"},"security_group":{"id":"c32f80e2-f8a7-485b-ae97-5bdc16c3694e","name":"kubernetes
-      6095886a-6f80-4247-8151-e3d969998506"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=6095886a-6f80-4247-8151-e3d969998506","pool=d07f8661-59da-4bf6-b63c-d964fec920dc","pool-name=pool","runtime=containerd","managed=true","node=f3247c3d-959a-4bca-b6cb-bbefc876e8b7"],"volumes":{"0":{"boot":false,"creation_date":"2023-04-07T13:53:20.025533+00:00","export_uri":null,"id":"91ad0109-7ac0-40b4-bc89-bbae109d5311","modification_date":"2023-04-07T13:53:20.025533+00:00","name":"k8s_base_node_2021-04-12_11:03","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"c2b09629-cf19-483b-b1d4-2883d199eb5b","name":"scw-k8s-private-network-cluster-pool-f3247c3d9"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-04-11T12:40:30.584326+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-k8s-private-network-cluster-pool-d4bb720e4","id":"0028ebb8-6688-4082-8350-295a3c4fa20c","image":{"arch":"x86_64","creation_date":"2021-04-12T11:08:57.473796+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"39a71c71-bb3e-4ba9-b550-e45f491cf6a7","modification_date":"2021-04-12T11:08:59.914868+00:00","name":"Kubernetes
+      base node 94cae785 20210412-1103","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"b2b0cd24-b0c2-4806-92cc-edb58a1fdfb0","name":"k8s_base_node_2021-04-12_11:03","size":10000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:624:b02::1","gateway":"2001:bc8:624:b02::","netmask":"64"},"location":{"cluster_id":"27","hypervisor_id":"602","node_id":"3","platform_id":"14","zone_id":"par1"},"maintenances":[],"modification_date":"2023-04-11T12:41:38.866903+00:00","name":"scw-k8s-private-network-cluster-pool-d4bb720e4","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.66.44.197","private_nics":[{"creation_date":"2023-04-11T12:40:31.257575+00:00","id":"2c649c12-0423-4fc2-9db8-3a967bf9fb7d","mac_address":"02:00:00:12:ae:e4","modification_date":"2023-04-11T12:40:31.913183+00:00","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","server_id":"0028ebb8-6688-4082-8350-295a3c4fa20c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"163.172.176.167","dynamic":true,"id":"8b4cee07-cb17-4260-bfc2-fe9d6428d320"},"security_group":{"id":"9a8ad09c-41ef-4666-9b21-95565ea6243c","name":"kubernetes
+      99808a21-2130-4bb6-8451-88a5b2f194e0"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=99808a21-2130-4bb6-8451-88a5b2f194e0","pool=3f1c2316-0865-45fe-aa8e-8b83cb18a53d","pool-name=pool","runtime=containerd","managed=true","node=d4bb720e-4a23-4109-b247-103e9fbac3d1"],"volumes":{"0":{"boot":false,"creation_date":"2023-04-11T12:40:30.584326+00:00","export_uri":null,"id":"476838f8-b9bb-4bd2-afaf-5d60a0ea58a6","modification_date":"2023-04-11T12:40:30.584326+00:00","name":"k8s_base_node_2021-04-12_11:03","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"0028ebb8-6688-4082-8350-295a3c4fa20c","name":"scw-k8s-private-network-cluster-pool-d4bb720e4"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3555"
+      - "3554"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:52 GMT
+      - Tue, 11 Apr 2023 12:43:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3945,7 +3978,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30546e53-9664-48c9-9f2a-421e2c53b14e
+      - adb757f8-5e72-41dc-b571-60219cf4099b
     status: 200 OK
     code: 200
     duration: ""
@@ -3956,10 +3989,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/c39faed2-bc4b-440e-8502-4cc37bbb2cda
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/96fcec8a-1f37-4e89-b3f3-5bec370bd3a3
     method: GET
   response:
-    body: '{"created_at":"2023-04-07T13:50:29.248847Z","id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:80b8::/64"],"tags":[],"updated_at":"2023-04-07T13:50:29.248847Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-04-11T12:35:27.884073Z","id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:54c6::/64"],"tags":[],"updated_at":"2023-04-11T12:35:27.884073Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "361"
@@ -3968,7 +4001,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:52 GMT
+      - Tue, 11 Apr 2023 12:43:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3978,7 +4011,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e05e80a-0d7c-4c84-886d-a978fce69be2
+      - c6d57d25-8869-4234-a1ad-1320871295f6
     status: 200 OK
     code: 200
     duration: ""
@@ -3989,10 +4022,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:51:43.619966Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:36:25.495131Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1444"
@@ -4001,7 +4034,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:52 GMT
+      - Tue, 11 Apr 2023 12:43:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4011,7 +4044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b90b2ff-c73a-482b-8a97-03719eee7421
+      - e43762df-ab8c-4e5d-b368-8b70e32cc4df
     status: 200 OK
     code: 200
     duration: ""
@@ -4022,10 +4055,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGRPYWtWNlRsUkJlazFXYjFoRVZFMTZUVVJSZDA1cVJYcE9WRUY2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMjl3Q2tSbk9HNXVaWEUzUzNJNGFGSkVOREYzV0drck5IaFRZbXh4ZWtVMWMxSlZjVmQyUVZWaWFuZFVUVVpTVTI1SlRHNHhhMEZwWkZoRFZuVk1Vbk5GTVV3S0szcG5VekF3VmpCVFVESmFUazFZUlROd1MwNW1abGwzTWtGSk1VNTVNMUJqYzNkRlZHSnRaVTFvVGtSa2EzTlZNa1p3VkZkUWIyeGlLMmRqZFRoMWNncFVNakpDVW1ONlQxZDFjMkpIWXpZelF6RjJURzlSTlZZMFFtOVlaRzVsZGtSUVdWVm9Meko1YjNSUmJHeEVORU14WVZoblYydE9VM2szVjNsMVNFMUtDalJqZEVrMmMydFJNV3hQYWtSMGJVbGFLMFIxYkc5SU1tdHBWSE0zUkVOb1JURlBNVEZpWjBkNFpIQnpkbVJaVG1aRWRYSlFOMjlLTURSWllrMTRMMkVLUWxSaVZXVlZLelZWY0hGblRsbHBTRmRpWVZWT1VFODJZM2hZU1VrMFJteFFUbWxTV0RJMU0yOTZiRlZJV0dGdmMwbG9TemxQTDNGT00ybGxNWEptVXdwNlJqRmtWbU5LWm1wbWJpdFZaMmxTVXpGalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTWFUVlVNVXNyZDNaSk4yMDNRUzlTWkN0Q1oycFNRMVI2Um5oTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFQwMVljbGt6VFZkeFlYZG9kWE5RUWxwTFRHdGlaVll3UTAxdlMxZExSbFJ3WldzM2JYcHdLMEY2SzNsUmJVNVdkd28wV1N0cVpUZEljMkVyY1N0VVkwWXlTR2RtV1ZCbFlWbHZRMFZCWWpWaGVIcDVWbmxVVVZaRFNVMVJNekV4V2tWbk1FTlVhMEV4Vm5nM1NEQlFSME5NQ2pNM1FpdFFTVTk2U2pndmNtSXJTVlZLTHlzNFMyaGtVbXBWVVc0dmFWaHNhVzUzYTJsYWJXdzFiMnhaZGxsVmVEbFlNbHBTVlcxUWEwbHBaRnBXWm5VS05XaGtRM3BpV1dsdU1GSk1iMncyUzBaemRUVnhTRzFUVmpGMFoxbFlTVFpXYUZCNFIxQkdlVTE1SzBwNlVUSmpkakE0Y0d0U2VuZHVhV3BJUW05eWFncHNRMk0wTDBWT05FOHdPSE5FVFdGb0wzaDRjMFJFYjBsbUwyeE1ibUp3TjFKdVlWSTNlbEl3ZVZSNFF6Wktaa3RaTlRWMk9VMVdVa2QwTlRrelJERlZDbFZsT0RFelZXbFplbTl2U0dwSFIzUjJNVTgyT0U5cWJWUm5UamxXVmpoWWJsVkZhQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNjA5NTg4NmEtNmY4MC00MjQ3LTgxNTEtZTNkOTY5OTk4NTA2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCZ0RqanhjUjJlbGZzSkIyWHA0RWM1Vm12ZnFqbVdPN1JzV29lZVVVZVUxRjBVbnZUM2ZTUDFyZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGhOUkVWNVRYcFZlVTlXYjFoRVZFMTZUVVJSZUUxRVJYbE5lbFY1VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbUZaQ2pkTmRXMVNaVE1yUWtkR1ZYVjRSVk5ET0hKb1ozaHlWalJsVFUxT1F5dFpMMVZVVDFwWFR5OHhkblpDTjJWWE16VXpSVFY2YUZCMWVYQnFlVEY2Y1VFS2NGSTFZalpKY0VOaGJrdFRVM0pIY21SaFYzUkdOV1JsVlRkT2VWWm5abTQzTUdaR2NTdHNZVVZ3Ym1kdFZYRmlNbGxoWmxWU1NEQjJXVUZRTWxCaVNBcHBaMUJsVUdwdFVHeG9SR1J1SzBZMGNqZHhhVmxYUW5OV2NIQXZTak5pWTFSd1YzVmFMMmR4YzJwa1ZrUm9NREZTTnpsVVlXRnFSM3BRTlV0M04yaGhDbHBDZGpWa1kzVnlURlYzYUhOU0x6SnhWVmwyZWxGcVRrSnpSVGd3Ukc1SVZ6UkRXVmh4ZWxGRFRUSkpObEZaVmxweE5WTnZTbmRKVWxJd2RrOW9WelFLYVhWT1dtcExkMDVMTkROVWFUTmtSMnBOWXpkRVZIQlNWRGg2WW14YU5EbHdaRkp6YUhkTlJYaFhWazlhV21wWFppdEVZVmxWYjJWclRsWTRTV1I0UVFwTWJXRlpOWFY0VFZOUWEzVndTVWc1T1Zjd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1dsVnBWbEl6YkU5RlRUTnNWRlZ3T0M5WFJuSjJiQzlNUkU5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmVrZG1VMnB0UjJONVJIVndZMU16WkVSQ2JrZGphRE01TmtRMVRHMXFiMFV6UVdaV2VtUk1SV0p4WWpaeU5tMXpUQXA0WTNCRWJVUTJjMjh5ZUVWaWNtNVphVFIzTDNKTlVrZEpVemRTWTFoVlVGaDZPRlZRYzNZMllYazVibkV5WlRWaFltZFFaVmxuT0ZOcFUxSnJVbGN3Q205V1FqTjVVVmgwTlRoMEsySlhXbUZWUWs1TmFVSm5Xamg1YlU0cmN6Wm1VaXRKY21kalJrWmxkVkZHT0hwNllrNW1NR1VyWW1OM01HcFpNeTluY3pnS1NUbEVUV1JCVUhoM05uUjFWbVJhTlVWaU1rRkdVQ3RJYVZGcFZXNVFlR2RNWXpZclZpOVBTVGxyZFU5Wk1UQjZURk14TWtoS1RWQllWU3REYzNOcVVncEtNWHBxU1dKd2VrNTRSemN4UTJ3MU5VSkpURzFuTUhwdU4ySm9SRUZzY2sxYU0xZHhhSEpoU21aMmNqQTBVRVIyZG5oQmEwRjRVSEY2UTBWWmVsaFpDbk01Ym10eFNGaDBTaTgwWWxkVlJXMDJjaTlOU0ZORlFrMUZXWEpwUmpKcFVUaHZkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTk4MDhhMjEtMjEzMC00YmI2LTg0NTEtODhhNWIyZjE5NGUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMUE1hdFZFZVR3OXNKRkc0c0ZoU29mU3FPeVhUNEcwQTE2WlNWcTVsSHZzZXdKNFhKYXVWVGVKMA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -4034,7 +4067,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:52 GMT
+      - Tue, 11 Apr 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4044,7 +4077,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a67e458-2a2c-478f-9f6b-c053606fca09
+      - 87ad706c-91d1-4ebb-a252-0bb3358ba112
     status: 200 OK
     code: 200
     duration: ""
@@ -4055,10 +4088,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-04-07T13:58:46.534372Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-04-11T12:43:55.488898Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "585"
@@ -4067,7 +4100,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:52 GMT
+      - Tue, 11 Apr 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4077,7 +4110,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2664fad-cb02-4c92-9b26-7149fedc0bf7
+      - 305c9d1e-aa97-4aea-8d9a-388443718771
     status: 200 OK
     code: 200
     duration: ""
@@ -4088,19 +4121,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506/nodes?order_by=created_at_asc&page=1&pool_id=d07f8661-59da-4bf6-b63c-d964fec920dc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0/nodes?order_by=created_at_asc&page=1&pool_id=3f1c2316-0865-45fe-aa8e-8b83cb18a53d&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-07T13:52:11.393337Z","error_message":null,"id":"2b99bd67-f9af-49de-9068-74e16f3e70e8","name":"scw-k8s-private-network-cluster-pool-2b99bd67f","pool_id":"d07f8661-59da-4bf6-b63c-d964fec920dc","provider_id":"scaleway://instance/fr-par-1/73b656a0-ab4d-4938-a47a-b0e32c5f1722","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-07T13:58:46.492791Z"},{"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-07T13:53:19.651718Z","error_message":null,"id":"f3247c3d-959a-4bca-b6cb-bbefc876e8b7","name":"scw-k8s-private-network-cluster-pool-f3247c3d9","pool_id":"d07f8661-59da-4bf6-b63c-d964fec920dc","provider_id":"scaleway://instance/fr-par-1/c2b09629-cf19-483b-b1d4-2883d199eb5b","public_ip_v4":"212.47.247.189","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-07T13:58:46.518088Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-11T12:38:17.924628Z","error_message":null,"id":"75e81d92-e967-4691-a040-3673abc215fe","name":"scw-k8s-private-network-cluster-pool-75e81d92e","pool_id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","provider_id":"scaleway://instance/fr-par-1/6f3a3563-b5c3-4e11-b18d-de21299843a4","public_ip_v4":"51.15.140.177","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-11T12:43:55.465283Z"},{"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-04-11T12:40:30.151116Z","error_message":null,"id":"d4bb720e-4a23-4109-b247-103e9fbac3d1","name":"scw-k8s-private-network-cluster-pool-d4bb720e4","pool_id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","provider_id":"scaleway://instance/fr-par-1/0028ebb8-6688-4082-8350-295a3c4fa20c","public_ip_v4":"163.172.176.167","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-04-11T12:43:55.479087Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1214"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:52 GMT
+      - Tue, 11 Apr 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4110,7 +4143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fe24ce1-d895-4a40-a02b-bdbc0f5c49f0
+      - deb9e9b4-ea89-49a1-9970-59de18693bd0
     status: 200 OK
     code: 200
     duration: ""
@@ -4121,10 +4154,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d07f8661-59da-4bf6-b63c-d964fec920dc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/3f1c2316-0865-45fe-aa8e-8b83cb18a53d
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"6095886a-6f80-4247-8151-e3d969998506","container_runtime":"containerd","created_at":"2023-04-07T13:50:35.069905Z","id":"d07f8661-59da-4bf6-b63c-d964fec920dc","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-04-07T13:58:53.183555999Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","container_runtime":"containerd","created_at":"2023-04-11T12:35:33.664231Z","id":"3f1c2316-0865-45fe-aa8e-8b83cb18a53d","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-04-11T12:43:58.396271671Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.26.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "591"
@@ -4133,7 +4166,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:53 GMT
+      - Tue, 11 Apr 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4143,7 +4176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee392ad3-a1bb-40dc-ae0c-7533092d5698
+      - df60c9b4-506a-4721-838c-26e039819669
     status: 200 OK
     code: 200
     duration: ""
@@ -4154,10 +4187,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:58:53.263136558Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:43:58.480564761Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1450"
@@ -4166,7 +4199,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:53 GMT
+      - Tue, 11 Apr 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4176,7 +4209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69548064-83bd-4aa5-83b4-49dc2137085f
+      - 282e84f7-5d0f-448f-9f85-66ff43ec42d4
     status: 200 OK
     code: 200
     duration: ""
@@ -4187,10 +4220,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:58:53.263137Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:43:58.480565Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1447"
@@ -4199,7 +4232,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:53 GMT
+      - Tue, 11 Apr 2023 12:43:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4209,7 +4242,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d982b629-97df-457f-8457-d66153796a31
+      - 0b53cf49-1a15-414f-8ec3-c3dea8d2341f
     status: 200 OK
     code: 200
     duration: ""
@@ -4220,10 +4253,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:58:53.263137Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:43:58.480565Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1447"
@@ -4232,7 +4265,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:58:58 GMT
+      - Tue, 11 Apr 2023 12:44:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4242,7 +4275,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 542281a0-91a4-4519-985f-918e568313a7
+      - 5fa96ef7-ebea-4ee2-bcbd-176b709965ed
     status: 200 OK
     code: 200
     duration: ""
@@ -4253,10 +4286,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:58:53.263137Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:43:58.480565Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1447"
@@ -4265,7 +4298,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:59:03 GMT
+      - Tue, 11 Apr 2023 12:44:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4275,7 +4308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9292e402-27bc-4652-9267-d1a1d856fee1
+      - 1aae9033-1647-47cf-b3f5-4db2e520a294
     status: 200 OK
     code: 200
     duration: ""
@@ -4286,10 +4319,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:58:53.263137Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://99808a21-2130-4bb6-8451-88a5b2f194e0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-11T12:35:28.259667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.99808a21-2130-4bb6-8451-88a5b2f194e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"99808a21-2130-4bb6-8451-88a5b2f194e0","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"96fcec8a-1f37-4e89-b3f3-5bec370bd3a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-11T12:43:58.480565Z","upgrade_available":false,"version":"1.26.2"}'
     headers:
       Content-Length:
       - "1447"
@@ -4298,7 +4331,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:59:08 GMT
+      - Tue, 11 Apr 2023 12:44:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4308,7 +4341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2e0b9b5-981e-4e42-a791-49daca6222ae
+      - 80b45afe-bf22-4b91-bb6a-75c228801dfb
     status: 200 OK
     code: 200
     duration: ""
@@ -4319,43 +4352,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6095886a-6f80-4247-8151-e3d969998506.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","created_at":"2023-04-07T13:50:29.602121Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6095886a-6f80-4247-8151-e3d969998506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6095886a-6f80-4247-8151-e3d969998506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c39faed2-bc4b-440e-8502-4cc37bbb2cda","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T13:58:53.263137Z","upgrade_available":false,"version":"1.26.2"}'
-    headers:
-      Content-Length:
-      - "1447"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 07 Apr 2023 13:59:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9fefd3bb-04d5-4300-939f-7623e94f4d90
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6095886a-6f80-4247-8151-e3d969998506","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4364,7 +4364,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:59:18 GMT
+      - Tue, 11 Apr 2023 12:44:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4374,7 +4374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63481c33-f9a7-4312-9b28-3fa2aaa38ae0
+      - 31b414c5-b523-4303-980b-98fcee980ee0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4385,7 +4385,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/c39faed2-bc4b-440e-8502-4cc37bbb2cda
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/96fcec8a-1f37-4e89-b3f3-5bec370bd3a3
     method: DELETE
   response:
     body: ""
@@ -4395,7 +4395,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:59:19 GMT
+      - Tue, 11 Apr 2023 12:44:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4405,7 +4405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7999af6e-910c-4885-a6f3-3690eddb37aa
+      - 10d93223-3d8c-4075-bc9d-aa1ef5e43edb
     status: 204 No Content
     code: 204
     duration: ""
@@ -4416,10 +4416,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6095886a-6f80-4247-8151-e3d969998506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/99808a21-2130-4bb6-8451-88a5b2f194e0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6095886a-6f80-4247-8151-e3d969998506","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"99808a21-2130-4bb6-8451-88a5b2f194e0","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4428,7 +4428,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 13:59:19 GMT
+      - Tue, 11 Apr 2023 12:44:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4438,7 +4438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfa8191e-1b41-470b-a5fa-714d6ac745e6
+      - 82f13f17-5ca4-4e2f-a667-4c3029c2edd1
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
Fixes the latest problem in the nightly tests (k8s version 1.26.2 supports 3 CNIs instead of 2)
+ small fix : changes the names in a test to fix a small unrelated problem that sometimes occur locally (`scaleway-sdk-go: invalid argument(s): name does not respect constraint, cluster name must be unique across the project`)