### PR TITLE
Set ForceNew on vpc_id argument of scaleway_vpc ressource

### DIFF
--- a/scaleway/resource_vpc_private_network.go
+++ b/scaleway/resource_vpc_private_network.go
@@ -148,6 +148,7 @@ func resourceScalewayVPCPrivateNetwork() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Description: "The VPC in which to create the private network",
 			},
 			"project_id": projectIDSchema(),


### PR DESCRIPTION
ForceNew option is missing on vpc_id argument.