### PR TITLE
tests(iam): get organization id from client in sweepers

### DIFF
--- a/scaleway/resource_iam_api_key_test.go
+++ b/scaleway/resource_iam_api_key_test.go
@@ -23,7 +23,14 @@ func testSweepIamAPIKey(_ string) error {
 
 		l.Debugf("sweeper: destroying the api keys")
 
-		listAPIKeys, err := api.ListAPIKeys(&iam.ListAPIKeysRequest{}, scw.WithAllPages())
+		orgID, exists := scwClient.GetDefaultOrganizationID()
+		if !exists {
+			return fmt.Errorf("missing organizationID")
+		}
+
+		listAPIKeys, err := api.ListAPIKeys(&iam.ListAPIKeysRequest{
+			OrganizationID: &orgID,
+		}, scw.WithAllPages())
 		if err != nil {
 			return fmt.Errorf("failed to list api keys: %w", err)
 		}

--- a/scaleway/resource_iam_application_test.go
+++ b/scaleway/resource_iam_application_test.go
@@ -21,7 +21,14 @@ func testSweepIamApplication(_ string) error {
 	return sweep(func(scwClient *scw.Client) error {
 		api := iam.NewAPI(scwClient)
 
-		listApps, err := api.ListApplications(&iam.ListApplicationsRequest{})
+		orgID, exists := scwClient.GetDefaultOrganizationID()
+		if !exists {
+			return fmt.Errorf("missing organizationID")
+		}
+
+		listApps, err := api.ListApplications(&iam.ListApplicationsRequest{
+			OrganizationID: &orgID,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to list applications: %w", err)
 		}

--- a/scaleway/resource_iam_group_test.go
+++ b/scaleway/resource_iam_group_test.go
@@ -2,7 +2,6 @@ package scaleway
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -22,10 +21,13 @@ func testSweepIamGroup(_ string) error {
 	return sweep(func(scwClient *scw.Client) error {
 		api := iam.NewAPI(scwClient)
 
-		// Requiring organization_id in list request is temporary
-		organizationID := os.Getenv("DEFAULT_ORGANIZATION_ID")
+		orgID, exists := scwClient.GetDefaultOrganizationID()
+		if !exists {
+			return fmt.Errorf("missing organizationID")
+		}
+
 		listApps, err := api.ListGroups(&iam.ListGroupsRequest{
-			OrganizationID: &organizationID,
+			OrganizationID: &orgID,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to list groups: %w", err)

--- a/scaleway/resource_iam_policy_test.go
+++ b/scaleway/resource_iam_policy_test.go
@@ -23,7 +23,14 @@ func testSweepIamPolicy(_ string) error {
 	return sweep(func(scwClient *scw.Client) error {
 		api := iam.NewAPI(scwClient)
 
-		listPols, err := api.ListPolicies(&iam.ListPoliciesRequest{})
+		orgID, exists := scwClient.GetDefaultOrganizationID()
+		if !exists {
+			return fmt.Errorf("missing organizationID")
+		}
+
+		listPols, err := api.ListPolicies(&iam.ListPoliciesRequest{
+			OrganizationID: &orgID,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to list policies: %w", err)
 		}


### PR DESCRIPTION
Sweepers are currently broken in nightly tests because of required organization ID