### PR TITLE
fix(functions): missing update on secret environment variables

### DIFF
--- a/scaleway/resource_function.go
+++ b/scaleway/resource_function.go
@@ -325,6 +325,7 @@ func resourceScalewayFunctionUpdate(ctx context.Context, d *schema.ResourceData,
 
 	if d.HasChanges("secret_environment_variables") {
 		req.SecretEnvironmentVariables = expandFunctionsSecrets(d.Get("secret_environment_variables"))
+		updated = true
 	}
 
 	if d.HasChange("description") {


### PR DESCRIPTION
To boolean telling to trigger function update was missing on secret environment variables, resulting in missing secret env variable when deploying a function.