### PR TITLE
fix(k8s): changes in PN should not always result in ForceNew

### DIFF
--- a/scaleway/helpers_k8s.go
+++ b/scaleway/helpers_k8s.go
@@ -256,3 +256,24 @@ func flattenKubeletArgs(args map[string]string) map[string]interface{} {
 
 	return kubeletArgs
 }
+
+func migrateToPrivateNetworkCluster(ctx context.Context, d *schema.ResourceData, i interface{}) error {
+	k8sAPI, region, clusterID, err := k8sAPIWithRegionAndID(i, d.Id())
+	if err != nil {
+		return err
+	}
+	pnID := expandRegionalID(d.Get("private_network_id").(string)).ID
+	_, err = k8sAPI.MigrateToPrivateNetworkCluster(&k8s.MigrateToPrivateNetworkClusterRequest{
+		Region:           region,
+		ClusterID:        clusterID,
+		PrivateNetworkID: pnID,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	_, err = waitK8SCluster(ctx, k8sAPI, region, clusterID, defaultK8SClusterTimeout)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/scaleway/resource_k8s_cluster_test.go
+++ b/scaleway/resource_k8s_cluster_test.go
@@ -398,12 +398,30 @@ func TestAccScalewayK8SCluster_PrivateNetwork(t *testing.T) {
 		CheckDestroy:      testAccCheckScalewayK8SClusterDestroy(tt),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckScalewayK8SClusterConfigPrivateNetwork(latestK8SVersion),
+				Config: testAccCheckScalewayK8SClusterConfigPrivateNetworkNotLinked(latestK8SVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayK8SClusterExists(tt, "scaleway_k8s_cluster.private_network"),
+					testAccCheckScalewayVPCPrivateNetworkExists(tt, "scaleway_vpc_private_network.private_network"),
+					resource.TestCheckNoResourceAttr("scaleway_k8s_cluster.private_network", "private_network_id"),
+				),
+			},
+			{
+				Config: testAccCheckScalewayK8SClusterConfigPrivateNetworkLinked(latestK8SVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayK8SClusterExists(tt, "scaleway_k8s_cluster.private_network"),
 					testAccCheckScalewayVPCPrivateNetworkExists(tt, "scaleway_vpc_private_network.private_network"),
 					testAccCheckScalewayK8sClusterPrivateNetworkID(tt, "scaleway_k8s_cluster.private_network", "scaleway_vpc_private_network.private_network"),
 				),
+			},
+			{
+				Config:             testAccCheckScalewayK8SClusterConfigPrivateNetworkChange(latestK8SVersion),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:             testAccCheckScalewayK8SClusterConfigPrivateNetworkNotLinked(latestK8SVersion),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -642,7 +660,22 @@ resource "scaleway_k8s_cluster" "auto_upgrade" {
 }`, version, enable, hour, day)
 }
 
-func testAccCheckScalewayK8SClusterConfigPrivateNetwork(version string) string {
+func testAccCheckScalewayK8SClusterConfigPrivateNetworkNotLinked(version string) string {
+	return fmt.Sprintf(`
+resource "scaleway_vpc_private_network" "private_network" {
+  name       = "k8s-private-network"
+}
+resource "scaleway_k8s_cluster" "private_network" {
+	cni = "calico"
+	version = "%s"
+	name = "k8s-private-network-cluster"
+	tags = [ "terraform-test", "scaleway_k8s_cluster", "private_network" ]
+	delete_additional_resources = true
+	depends_on = [scaleway_vpc_private_network.private_network]
+}`, version)
+}
+
+func testAccCheckScalewayK8SClusterConfigPrivateNetworkLinked(version string) string {
 	return fmt.Sprintf(`
 resource "scaleway_vpc_private_network" "private_network" {
   name       = "k8s-private-network"
@@ -655,6 +688,25 @@ resource "scaleway_k8s_cluster" "private_network" {
 	tags = [ "terraform-test", "scaleway_k8s_cluster", "private_network" ]
 	delete_additional_resources = true
 	depends_on = [scaleway_vpc_private_network.private_network]
+}`, version)
+}
+
+func testAccCheckScalewayK8SClusterConfigPrivateNetworkChange(version string) string {
+	return fmt.Sprintf(`
+resource "scaleway_vpc_private_network" "private_network" {
+ name       = "k8s-private-network"
+}
+resource "scaleway_vpc_private_network" "private_network_2" {
+ name       = "other-private-network"
+}
+resource "scaleway_k8s_cluster" "private_network" {
+	cni = "calico"
+	version = "%s"
+	name = "k8s-private-network-cluster"
+   private_network_id = scaleway_vpc_private_network.private_network_2.id
+	tags = [ "terraform-test", "scaleway_k8s_cluster", "private_network" ]
+	delete_additional_resources = true
+	depends_on = [scaleway_vpc_private_network.private_network_2]
 }`, version)
 }
 

--- a/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
@@ -6,26 +6,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
     method: GET
   response:
-    body: '{"versions":[{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.26.2","name":"1.26.2","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.25.7","name":"1.25.7","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.24.11","name":"1.24.11","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.23.16","name":"1.23.16","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.22.16","name":"1.22.16","region":"fr-par"}]}'
+    body: '{"versions":[{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.27.1","name":"1.27.1","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.4","name":"1.26.4","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.25.9","name":"1.25.9","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd","crio"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.13","name":"1.24.13","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.17","name":"1.23.17","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd","crio","docker"],"available_feature_gates":["TTLAfterFinished","HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.22.17","name":"1.22.17","region":"fr-par"}]}'
     headers:
-      Content-Length:
-      - "3835"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:02 GMT
+      - Thu, 01 Jun 2023 15:13:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -35,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad6cd2c0-d89b-4637-a6fa-008477b0630a
+      - e477777f-5231-4bbd-b3df-802c827a1ae1
     status: 200 OK
     code: 200
     duration: ""
@@ -46,21 +45,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-04-07T09:44:02.981601Z","id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:30dc::/64"],"tags":[],"updated_at":"2023-04-07T09:44:02.981601Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "361"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:03 GMT
+      - Thu, 01 Jun 2023 15:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -70,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bde8b10e-6493-4a5a-955c-8d18ff647c70
+      - 46013a22-e548-49a1-8c2e-19eab5c40815
     status: 200 OK
     code: 200
     duration: ""
@@ -79,21 +78,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
     method: GET
   response:
-    body: '{"created_at":"2023-04-07T09:44:02.981601Z","id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:30dc::/64"],"tags":[],"updated_at":"2023-04-07T09:44:02.981601Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "361"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:03 GMT
+      - Thu, 01 Jun 2023 15:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -103,32 +102,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dece01d1-a0fe-4251-8bc1-e30cef46ce55
+      - 6d111301-cf7c-46d6-8165-fdb07d617873
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.26.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b"}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.27.1","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430092Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:03.440416133Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757010Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:37.149670759Z","upgrade_available":false,"version":"1.27.1"}'
     headers:
       Content-Length:
-      - "1453"
+      - "1376"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:03 GMT
+      - Thu, 01 Jun 2023 15:18:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -138,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1967f237-0dcd-4025-85fb-5fe81ed5a666
+      - 1566fd69-38b1-4866-924e-62c097755b18
     status: 200 OK
     code: 200
     duration: ""
@@ -147,21 +146,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:03.440416Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:37.149671Z","upgrade_available":false,"version":"1.27.1"}'
     headers:
       Content-Length:
-      - "1447"
+      - "1370"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:03 GMT
+      - Thu, 01 Jun 2023 15:18:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -171,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a22b9f5e-a6ab-46cc-903f-8c2d1b9f2f11
+      - 33076e4a-9d93-4348-9d6c-8eebd3b2b750
     status: 200 OK
     code: 200
     duration: ""
@@ -180,21 +179,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:40.261457Z","upgrade_available":false,"version":"1.27.1"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1375"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:08 GMT
+      - Thu, 01 Jun 2023 15:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -204,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1fb5e05-de4b-4445-af4a-55cf209041d2
+      - 2069dcaa-66c2-46a0-9d6f-6a18c5b51072
     status: 200 OK
     code: 200
     duration: ""
@@ -213,21 +212,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:40.261457Z","upgrade_available":false,"version":"1.27.1"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1375"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:08 GMT
+      - Thu, 01 Jun 2023 15:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -237,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92608ada-f065-4519-b6b5-493b43f94bcf
+      - edebe599-a84b-49e2-9762-1b5bfd3b22c7
     status: 200 OK
     code: 200
     duration: ""
@@ -246,21 +245,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGRPYWtFMVRrUlJkMDVHYjFoRVZFMTZUVVJSZDA1cVFUVk9SRkYzVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkIwQ25OclRtWlRWemcxTDJaNFZqUkZXWEZUVlRCNWExZE1VVnBGZVVOb1lWRkhlbUZtV1ZVeloyRmhiVFJGTVRsQlpGbzRhemxUVHpKNE0weGlSRW8xTTFVS01VNVlhR2hzVG1nd1YyTjBja0pZTlRWd2FHTjZhbmRVWVZobWVtTlRhbGhJVlZjNFVFNTVUV2xvUWpoeUszUnJPVzFNYTFsVU4xTkdRamRMY0RKS1dRcEpTa0ptYms5dFpWVXZkR0l3TVhOS1VGWmlTa3BOYXpkbFlXTXZWUzlPY1NzMWRESkZiSFo0WXpoaVIwZ3dUbFpLYmpaVWIzWXpRa1pzTTJWcFZrTlJDbmRFVUVnNU5FRk9OMUV2WTJRNWIxVkNTMVZVTlRaRlFXYzNiV3RIUjBkU2Myb3pNazVNVVd4U1pFbDVhRGw0U2s5NVdqWTViMHR3VURsQk1rRmxWRW9LVVZOekwwSkROazE0ZVcwNGJHdHRZM0ZOTjA1TFEwNVNVMFJaZGtkTWVsaGlUamRLY0haWFRFYzFVVWh6ZG5weU1EQmpSRkJ3S3l0eVRtdDZSekprVlFwcmVtNUhWM0pEVkZSYU1rUlJiVm92Tm1Nd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRU0yOUlkMklySzNWYWFITktjVzB6VGxOR05ucEpPRmQ2ZFZOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmNGZGxVMjFNZVZVMk5rUXZUa1JUVFhGQ1lUbDZaRkJpUjBKVVZsaHlhRVl4UkVseFFXTlNhMGd5YTNjelZGSlllZ3BvY1dwMVQxWjBVR2g0VWpKaU1raDJVbk5aZW1abVNqbEdVRXM0ZFdOYVNXSllPRlpDUm0xWmFXTnhaV3hCZUhrMVZqTlNhMWRqWld0bmNUWkZSMkV6Q21sdWVtaFBaRkpLYTFGM1JWUlFUMnhoUjFWNlVHNXBiV3QyUWtONGVHNVJSa1k0VEROQlJsbHdhRXhCZFVsNVoxbEdWbnBvUmpoTk16SlhSVmhvUWk4S09WSm5VM1ZRZVdKblZqSkdVSEpCYlRsUVVFUmhSbWhtTUVkNGFUQkhXRXh5TlRGM09HTlliMk4wUkc4ME9URnVNMDFaYlZGa1IzaFJOV1Z1WVhkdWFRcGxVRlJuVG1aVlNIRnhkVXhIT0UxMFVWTlVkVUV3Y0U1c1NrZ3lTbEpKVm5JeWNXSkxlazAxTldWbU5ITXdOMWxEVmtvMWNsZHFVMHQxT0RFNFNVSldDbVF2ZEZVeUwzSk5XRzh2UzFodFpEWXZZVEY2VlRNMlRYWXlOVTF5UWpnMGFXdE1TUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDEyODJmNTUtMzQ5MC00YmVmLWI3MjUtNTk5NjM0MzA0M2E2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpRnF0RzJnRnF2QVdkT3JJc1FoQzBLMmJVSUFLMHlweDNoTm1wajFoaEpxMHdpeGtTb0hoYnJVZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:08 GMT
+      - Thu, 01 Jun 2023 15:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -270,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2333ae2a-f8a1-4e7e-8d17-b0c07dce0c01
+      - 751088ca-35ec-458c-84d0-6383d848c226
     status: 200 OK
     code: 200
     duration: ""
@@ -279,21 +278,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:40.261457Z","upgrade_available":false,"version":"1.27.1"}'
     headers:
       Content-Length:
-      - "1452"
+      - "1375"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:08 GMT
+      - Thu, 01 Jun 2023 15:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -303,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d03f1e2-66bf-43b8-8d85-53ef193fcbb0
+      - 70f2c726-ddd9-4bf6-a367-6ee60ec6920c
     status: 200 OK
     code: 200
     duration: ""
@@ -312,21 +311,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
     method: GET
   response:
-    body: '{"created_at":"2023-04-07T09:44:02.981601Z","id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:30dc::/64"],"tags":[],"updated_at":"2023-04-07T09:44:02.981601Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "361"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:08 GMT
+      - Thu, 01 Jun 2023 15:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -336,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76f35082-d710-4f31-97a6-9444fd6eab64
+      - 5684eeb8-5e27-43e5-93c1-46efdc8e45b6
     status: 200 OK
     code: 200
     duration: ""
@@ -345,21 +344,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1452"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:08 GMT
+      - Thu, 01 Jun 2023 15:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -369,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2caf2205-2b91-481d-9f2e-5ff7ba419079
+      - e35329bf-d35f-4272-a13b-208fa07ebf26
     status: 200 OK
     code: 200
     duration: ""
@@ -378,21 +377,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
     method: GET
   response:
-    body: '{"created_at":"2023-04-07T09:44:02.981601Z","id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.4.0/22","fd63:256c:45f7:30dc::/64"],"tags":[],"updated_at":"2023-04-07T09:44:02.981601Z","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:40.261457Z","upgrade_available":false,"version":"1.27.1"}'
     headers:
       Content-Length:
-      - "361"
+      - "1375"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:09 GMT
+      - Thu, 01 Jun 2023 15:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -402,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08b3b545-ec6d-4565-841d-a751c8277ea5
+      - 9ff69301-afb1-40d6-81a8-599914fb0295
     status: 200 OK
     code: 200
     duration: ""
@@ -411,21 +410,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:05.166338Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1452"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:09 GMT
+      - Thu, 01 Jun 2023 15:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -435,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4623219f-b7e5-4b4a-8e09-055ee45af0c8
+      - df82c57e-0845-47f5-91e3-27538226970c
     status: 200 OK
     code: 200
     duration: ""
@@ -444,21 +443,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6/kubeconfig
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVVWGRPYWtFMVRrUlJkMDVHYjFoRVZFMTZUVVJSZDA1cVFUVk9SRkYzVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkIwQ25OclRtWlRWemcxTDJaNFZqUkZXWEZUVlRCNWExZE1VVnBGZVVOb1lWRkhlbUZtV1ZVeloyRmhiVFJGTVRsQlpGbzRhemxUVHpKNE0weGlSRW8xTTFVS01VNVlhR2hzVG1nd1YyTjBja0pZTlRWd2FHTjZhbmRVWVZobWVtTlRhbGhJVlZjNFVFNTVUV2xvUWpoeUszUnJPVzFNYTFsVU4xTkdRamRMY0RKS1dRcEpTa0ptYms5dFpWVXZkR0l3TVhOS1VGWmlTa3BOYXpkbFlXTXZWUzlPY1NzMWRESkZiSFo0WXpoaVIwZ3dUbFpLYmpaVWIzWXpRa1pzTTJWcFZrTlJDbmRFVUVnNU5FRk9OMUV2WTJRNWIxVkNTMVZVTlRaRlFXYzNiV3RIUjBkU2Myb3pNazVNVVd4U1pFbDVhRGw0U2s5NVdqWTViMHR3VURsQk1rRmxWRW9LVVZOekwwSkROazE0ZVcwNGJHdHRZM0ZOTjA1TFEwNVNVMFJaZGtkTWVsaGlUamRLY0haWFRFYzFVVWh6ZG5weU1EQmpSRkJ3S3l0eVRtdDZSekprVlFwcmVtNUhWM0pEVkZSYU1rUlJiVm92Tm1Nd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRU0yOUlkMklySzNWYWFITktjVzB6VGxOR05ucEpPRmQ2ZFZOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmNGZGxVMjFNZVZVMk5rUXZUa1JUVFhGQ1lUbDZaRkJpUjBKVVZsaHlhRVl4UkVseFFXTlNhMGd5YTNjelZGSlllZ3BvY1dwMVQxWjBVR2g0VWpKaU1raDJVbk5aZW1abVNqbEdVRXM0ZFdOYVNXSllPRlpDUm0xWmFXTnhaV3hCZUhrMVZqTlNhMWRqWld0bmNUWkZSMkV6Q21sdWVtaFBaRkpLYTFGM1JWUlFUMnhoUjFWNlVHNXBiV3QyUWtONGVHNVJSa1k0VEROQlJsbHdhRXhCZFVsNVoxbEdWbnBvUmpoTk16SlhSVmhvUWk4S09WSm5VM1ZRZVdKblZqSkdVSEpCYlRsUVVFUmhSbWhtTUVkNGFUQkhXRXh5TlRGM09HTlliMk4wUkc4ME9URnVNMDFaYlZGa1IzaFJOV1Z1WVhkdWFRcGxVRlJuVG1aVlNIRnhkVXhIT0UxMFVWTlVkVUV3Y0U1c1NrZ3lTbEpKVm5JeWNXSkxlazAxTldWbU5ITXdOMWxEVmtvMWNsZHFVMHQxT0RFNFNVSldDbVF2ZEZVeUwzSk5XRzh2UzFodFpEWXZZVEY2VlRNMlRYWXlOVTF5UWpnMGFXdE1TUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDEyODJmNTUtMzQ5MC00YmVmLWI3MjUtNTk5NjM0MzA0M2E2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpRnF0RzJnRnF2QVdkT3JJc1FoQzBLMmJVSUFLMHlweDNoTm1wajFoaEpxMHdpeGtTb0hoYnJVZg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2710"
+      - "352"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:09 GMT
+      - Thu, 01 Jun 2023 15:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -468,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9d39a44-f87b-47ef-990b-a6285a87ba4e
+      - 96715743-b76a-4129-9112-05160b4622ab
     status: 200 OK
     code: 200
     duration: ""
@@ -477,21 +476,949 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:40.261457Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1375"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 66427c13-1482-48e0-a809-edd5958d1ab1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9bdd2d38-adf5-4bf3-a2d8-60a95e5e15f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/migrate-to-private-network
+    method: POST
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:44.663136444Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1407"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 02ad109f-3b0f-4b59-b6c7-a32d9ad75a18
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:44.663136Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1404"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cf2b8917-ba8a-46df-bfe3-2f8cd01a01f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:46.144749Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62fb564d-8f3b-45a1-a89e-23085676cca0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: PATCH
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:50.039413877Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1407"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a2428011-8a33-4454-8864-d5f30cec4395
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:50.039414Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1404"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2e635c9e-52a7-48c7-bcee-fd860c50e71c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e2582009-de45-40c4-82a2-ce9a933d354c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc65c0c7-bea9-403c-921d-d0f9ea2a387b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 95371e6d-53f9-4409-b493-561c492cd23a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fdc8a582-85f8-44e4-97c0-5d6206d9e858
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
+    method: GET
+  response:
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01f0160d-f3a3-4474-be3d-756125579b8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0d98ec4-9ca8-40d1-9477-2155ec0ecc5f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
+    method: GET
+  response:
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06aabad5-cf5a-4908-a867-d1f9ce63f7de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 284f3280-a3bb-4084-9377-189db4fc05bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a625e124-dad7-4e37-b0d7-2d98b51cc9ae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
+    method: GET
+  response:
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a272c7d-5ebf-41f1-ac29-91c82c13a149
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 958c7ae7-087b-4767-b883-efef6ac03a09
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6658d078-13bb-472d-b2c4-d63a5eea6ce7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 09e709ba-e76a-43e9-bd91-eea3ca96c646
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
+    method: GET
+  response:
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8dde34c7-e451-446d-9e9c-2816a9e7d2a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6ed51e32-5eac-43a3-950d-eb715acd21ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
+    method: GET
+  response:
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0bed70a1-91e6-4e60-9200-4146658c20a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25f6131b-c13c-4f6c-9e1b-b7dee5c3a2f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b1bf0735-7a92-4dd6-9ca4-75df29307c6a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
+    method: GET
+  response:
+    body: '{"created_at":"2023-06-01T15:18:36.700046Z","id":"2006d3b5-48af-4868-9715-0a38dfca51a3","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnets":["172.16.8.0/22","fd63:256c:45f7:4848::/64"],"tags":[],"updated_at":"2023-06-01T15:18:36.700046Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "352"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 27b6b3a8-2a51-42a4-97d7-3173382abefe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:51.210167Z","upgrade_available":false,"version":"1.27.1"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82be7030-0844-480f-aba5-b050200e0a66
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMUVWWHBOVkVVeFRWUm5lazlXYjFoRVZFMTZUVVJWZWsxVVJURk5WR2Q2VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV0l2Q200dlRIUlFVbWRITnpVNGVYQldXVWhCUzJkc1JEWjVSVTh4V25oSVJYTk5TSEJJTld4QllVaGlTa1ZIUjB4dlYxSnlaalZ0TnpOa1RuUmlSM2xyVGxNS1JFdHphbkE1U0RsblR6SnllWE53YlZwcVNFOVdURVJ0SzNKMFpqQlZUUzlVY0RSbmVFVXJiRGxJUjFWVFpuSnFSVzR2U0VKTmNEaFlVbU0wU1ZCT05ncFZlblZ6TkhCb1RFMHlMMGhRVkdweWFYSk5hRzVaV1ZwaWFIQjROSEJ5ZVRKSFQwVkpZbTlxYnpJMVMwZEVkV2RWTjJWeWNGVnpVVVZ6U21zemNIQkxDa1ZTYkRGcFJXOWFSVnBNY2sxWVJXVkxSRVoxWm1SVk4xSXZkRU5rVVhwTlNtVmhPRXBxYUVoSldHazJXamhwVUZvNFdIRk9TV1JYYVVwRFozbGFjMk1LVVV0clduUjFaRUZuVGpOc1JVdzBWbXRXU1hoUmNVZFlVMk5OZEdWYVNWSmxVVXQxU0VaWFVWbHFSamRXUnpsd1JURjZZMmxGVEdVdldHTmhVSFozTWdwT2JteHZkakpzT0VOaE5Yb3ZOVkI1WTFKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2RtSkhaa1JsZUZRME1TODBhazVUY20xMVNtdENWMFYwTUUxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ01YVkdlR1ZHT0d0RE9HRm1UWEIzYlZjNVZtazFkMHRPVDJGSWNtdFpja3RoWlVKSll6SkpVbHBtTTJGM1pqbHdXUXBIVVRBM1ZVWm9kMFl6WTNKdE1HVk1VbGxRYlRCV1ZUVklOWE40WVV4dGJrcDZSWGhoT0dOeE1VSkNSRmxUVEUxb1dqbE1SVVpUVmxWU05FTXpVMmhMQ2xNMVZ6Qm1UbXRQV25WWGJ6Rk5NeTlqVVhscldISTRZM0F2TXpaVlJFaHFLMDQ1VkhkNGFYUlRRVGc1YzA1bmJIQjRjMjFRYzJ0eGJWaHdja296WTJzS1RtRnJNVlUxT0VSRU1IUldLMll5T0dGYVRtTnJkbkJCVVhjclVVbG1WbTQyYmtsa05WUjBZak5QTHpsSE9GVktaR0puVEVsbldFNXFaalZIU1U1VlJRcE9ZamhtUml0ak1IbEhkbVJtUzFsVGVIRnNSV1JFSzBWV01qZzNkVWt6VkVoblJ6UlBiRWxYWmxwUVRHdDVWWGxRVEhBMFpUQlFjbUVyUTFrcmFqRkVDbmxQUVZkR1pXY3ZPRzk1VFdoeFZ6RkRaVWRyS3l0WU5sRTFXRVZ4YURSTlVrcGlhUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTU0OTJlYTItNGY0Ny00NTY1LWFjNWQtMjE5ZjM3ZWMwYWIyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIZ2JKMEdtVzVsTXVSZXZwWGhaMTZDbkdSak56anQ1SFhLdHR5eGN3R0pSY2swaTNENDBvaElKWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Jun 2023 15:18:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a4b144cc-b58a-43e6-bf6b-2a18f0d011b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:09.534634693Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:57.566447162Z","upgrade_available":false,"version":"1.27.1"}'
     headers:
       Content-Length:
-      - "1450"
+      - "1407"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:09 GMT
+      - Thu, 01 Jun 2023 15:18:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -501,7 +1428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b028380c-e01f-4fb5-8f5d-7ecfad6e60af
+      - ecc16fee-46db-4587-869c-6594d86dc6ca
     status: 200 OK
     code: 200
     duration: ""
@@ -510,21 +1437,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1282f55-3490-4bef-b725-5996343043a6.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-04-07T09:44:03.431430Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1282f55-3490-4bef-b725-5996343043a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1282f55-3490-4bef-b725-5996343043a6","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-04-07T09:44:09.534635Z","upgrade_available":false,"version":"1.26.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a5492ea2-4f47-4565-ac5d-219f37ec0ab2.api.k8s.fr-par.scw.cloud:6443","cni":"calico","created_at":"2023-06-01T15:18:37.102757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a5492ea2-4f47-4565-ac5d-219f37ec0ab2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"2006d3b5-48af-4868-9715-0a38dfca51a3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-06-01T15:18:57.566447Z","upgrade_available":false,"version":"1.27.1"}'
     headers:
       Content-Length:
-      - "1447"
+      - "1404"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:09 GMT
+      - Thu, 01 Jun 2023 15:18:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -534,7 +1461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dae1019-7d9d-4839-a5e7-e3b1cbcc6fbe
+      - 0584de56-bdad-4730-81c1-ed00733879fa
     status: 200 OK
     code: 200
     duration: ""
@@ -543,12 +1470,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d1282f55-3490-4bef-b725-5996343043a6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -557,7 +1484,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:14 GMT
+      - Thu, 01 Jun 2023 15:19:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -567,7 +1494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a6597a5-4a9e-4867-95d1-2872f2c34e64
+      - 76d9eab2-a468-40f8-8eaa-fcb9dc964cfe
     status: 404 Not Found
     code: 404
     duration: ""
@@ -576,9 +1503,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/1d9ebfdf-eae1-4ec3-ab1a-216ae302f45b
+    url: https://api.scaleway.com/vpc/v1/zones/fr-par-1/private-networks/2006d3b5-48af-4868-9715-0a38dfca51a3
     method: DELETE
   response:
     body: ""
@@ -588,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:15 GMT
+      - Thu, 01 Jun 2023 15:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -598,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 747bac9e-ac4a-45f2-acb7-34860d2aeb71
+      - b0b07134-7338-4020-8006-5056abf24bdf
     status: 204 No Content
     code: 204
     duration: ""
@@ -607,12 +1534,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1282f55-3490-4bef-b725-5996343043a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a5492ea2-4f47-4565-ac5d-219f37ec0ab2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d1282f55-3490-4bef-b725-5996343043a6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a5492ea2-4f47-4565-ac5d-219f37ec0ab2","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -621,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 07 Apr 2023 09:44:15 GMT
+      - Thu, 01 Jun 2023 15:19:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -631,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bb5d4d7-bfaf-433d-b039-ab2441a9e95b
+      - 39597419-78b7-4fc6-a992-36863d313898
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
Changing the Private Network after the creation of the cluster is not possible, therefore the `private_network_id` field was marked as ForceNew. But since it could result in the loss of data, we prefer to change things up a bit and add more warning before triggering the destruction and recreation of the cluster. 

No PNID -> PNID : migrates the cluster to the private network
PNID -> no PNID : warns before forcing new cluster
PNID a -> PNID b : warns before forcing new cluster

If no PNID is specified when creating a cluster, this still creates a legacy cluster (without PN)

Closes  #1947