### PR TITLE
feat(tftemplate): add datasource generation to tftemplate

### DIFF
--- a/cmd/tftemplate/datasource.go.tmpl
+++ b/cmd/tftemplate/datasource.go.tmpl
@@ -1,0 +1,77 @@
+{{- /*gotype: tftemplate/models.ResourceTemplate*/ -}}
+package scaleway
+
+import (
+    "context"
+
+    "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceScaleway{{.Resource}}() *schema.Resource {
+    // Generate datasource schema from resource
+    dsSchema := datasourceSchemaFromResourceSchema(resourceScaleway{{.Resource}}().Schema)
+    
+    addOptionalFieldsToSchema(dsSchema, "name", "{{.Locality}}")
+    
+    dsSchema["{{.ResourceCleanLow}}_id"] = &schema.Schema{
+        Type:          schema.TypeString,
+        Optional:      true,
+        Description:   "The ID of the {{.ResourceCleanLow}}",
+        ConflictsWith: []string{"name"},
+        ValidateFunc:  validationUUIDorUUIDWithLocality(),
+    }
+    
+    return &schema.Resource{
+        ReadContext: dataSourceScaleway{{.Resource}}Read,
+        Schema:      dsSchema,
+    }
+}
+
+func dataSourceScaleway{{.Resource}}Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+    api, {{.Locality}}, err := {{.API}}APIWith{{.LocalityUpper}}(d, meta)
+    if err != nil {
+        return diag.FromErr(err)
+    }
+
+    {{.ResourceCleanLow}}ID, {{.ResourceCleanLow}}IDExists := d.GetOk("{{.ResourceCleanLow}}_id")
+    if !{{.ResourceCleanLow}}IDExists {
+        res, err := api.List{{.ResourceClean}}s(&{{.API}}.List{{.ResourceClean}}sRequest{
+            {{.LocalityUpper}}:     {{.Locality}},
+            Name:       expandStringPtr(d.Get("name")),
+            ProjectID:  expandStringPtr(d.Get("project_id")),
+        })
+        if err != nil {
+            return diag.FromErr(err)
+        }
+        for _, {{.ResourceCleanLow}} := range res.{{.ResourceClean}}s {
+            if {{.ResourceCleanLow}}.Name == d.Get("name").(string) {
+                if {{.ResourceCleanLow}}ID != "" {
+                    return diag.Errorf("more than 1 {{.ResourceCleanLow}} found with the same name %s", d.Get("name"))
+                }
+                {{.ResourceCleanLow}}ID = {{.ResourceCleanLow}}.ID
+            }
+        }
+        if {{.ResourceCleanLow}}ID == "" {
+            return diag.Errorf("no {{.ResourceCleanLow}} found with the name %s", d.Get("name"))
+        }
+    }
+
+    {{.Locality}}ID := datasourceNew{{.LocalityAdjectiveUpper}}ID({{.ResourceCleanLow}}ID, {{.Locality}})
+    d.SetId({{.Locality}}ID)
+    err = d.Set("{{.ResourceCleanLow}}_id", {{.Locality}}ID)
+    if err != nil {
+        return diag.FromErr(err)
+    }
+
+    diags := resourceScaleway{{.Resource}}Read(ctx, d, meta)
+    if diags != nil {
+        return append(diags, diag.Errorf("failed to read {{.ResourceCleanLow}} state")...)
+    }
+
+    if d.Id() == "" {
+        return diag.Errorf("{{.ResourceCleanLow}} (%s) not found", {{.Locality}}ID)
+    }
+
+    return nil
+}

--- a/cmd/tftemplate/datasource_test.go.tmpl
+++ b/cmd/tftemplate/datasource_test.go.tmpl
@@ -1,0 +1,45 @@
+{{- /*gotype: tftemplate/models.ResourceTemplate*/ -}}
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccScalewayDataSource{{.Resource}}_Basic(t *testing.T) {
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScaleway{{.Resource}}Destroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource scaleway_{{.ResourceHCL}} main {
+  						name = "test-ds-{{.API}}-{{ .ResourceCleanLow}}-basic"
+					}
+
+					data scaleway_{{.ResourceHCL}} find_by_name {
+						name = scaleway_{{.ResourceHCL}}.main.name
+					}
+
+					data scaleway_{{.ResourceHCL}} find_by_id {
+						{{.ResourceCleanLow}}_id = scaleway_{{.ResourceHCL}}.main.id
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScaleway{{.Resource}}Exists(tt, "scaleway_{{.ResourceHCL}}.main"),
+
+					resource.TestCheckResourceAttrPair("scaleway_{{.ResourceHCL}}.main", "name", "data.scaleway_{{.ResourceHCL}}.find_by_name", "name"),
+					resource.TestCheckResourceAttrPair("scaleway_{{.ResourceHCL}}.main", "name", "data.scaleway_{{.ResourceHCL}}.find_by_id", "name"),
+					resource.TestCheckResourceAttrPair("scaleway_{{.ResourceHCL}}.main", "id", "data.scaleway_{{.ResourceHCL}}.find_by_name", "id"),
+					resource.TestCheckResourceAttrPair("scaleway_{{.ResourceHCL}}.main", "id", "data.scaleway_{{.ResourceHCL}}.find_by_id", "id"),
+				),
+			},
+		},
+	})
+}

--- a/cmd/tftemplate/resource.go.tmpl
+++ b/cmd/tftemplate/resource.go.tmpl
@@ -74,6 +74,8 @@ func resourceScaleway{{ .Resource }}Read(ctx context.Context, d *schema.Resource
 	}
 
 	_ = d.Set("name", {{ .ResourceCleanLow }}.Name)
+	_ = d.Set("{{.Locality}}", {{.ResourceCleanLow}}.{{.LocalityUpper}})
+	_ = d.Set("project_id", {{.ResourceCleanLow}}.ProjectID)
 
 	return nil
 }


### PR DESCRIPTION
```
in cmd/tftemplate
>> go run .
? Choose targets
- [x] resource
- [ ] datasource
? API name (function, instance, container) block
? Resource name (FunctionNamespace, InstanceServer) BlockVolume
? Choose locality
> zone
  region
? Generate helpers ? Will override scaleway/helpers_{api}.go (y/N)
? Generate waiters ? Will be added to scaleway/helpers_{api}.go (Y/n)
```