### PR TITLE
docs(container): change example protocol from h2c to http1

### DIFF
--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -34,7 +34,7 @@ resource scaleway_container main {
     timeout = 600
     max_concurrency = 80
     privacy = "private"
-    protocol = "h2c"
+    protocol = "http"
     deploy = true
 
     environment_variables = {

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -34,7 +34,7 @@ resource scaleway_container main {
     timeout = 600
     max_concurrency = 80
     privacy = "private"
-    protocol = "http"
+    protocol = "http1"
     deploy = true
 
     environment_variables = {


### PR DESCRIPTION
Hey team!

We got some feedback from one user that the default protocol in the Terraform container example was error-inducing. We agreed, because h2c is only useful for certain use cases (http2, plaintext grpc) which most users are not after. So IMO, it would be better to switch it to HTTP for the time being because it fits most use cases.

What do you think?

Cheers!