### PR TITLE
feat(tftemplate): generate helpers with resource

### DIFF
--- a/cmd/tftemplate/helpers.go.tmpl
+++ b/cmd/tftemplate/helpers.go.tmpl
@@ -1,0 +1,34 @@
+{{- /*gotype: tftemplate/models.ResourceTemplate*/ -}}
+package scaleway
+
+import (
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+    "github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+// {{.API}}APIWith{{.LocalityUpper}} returns a new {{.API}} API and the {{.Locality}} for a Create request
+func {{.API}}APIWith{{.LocalityUpper}}(d *schema.ResourceData, m interface{}) (*{{.API}}.API, scw.{{.LocalityUpper}}, error) {
+    meta := m.(*Meta)
+    {{.API}}API := {{.API}}.NewAPI(meta.scwClient)
+
+    {{.Locality}}, err := extract{{.LocalityUpper}}(d, meta)
+    if err != nil {
+        return nil, "", err
+    }
+
+    return {{.API}}API, {{.Locality}}, nil
+}
+
+// {{.API}}APIWith{{.LocalityAdjectiveUpper}}AndID returns a new {{.API }} API with {{.Locality}} and ID extracted from the state
+func {{.API}}APIWith{{.LocalityUpper}}AndID(m interface{}, {{.LocalityAdjective}}ID string) (*{{.API}}.API, scw.{{.LocalityUpper}}, string, error) {
+    meta := m.(*Meta)
+    {{.API}}API := {{.API}}.NewAPI(meta.scwClient)
+
+    {{.Locality}}, ID, err := parse{{.LocalityAdjectiveUpper}}ID({{.LocalityAdjective}}ID)
+    if err != nil {
+        return nil, "", "", err
+    }
+
+    return {{.API}}API, {{.Locality}}, ID, nil
+}
+

--- a/cmd/tftemplate/models/resource.go
+++ b/cmd/tftemplate/models/resource.go
@@ -6,7 +6,8 @@ import (
 )
 
 type ResourceTemplate struct {
-	LocalityAdjectiveUpper string // Regional
+	LocalityAdjectiveUpper string // Regional/Zoned
+	LocalityAdjective      string // regional/zoned
 	LocalityUpper          string // Region
 	Locality               string // region
 	Resource               string // FunctionNamespace
@@ -75,12 +76,24 @@ func resourceWordsLower(resource string) []string {
 	return words
 }
 
+func adjectiveLocality(locality string) string {
+	switch locality {
+	case "zone":
+		return "zoned"
+	case "region":
+		return "regional"
+	}
+
+	return locality
+}
+
 // api: function, container, instance
 // resource: FunctionNamespace, InstanceServer, ContainerDomain
 // locality: region, zone
 func NewResourceTemplate(api string, resource string, locality string) ResourceTemplate {
 	return ResourceTemplate{
-		LocalityAdjectiveUpper: strings.Title(locality) + "al",
+		LocalityAdjectiveUpper: strings.Title(adjectiveLocality(locality)),
+		LocalityAdjective:      adjectiveLocality(locality),
 		LocalityUpper:          strings.Title(locality),
 		Locality:               locality,
 		Resource:               resource,

--- a/cmd/tftemplate/templates.go
+++ b/cmd/tftemplate/templates.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"log"
+	"os"
+	"text/template"
+	"tftemplate/models"
+)
+
+type TerraformTemplate struct {
+	// Target file for output
+	FileName string
+	// TemplateFile is a Go template as string
+	TemplateFile string
+	// Template is a Go template, will be created from TemplateFile if nil
+	Template *template.Template
+	// Skip template generation if true
+	Skip bool
+	// Append template output to target if true
+	Append bool
+}
+
+func executeTemplate(tmpl *TerraformTemplate, data models.ResourceTemplate) error {
+	var outputFile *os.File
+	var err error
+
+	if tmpl.Append {
+		outputFile, err = os.OpenFile(tmpl.FileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	} else {
+		outputFile, err = os.Create(tmpl.FileName)
+	}
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer outputFile.Close()
+
+	err = tmpl.Template.Execute(outputFile, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/tftemplate/waiters.go.tmpl
+++ b/cmd/tftemplate/waiters.go.tmpl
@@ -1,0 +1,17 @@
+{{- /*gotype: tftemplate/models.ResourceTemplate*/ -}}
+
+func waitFor{{.Resource}}(ctx context.Context, {{.API}}API *{{.API}}.API, {{.Locality}} scw.{{.LocalityUpper}}, id string, timeout time.Duration) (*{{.API}}.{{.ResourceClean}}, error) {
+    retryInterval := defaultFunctionRetryInterval
+    if DefaultWaitRetryInterval != nil {
+        retryInterval = *DefaultWaitRetryInterval
+    }
+
+    {{.ResourceCleanLow}}, err := {{.API}}API.WaitFor{{.ResourceClean}}(&{{.API}}.WaitFor{{.ResourceClean}}Request{
+        {{.LocalityUpper}}:        {{.Locality}},
+        {{.ResourceClean}}ID:   id,
+        RetryInterval: &retryInterval,
+        Timeout:       scw.TimeDurationPtr(timeout),
+    }, scw.WithContext(ctx))
+
+    return {{.ResourceCleanLow}}, err
+}


### PR DESCRIPTION
Added two new prompt, example with new block volume resource:
```
? API name (function, instance, container) block
? Resource name (FunctionNamespace, InstanceServer) BlockVolume
?  zone
? Generate helpers ? Will override scaleway/helpers_{api}.go (y/N) Yes
? Generate helpers ? Will be added to scaleway/helpers_{api}.go (Y/n) Yes

```