### PR TITLE
Remove resource vpc_private_network only on 404

### DIFF
--- a/scaleway/resource_vpc_private_network.go
+++ b/scaleway/resource_vpc_private_network.go
@@ -290,7 +290,7 @@ func resourceScalewayVPCPrivateNetworkDelete(ctx context.Context, d *schema.Reso
 		Region:           region,
 	}, scw.WithContext(ctx))
 	if err != nil {
-		if is409Error(err) || is412Error(err) || is404Error(err) {
+		if is404Error(err) {
 			return append(warnings, diag.Diagnostic{
 				Severity: diag.Warning,
 				Summary:  err.Error(),


### PR DESCRIPTION
I think the provider should remove the vpc_private_network resource from the state only if not found, so we'll be able to retry the removal if there is another type of error.