### PR TITLE
feat(k8s): integrate `public_ip_disabled` field

### DIFF
--- a/docs/resources/k8s_pool.md
+++ b/docs/resources/k8s_pool.md
@@ -83,7 +83,10 @@ The following arguments are supported:
 
 - `region` - (Defaults to [provider](../index.md#region) `region`) The [region](../guides/regions_and_zones.md#regions) in which the pool should be created.
 
-- `wait_for_pool_ready` - (Default to `false`) Whether to wait for the pool to be ready.
+- `wait_for_pool_ready` - (Defaults to `false`) Whether to wait for the pool to be ready.
+
+- `public_ip_disabled` - (Defaults to `false`) Defines if the public IP should be removed from Nodes. To use this feature, your Cluster must have an attached [Private Network](vpc_private_network.md) set up with a [Public Gateway](vpc_public_gateway.md).
+~> **Important:** Updates to this field will recreate a new resource.
 
 ## Attributes Reference
 

--- a/scaleway/testdata/k8s-cluster-pool-public-ip-disabled.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-public-ip-disabled.cassette.yaml
@@ -1,0 +1,7384 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
+    method: GET
+  response:
+    body: '{"versions":[{"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","SidecarContainers","ValidatingAdmissionPolicy"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.28.2","name":"1.28.2","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod","ValidatingAdmissionPolicy","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.27.6","name":"1.27.6","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod","ValidatingAdmissionPolicy","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.9","name":"1.26.9","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.25.14","name":"1.25.14","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.17","name":"1.24.17","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.17","name":"1.23.17","region":"fr-par"}]}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b1b66eab-4e9a-49d1-ad48-a797b4ffa575
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"k8s-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"172.16.4.0/22","updated_at":"2023-10-13T16:39:47.032043Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:39:47.032043Z"}],"tags":[],"updated_at":"2023-10-13T16:39:47.032043Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6da6f070-26e7-4c5c-9b92-9f695b3004fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"172.16.4.0/22","updated_at":"2023-10-13T16:39:47.032043Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:39:47.032043Z"}],"tags":[],"updated_at":"2023-10-13T16:39:47.032043Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 36925f98-21d2-4c43-8e29-ac2a0f88a921
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
+    method: POST
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266330Z","created_at":"2023-10-13T16:39:48.130266330Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:39:48.143092189Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1472"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f574bcdf-aed1-4116-a584-f3699f41dfbb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:39:48.143092Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c86e914-43fc-4aa6-8070-eee13fdbade9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:39:50.052788Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1468"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a718c9b-393a-453e-8f1f-5326c0e51b84
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:39:50.052788Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1468"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62f2a4b9-04bb-4fa2-923d-286d159733af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE5ha1V5VFhwck1FOVdiMWhFVkUxNlRWUkJlRTFxUlRKTmVtc3dUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRHUnZDazlQTjBOMWVHeHFZbk0zTTNKdFNVWlFjbEEwVVV4S1FqWjNkREZDY1RGRWJGbFdNVEozTTB4cGJHZDVkVGxOYUdGSVZXRnJUa1ZGU0VFNU5HbHVSMlFLY2tsTFdYZ3ZRM05wWmtwSE9WRktaMVpzUldaTVlsQkNkQzlUZG1JeE9XVjVNamROZFZoV1FreHZWek5xVlhWbWFuWnRjbVZzU21KeWNVNVFaRmcxVWdwUE5GWnFNMHhOV1cxd1pVOVpPVWxzWkhwM01rbzBhekJ1ZUc1dlN6Uk1TMlJuVGt0R1ZsUTNSekJqVm1WSGFEWnJWamMwV1ZkUWMwRTNhMGhvUzJobUNtODFTM0ZrWWtGSmJVMWFVbWw0TkV3M0szWmtiemRhU0dOb2R6QllSVk5EV1Roc1FYcHROUzlTV1RocFowVXphems1VUdaNFduQlhPRmMzYlhCMU9VWUtXREZhWlhoU2VUUjZVR29yVWt0RU9VVldaRFJDUkVkM1p6ZGFWMEZHZWtKaVpXbE9UMmRrUlRnM1JYRnBjR0ZaV2tOSWVDOUNTRlpJTldNd1FuaFNkUXBwVW1ndmNtbE1WM2xvTWtjNFpYcDJiWG80UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRUjJFM2FUWkxaa1I2VG10bGQyNXNRelJxWVhSS1pGZ3JORUZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUm14d09WWnNXRU5GY2toVFUyaHVaa0ZPU2xSTWEzWjRhamRXYm1kd2RIWjZTVmxOUmpoT1MzaGtSV2x1UlN0d1JBcDRVRlF3YVhabk4wTlJaR2h1YlZJNGFsUXJTVnBOZHl0eFJscENibFpPZEc5RmIyOXNRM1I1ZDBVclVWZ3hWa2g0VGtSdWEzSjVPSEZFWkdVMmEzbFpDbUZRY0hWamFYVkNRVU53WldaMGJWVlVlRTB4YUhSek5IQkpSR0ZqWW5OWE5tWnFSbXR5YzNGMGQzSnBSVWd4WTFKaWJWZElTRWxoTDFWRlNIQnRNM2NLWWsxdVNFeG5NM2N6VGxGTlVUVlpXblJaTkRGQmJXTnRaRlpMVG0xRkwwbDZRbFZwTm1SUmQzaGhjbWhFVjBaeE4yNU5lV1ZaVmpSSWNtdHFiWFU1ZVFveFZIUkRSMlJHVkV0NFZITjZZV3hyUzFKRFoyaGtNVlF4UVZGemJYWlFZblF3Ym13d2VGUnpaMDVKZVdWVVMyUjVUMk5QVm5OYVozSktaaXRCVVRaeENrTmlVVkZOWWxORVkwVkdXVWhTTldaelRtWmhNelJSY1RKaGR6SkZRblpTVVZGaFJnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZjljOGM4Ny04OGMwLTQyZmEtYWJhZC1jN2QyYjVjYjhkN2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcHJpdmF0ZS1uZXR3b3JrLWNsdXN0ZXIKICBjb250ZXh0OgogICAgY2x1c3RlcjogInByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogcHJpdmF0ZS1uZXR3b3JrLWNsdXN0ZXItYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwcml2YXRlLW5ldHdvcmstY2x1c3RlcgpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpSkF6UWZoc1JMMGwzdWhwWTR4Nkw0WVBxRHlGYTcyc0ZYalZNM1JicUJtaUNpZE93VTZPRHM4bw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2676"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01e8bc99-76c6-4b9c-89c3-c4f52c79fc8c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:39:50.052788Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1468"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c1733025-b9b6-47f6-b2bb-9504136fb47c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"pool","node_type":"gp1_xs","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/pools
+    method: POST
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881380Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "595"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5dc3ac6c-87d9-44d0-b6c1-c148a7630ba1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 251c4d34-675d-4ecb-962d-54e37c692928
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:39:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 542700af-e79e-48e9-ac6e-e54f09cf84e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e7e8f472-ed7f-4e00-81fa-bbdfab6813d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5d086e1b-5b9d-40a2-9ec1-640f6ed707a2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dbb9dc75-13ea-4ede-a151-2e7ca06151c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2d265e1d-0082-4d3f-9152-320d92f96e52
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ac36692c-5993-420d-ab2b-52c45522c951
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df215979-260f-4b89-a31d-b6362853fc47
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a7a8605-04c0-4b3b-9608-552f87bcef8e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ad0e92e6-af84-46f3-a536-07131c003c60
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 254b8dd1-5f70-496e-bb5e-cdeb76f2ee86
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8600966f-1816-4ecf-96fc-255f79ed6ea5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77e71cb3-26bc-4322-ba26-799cb4156dc5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:40:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3284bbc9-5e19-4cfe-ad58-18b3055e0657
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c983dcc4-ca06-4735-9ae8-6256b3ef22b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8974d59b-e422-440e-99f3-e51c76e95d36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 58100f79-f4b2-4635-a975-d27fd3699b46
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2d714bb7-d8d6-4b21-8189-25daa17675fa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 781a2587-31bb-4eba-821e-0aa7a62c02eb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62f59d57-9272-4902-adac-3f29c4ea1c5e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01997959-6735-44b6-83b2-98dca5ca0347
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0e3ca740-f9bf-48c2-b352-d43a0118ab4e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ebad93d7-8369-471a-abc5-d2934fd53dbd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c67c3d5b-284e-4052-8dc7-53dbce63c73a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:41:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83501822-7d99-425f-a479-e827820f7184
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 905e6669-26c6-403e-99a7-09b54fbd4e7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6c88d134-9fa2-4289-ac1f-d9199fe6272e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8cb5f7b-ea20-46cf-94c1-9827f24cd710
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1e7bcf7a-35f9-4408-a9c4-46155d0e006c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 18286bea-8211-4b12-afde-ff1e932eccbf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d97ab268-0480-40a8-9b4d-672763b12fda
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c28f9b9-e7cd-4310-9866-11e1d5cc5373
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6996f900-410e-4fd8-b4fb-0927cb930ae5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4a40f64b-c441-4acd-abfb-f32281d59bd5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cf442ada-446c-4e35-9cb4-8682601166c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c70fcdd0-5305-446b-bd49-f6e885fbff61
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:42:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b74e6fb6-2ec1-4b5a-8a62-70a58d262ed2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8d8d79a9-ad84-4854-a885-adf412a4855a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a870645e-e3fc-495b-9601-7adabf202610
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f282d4e-1370-4b92-9922-5b632622d698
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 954af50c-b7db-4f10-aed2-8279caf1138a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f427186c-435e-44c4-b4a9-be4529cd4716
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9b291917-4247-494b-b334-add48a449002
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb4216f8-64fe-405c-a38d-b6e28ba5d097
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1cd90bed-78a0-45fa-bfa9-a6f42c362ddf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 805101de-be6d-477b-80ba-0ad6e6336f2d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fbce2084-e2ad-4be7-8e9d-27b2e62be62f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 33a813a7-eff9-4b91-b93a-dd8341fadaf7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:43:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b36c7c86-f632-4c7f-b658-76505f9f1f96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - de5ca2cc-69f5-46ec-8184-6174ec690e88
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4c5b3102-ff43-49c7-acc7-911a7b68636d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ce08e97-fd83-45b9-bc41-335e00a80f45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6c68db0c-558b-4d4a-9e8d-2607fe3ba4e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 642bb850-fb08-4a78-8884-aaa520b9af90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7182d079-7544-4c09-b43a-bb55ac337add
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83974860-714b-433d-910a-bbc4442a0afe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1b3523ae-458e-4133-82b2-71ae14e43f7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14ed3ce0-f433-4a24-854d-bc2b595f4af6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4583e9a5-11af-468f-a463-a5c60c9d70e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 706584de-9f59-45f9-9253-9e46840baf42
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:44:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9bbcbf59-b191-445a-a837-fed0ed02a34f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8f8e9d3c-0d19-4256-99cc-045b24f8a129
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1f2fc5bf-1ea7-4686-8545-e45a2149d863
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60dc0671-a3a8-496c-b02c-2d5a78281602
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:39:53.568881Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "592"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14aaed45-4eea-43db-81c0-9e9fadcedd52
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:45:18.171587Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "590"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3ee8616-ef76-4c3d-b367-cc4d988a234b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:41:02.228220Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1460"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc375149-4494-41b5-8c30-7571944df5b1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:45:18.171587Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "590"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 36fca36e-587f-4c1b-a649-865518ac0d5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/nodes?order_by=created_at_asc&page=1&pool_id=bb91e99d-5ba7-4073-bade-3d3d1b75dc8c&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-13T16:41:15.990110Z","error_message":null,"id":"37b6afe1-aca0-4792-90f4-0416c78bd8ed","name":"scw-private-network-cluster-pool-37b6afe1aca04","pool_id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","provider_id":"scaleway://instance/fr-par-1/2fa5c836-c7f1-4f08-bedd-0ffdc13ee35b","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-13T16:45:18.154355Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8b0eb6c-bcfa-4337-8ee1-c88d3a576692
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:41:02.228220Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1460"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e5c81689-3218-4077-a01b-201966318098
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"172.16.4.0/22","updated_at":"2023-10-13T16:39:47.032043Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:39:47.032043Z"}],"tags":[],"updated_at":"2023-10-13T16:39:47.032043Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9fde4299-af42-44a4-b0f5-3588436c0338
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:45:18.171587Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "590"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a39f2022-dcb1-46f2-8271-f57076b57f9a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/nodes?order_by=created_at_asc&pool_id=bb91e99d-5ba7-4073-bade-3d3d1b75dc8c&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-13T16:41:15.990110Z","error_message":null,"id":"37b6afe1-aca0-4792-90f4-0416c78bd8ed","name":"scw-private-network-cluster-pool-37b6afe1aca04","pool_id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","provider_id":"scaleway://instance/fr-par-1/2fa5c836-c7f1-4f08-bedd-0ffdc13ee35b","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-13T16:45:18.154355Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e5bbf0b-91d5-467a-a943-eb0f72090f8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2fa5c836-c7f1-4f08-bedd-0ffdc13ee35b
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-10-13T16:41:16.592283+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-private-network-cluster-pool-37b6afe1aca04","id":"2fa5c836-c7f1-4f08-bedd-0ffdc13ee35b","image":{"arch":"x86_64","creation_date":"2023-10-05T10:50:51.838301+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8795d4a3-0918-41f3-b119-03a7effbdd8f","modification_date":"2023-10-05T11:06:46.734414+00:00","name":"k8s_base_node_2023-09-27.6","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"23e4a5ca-9587-4556-8eee-34cafe7b43cc","name":"k8s_base_node_2023-09-27.6","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:638:1b03::1","gateway":"2001:bc8:638:1b03::","netmask":"64"},"location":{"cluster_id":"28","hypervisor_id":"1402","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:28:b1:8d","maintenances":[],"modification_date":"2023-10-13T16:41:31.808107+00:00","name":"scw-private-network-cluster-pool-37b6afe1aca04","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.66.70.199","private_nics":[{"creation_date":"2023-10-13T16:41:17.071826+00:00","id":"b4d2ed41-cf89-43a3-8f4b-2a7713c81047","mac_address":"02:00:00:14:3a:53","modification_date":"2023-10-13T16:41:17.974228+00:00","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","server_id":"2fa5c836-c7f1-4f08-bedd-0ffdc13ee35b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"163.172.164.36","dynamic":true,"family":"inet","gateway":null,"id":"56524145-6f45-47eb-a301-46ecb9edc884","netmask":"32","provisioning_mode":"dhcp","tags":[]},"public_ips":[{"address":"163.172.164.36","dynamic":true,"family":"inet","gateway":null,"id":"56524145-6f45-47eb-a301-46ecb9edc884","netmask":"32","provisioning_mode":"dhcp","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"44e4f345-a9c0-4460-8a89-e19be6040633","name":"kubernetes
+      af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","pool=bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","pool-name=pool","runtime=containerd","managed=true","node=37b6afe1-aca0-4792-90f4-0416c78bd8ed"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-13T16:41:16.592283+00:00","export_uri":null,"id":"7cb871d1-cf98-4954-8e39-63cdbafff427","modification_date":"2023-10-13T16:41:16.592283+00:00","name":"k8s_base_node_2023-09-27.6","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"2fa5c836-c7f1-4f08-bedd-0ffdc13ee35b","name":"scw-private-network-cluster-pool-37b6afe1aca04"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3913"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 04884763-7b2d-4ce3-904d-2723fc9713f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"172.16.4.0/22","updated_at":"2023-10-13T16:39:47.032043Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:39:47.032043Z"}],"tags":[],"updated_at":"2023-10-13T16:39:47.032043Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5f976337-1478-4b20-a05d-a0eed1efaea6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:41:02.228220Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1460"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6983ffea-b3d7-49a1-941a-97e4d99ef6fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE5ha1V5VFhwck1FOVdiMWhFVkUxNlRWUkJlRTFxUlRKTmVtc3dUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRHUnZDazlQTjBOMWVHeHFZbk0zTTNKdFNVWlFjbEEwVVV4S1FqWjNkREZDY1RGRWJGbFdNVEozTTB4cGJHZDVkVGxOYUdGSVZXRnJUa1ZGU0VFNU5HbHVSMlFLY2tsTFdYZ3ZRM05wWmtwSE9WRktaMVpzUldaTVlsQkNkQzlUZG1JeE9XVjVNamROZFZoV1FreHZWek5xVlhWbWFuWnRjbVZzU21KeWNVNVFaRmcxVWdwUE5GWnFNMHhOV1cxd1pVOVpPVWxzWkhwM01rbzBhekJ1ZUc1dlN6Uk1TMlJuVGt0R1ZsUTNSekJqVm1WSGFEWnJWamMwV1ZkUWMwRTNhMGhvUzJobUNtODFTM0ZrWWtGSmJVMWFVbWw0TkV3M0szWmtiemRhU0dOb2R6QllSVk5EV1Roc1FYcHROUzlTV1RocFowVXphems1VUdaNFduQlhPRmMzYlhCMU9VWUtXREZhWlhoU2VUUjZVR29yVWt0RU9VVldaRFJDUkVkM1p6ZGFWMEZHZWtKaVpXbE9UMmRrUlRnM1JYRnBjR0ZaV2tOSWVDOUNTRlpJTldNd1FuaFNkUXBwVW1ndmNtbE1WM2xvTWtjNFpYcDJiWG80UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRUjJFM2FUWkxaa1I2VG10bGQyNXNRelJxWVhSS1pGZ3JORUZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUm14d09WWnNXRU5GY2toVFUyaHVaa0ZPU2xSTWEzWjRhamRXYm1kd2RIWjZTVmxOUmpoT1MzaGtSV2x1UlN0d1JBcDRVRlF3YVhabk4wTlJaR2h1YlZJNGFsUXJTVnBOZHl0eFJscENibFpPZEc5RmIyOXNRM1I1ZDBVclVWZ3hWa2g0VGtSdWEzSjVPSEZFWkdVMmEzbFpDbUZRY0hWamFYVkNRVU53WldaMGJWVlVlRTB4YUhSek5IQkpSR0ZqWW5OWE5tWnFSbXR5YzNGMGQzSnBSVWd4WTFKaWJWZElTRWxoTDFWRlNIQnRNM2NLWWsxdVNFeG5NM2N6VGxGTlVUVlpXblJaTkRGQmJXTnRaRlpMVG0xRkwwbDZRbFZwTm1SUmQzaGhjbWhFVjBaeE4yNU5lV1ZaVmpSSWNtdHFiWFU1ZVFveFZIUkRSMlJHVkV0NFZITjZZV3hyUzFKRFoyaGtNVlF4UVZGemJYWlFZblF3Ym13d2VGUnpaMDVKZVdWVVMyUjVUMk5QVm5OYVozSktaaXRCVVRaeENrTmlVVkZOWWxORVkwVkdXVWhTTldaelRtWmhNelJSY1RKaGR6SkZRblpTVVZGaFJnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZjljOGM4Ny04OGMwLTQyZmEtYWJhZC1jN2QyYjVjYjhkN2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcHJpdmF0ZS1uZXR3b3JrLWNsdXN0ZXIKICBjb250ZXh0OgogICAgY2x1c3RlcjogInByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogcHJpdmF0ZS1uZXR3b3JrLWNsdXN0ZXItYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwcml2YXRlLW5ldHdvcmstY2x1c3RlcgpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpSkF6UWZoc1JMMGwzdWhwWTR4Nkw0WVBxRHlGYTcyc0ZYalZNM1JicUJtaUNpZE93VTZPRHM4bw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2676"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a5aabae-4b2a-42cd-a969-c448b2c6f7c8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:45:18.171587Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "590"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f9f8d78b-9331-4ee0-9680-15f5aec702f6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/nodes?order_by=created_at_asc&page=1&pool_id=bb91e99d-5ba7-4073-bade-3d3d1b75dc8c&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-13T16:41:15.990110Z","error_message":null,"id":"37b6afe1-aca0-4792-90f4-0416c78bd8ed","name":"scw-private-network-cluster-pool-37b6afe1aca04","pool_id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","provider_id":"scaleway://instance/fr-par-1/2fa5c836-c7f1-4f08-bedd-0ffdc13ee35b","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-13T16:45:18.154355Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff48d712-cf41-4b93-82b1-0eb7128eb163
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"172.16.4.0/22","updated_at":"2023-10-13T16:39:47.032043Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:39:47.032043Z"}],"tags":[],"updated_at":"2023-10-13T16:39:47.032043Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - caaf6e8a-e3fc-4a50-9d33-f2e72d8e24a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:41:02.228220Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1460"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7cd604d0-2605-4c82-aaad-113794bffa66
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE5ha1V5VFhwck1FOVdiMWhFVkUxNlRWUkJlRTFxUlRKTmVtc3dUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRHUnZDazlQTjBOMWVHeHFZbk0zTTNKdFNVWlFjbEEwVVV4S1FqWjNkREZDY1RGRWJGbFdNVEozTTB4cGJHZDVkVGxOYUdGSVZXRnJUa1ZGU0VFNU5HbHVSMlFLY2tsTFdYZ3ZRM05wWmtwSE9WRktaMVpzUldaTVlsQkNkQzlUZG1JeE9XVjVNamROZFZoV1FreHZWek5xVlhWbWFuWnRjbVZzU21KeWNVNVFaRmcxVWdwUE5GWnFNMHhOV1cxd1pVOVpPVWxzWkhwM01rbzBhekJ1ZUc1dlN6Uk1TMlJuVGt0R1ZsUTNSekJqVm1WSGFEWnJWamMwV1ZkUWMwRTNhMGhvUzJobUNtODFTM0ZrWWtGSmJVMWFVbWw0TkV3M0szWmtiemRhU0dOb2R6QllSVk5EV1Roc1FYcHROUzlTV1RocFowVXphems1VUdaNFduQlhPRmMzYlhCMU9VWUtXREZhWlhoU2VUUjZVR29yVWt0RU9VVldaRFJDUkVkM1p6ZGFWMEZHZWtKaVpXbE9UMmRrUlRnM1JYRnBjR0ZaV2tOSWVDOUNTRlpJTldNd1FuaFNkUXBwVW1ndmNtbE1WM2xvTWtjNFpYcDJiWG80UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRUjJFM2FUWkxaa1I2VG10bGQyNXNRelJxWVhSS1pGZ3JORUZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUm14d09WWnNXRU5GY2toVFUyaHVaa0ZPU2xSTWEzWjRhamRXYm1kd2RIWjZTVmxOUmpoT1MzaGtSV2x1UlN0d1JBcDRVRlF3YVhabk4wTlJaR2h1YlZJNGFsUXJTVnBOZHl0eFJscENibFpPZEc5RmIyOXNRM1I1ZDBVclVWZ3hWa2g0VGtSdWEzSjVPSEZFWkdVMmEzbFpDbUZRY0hWamFYVkNRVU53WldaMGJWVlVlRTB4YUhSek5IQkpSR0ZqWW5OWE5tWnFSbXR5YzNGMGQzSnBSVWd4WTFKaWJWZElTRWxoTDFWRlNIQnRNM2NLWWsxdVNFeG5NM2N6VGxGTlVUVlpXblJaTkRGQmJXTnRaRlpMVG0xRkwwbDZRbFZwTm1SUmQzaGhjbWhFVjBaeE4yNU5lV1ZaVmpSSWNtdHFiWFU1ZVFveFZIUkRSMlJHVkV0NFZITjZZV3hyUzFKRFoyaGtNVlF4UVZGemJYWlFZblF3Ym13d2VGUnpaMDVKZVdWVVMyUjVUMk5QVm5OYVozSktaaXRCVVRaeENrTmlVVkZOWWxORVkwVkdXVWhTTldaelRtWmhNelJSY1RKaGR6SkZRblpTVVZGaFJnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZjljOGM4Ny04OGMwLTQyZmEtYWJhZC1jN2QyYjVjYjhkN2UuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AcHJpdmF0ZS1uZXR3b3JrLWNsdXN0ZXIKICBjb250ZXh0OgogICAgY2x1c3RlcjogInByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogcHJpdmF0ZS1uZXR3b3JrLWNsdXN0ZXItYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkBwcml2YXRlLW5ldHdvcmstY2x1c3RlcgpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpSkF6UWZoc1JMMGwzdWhwWTR4Nkw0WVBxRHlGYTcyc0ZYalZNM1JicUJtaUNpZE93VTZPRHM4bw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2676"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2d451e20-4247-468e-bdd5-cde0c601ce21
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:45:18.171587Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "590"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e812f841-a670-44a4-b179-30b4d807ec30
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/nodes?order_by=created_at_asc&page=1&pool_id=bb91e99d-5ba7-4073-bade-3d3d1b75dc8c&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-13T16:41:15.990110Z","error_message":null,"id":"37b6afe1-aca0-4792-90f4-0416c78bd8ed","name":"scw-private-network-cluster-pool-37b6afe1aca04","pool_id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","provider_id":"scaleway://instance/fr-par-1/2fa5c836-c7f1-4f08-bedd-0ffdc13ee35b","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-13T16:45:18.154355Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d92800c7-81d6-4f0d-85b6-dfa2152cb44c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/bb91e99d-5ba7-4073-bade-3d3d1b75dc8c
+    method: DELETE
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:39:53.559754Z","id":"bb91e99d-5ba7-4073-bade-3d3d1b75dc8c","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-13T16:45:26.575659609Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "596"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 09302a28-3730-4a34-81ae-20e4ec0ff9d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.0.0/22","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":true,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
+    method: POST
+  response:
+    body: '{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "568"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73c92408-3756-46d4-9ee3-bfd8be3a5171
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"private-network-for-public-ip","tags":[]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: PATCH
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"private-network-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"172.16.4.0/22","updated_at":"2023-10-13T16:39:47.032043Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:39:47.032043Z"}],"tags":[],"updated_at":"2023-10-13T16:45:26.655070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "712"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 31dd99b4-a96c-489e-8fbd-081554489837
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/8eb8761b-b46c-48a9-bd1a-f9ff5046cfca
+    method: GET
+  response:
+    body: '{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "568"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 12b16dd2-4b4e-4533-83cc-936a1cead80d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"private-network-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"172.16.4.0/22","updated_at":"2023-10-13T16:39:47.032043Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:39:47.032043Z"}],"tags":[],"updated_at":"2023-10-13T16:45:26.655070Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "712"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5bb5fd5a-908e-4486-b91b-7b9f25ab66fe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"public-gateway-for-public-ip","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":null,"enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+    method: POST
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:27.260199Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "948"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b54b9233-e412-4c06-82fa-e4097df4afa2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:27.315680Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "951"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73d162e8-c576-4c4e-90ef-b954d20ab9e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:28.091477Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "948"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fc4def0a-4782-47eb-b589-89b53a152fcd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:28.091477Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "948"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aeb4b9c7-0192-4bef-ade0-962c43654e3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:28.091477Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "948"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 95a124a8-19d5-41ee-ba84-c74b717b5116
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
+    method: POST
+  response:
+    body: '{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":null,"private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"created","updated_at":"2023-10-13T16:45:34.211630Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "934"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8ea0057-596a-4f10-8967-3be6c01d5aa9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":null,"private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"created","updated_at":"2023-10-13T16:45:34.211630Z","zone":"fr-par-1"}],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:34.449562Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1886"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1f7be1a3-d06d-4408-ae10-ab37d91760c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:37.985611Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1895"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 79296039-7293-44ba-b87d-ec185b2d6728
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 705ab503-50dc-4724-9c61-39e7a8a75656
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b3ae3d9d-fbf1-429f-b838-38834e88d288
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:37.985611Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1895"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5082cee1-7752-480d-bc30-39cb4d9132fe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 340c2f7a-2e6f-4f33-aa28-c8381569bd00
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"cluster-for-public-ip","description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: PATCH
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:45:40.056342234Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1464"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c01c3fb1-967b-4dda-bb31-583becb256b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:45:40.056342Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1461"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0782eedc-80d4-421a-8538-f484f824e9f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:45:40.267642Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1466"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8b382a71-360f-419a-a064-1496905322aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:45:40.267642Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1466"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99dc1669-24c8-4772-9f77-f20bbe02900d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXItZm9yLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhOYWtVeVRYcHJNRTlXYjFoRVZFMTZUVlJCZUUxcVJUSk5lbXN3VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUR1J2Q2s5UE4wTjFlR3hxWW5NM00zSnRTVVpRY2xBMFVVeEtRalozZERGQ2NURkViRmxXTVRKM00weHBiR2Q1ZFRsTmFHRklWV0ZyVGtWRlNFRTVOR2x1UjJRS2NrbExXWGd2UTNOcFprcEhPVkZLWjFac1JXWk1ZbEJDZEM5VGRtSXhPV1Y1TWpkTmRWaFdRa3h2VnpOcVZYVm1hblp0Y21Wc1NtSnljVTVRWkZnMVVncFBORlpxTTB4TldXMXdaVTlaT1Vsc1pIcDNNa28wYXpCdWVHNXZTelJNUzJSblRrdEdWbFEzUnpCalZtVkhhRFpyVmpjMFdWZFFjMEUzYTBob1MyaG1DbTgxUzNGa1lrRkpiVTFhVW1sNE5FdzNLM1prYnpkYVNHTm9kekJZUlZORFdUaHNRWHB0TlM5U1dUaHBaMFV6YXprNVVHWjRXbkJYT0ZjM2JYQjFPVVlLV0RGYVpYaFNlVFI2VUdvclVrdEVPVVZXWkRSQ1JFZDNaemRhVjBGR2VrSmlaV2xPVDJka1JUZzNSWEZwY0dGWldrTkllQzlDU0ZaSU5XTXdRbmhTZFFwcFVtZ3ZjbWxNVjNsb01rYzRaWHAyYlhvNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVIyRTNhVFpMWmtSNlRtdGxkMjVzUXpScVlYUktaRmdyTkVGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlJteHdPVlpzV0VORmNraFRVMmh1WmtGT1NsUk1hM1o0YWpkV2JtZHdkSFo2U1ZsTlJqaE9TM2hrUldsdVJTdHdSQXA0VUZRd2FYWm5OME5SWkdodWJWSTRhbFFyU1ZwTmR5dHhSbHBDYmxaT2RHOUZiMjlzUTNSNWQwVXJVVmd4VmtoNFRrUnVhM0o1T0hGRVpHVTJhM2xaQ21GUWNIVmphWFZDUVVOd1pXWjBiVlZVZUUweGFIUnpOSEJKUkdGalluTlhObVpxUm10eWMzRjBkM0pwUlVneFkxSmliVmRJU0VsaEwxVkZTSEJ0TTNjS1lrMXVTRXhuTTNjelRsRk5VVFZaV25SWk5ERkJiV050WkZaTFRtMUZMMGw2UWxWcE5tUlJkM2hoY21oRVYwWnhOMjVOZVdWWlZqUkljbXRxYlhVNWVRb3hWSFJEUjJSR1ZFdDRWSE42WVd4clMxSkRaMmhrTVZReFFWRnpiWFpRWW5Rd2Jtd3dlRlJ6WjA1SmVXVlVTMlI1VDJOUFZuTmFaM0pLWml0QlVUWnhDa05pVVZGTllsTkVZMFZHV1VoU05XWnpUbVpoTXpSUmNUSmhkekpGUW5aU1VWRmhSZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYWY5YzhjODctODhjMC00MmZhLWFiYWQtYzdkMmI1Y2I4ZDdlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGNsdXN0ZXItZm9yLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiY2x1c3Rlci1mb3ItcHVibGljLWlwIgogICAgdXNlcjogY2x1c3Rlci1mb3ItcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AY2x1c3Rlci1mb3ItcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3Rlci1mb3ItcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpSkF6UWZoc1JMMGwzdWhwWTR4Nkw0WVBxRHlGYTcyc0ZYalZNM1JicUJtaUNpZE93VTZPRHM4bw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2660"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 365d0518-f092-48ca-a640-6c2ca4c4e226
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:45:40.267642Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1466"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2bcdce50-7e02-48fb-aed8-df95572c1739
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"pool","node_type":"gp1_xs","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":true}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/pools
+    method: POST
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601107677Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "594"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9e5fdddb-0ddf-4fc5-bbea-a35b397f7ead
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6da1d753-0ca5-4324-a3c5-c7accfdb1942
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d5e5ef3b-fda4-4713-9663-0acc23994b20
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:45:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a55b1904-2dc6-43a0-bd42-6a2f1a3aeac2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e1df8e25-d686-49eb-800f-43b5dcda5cfb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b30d64ad-d699-44a1-857d-bc503b88aa24
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e373a4d9-f59e-47d4-b9f0-06e677389e84
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 153343dc-eb25-4f99-88a9-5af1bb7f569f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b079017-d8bb-49d8-a14a-7955b7a4975a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e16b6364-4126-4a40-83a4-6450ebb0d946
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9e21964-8ea8-4e74-b414-0fc7566e0a67
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d1f52674-5f14-4862-9339-5001373416d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 65a649d8-a4ed-46bf-b506-8c36676781cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6455b260-f7dd-4e89-aa9c-fe4045989640
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bce33cda-83c3-4f4b-bf53-f553e41a2b02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:46:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a400d3c0-f2a7-4935-8a80-7b7fe807bb77
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8eae321-7471-4a48-a528-f3920154b6e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8ed01595-f44f-486d-8c17-815cdbc658e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db0a9794-0f4a-4625-8e54-1a34a902fb46
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a7235fa-cab5-468f-b47c-79cf49345dbd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7d7890f5-5805-4174-b4e5-749cadfde548
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4b02f028-713e-4796-8556-43d494cbd5d6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d3db3e3d-6d50-4162-87b6-13a1f249226f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c2515a07-e030-4bec-a006-256eac622e5a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec206261-3ab5-4e1e-b4d9-96333f34d25f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14122eff-1f16-4ace-8c93-6983b9aed5aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 39a1496f-27fc-4590-9440-31438ee41f69
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:47:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a18413a8-db5b-4086-ad65-20a5e20f41f0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5104e5fb-f4e0-41ee-a26f-2de5c062d7bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b652c4d2-5ed1-49f7-84d3-c5cba4899425
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - de5d77ba-8d5e-4564-bbd2-7fc5c793bacd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ed10a5c-8d09-437e-8b62-dbd9e677685e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08ce852c-310b-47c3-8b0e-e7ba02aa6f1a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f434e98f-9c5f-4c81-beee-bc83e810047e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c1dcd56-3976-4656-95fb-5f980c3559e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0166e4f1-0cb1-47d0-89a9-08393b13fe15
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 47a4dbd9-bcbd-40dc-b05f-fb95f583e5c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ac7985b9-c381-4f13-acda-80e6e313866c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40264d36-3299-43bc-8d98-d179086414ce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:48:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d8e18269-4399-4019-bef9-f8bf9b6e545e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd7af838-a39e-4718-aaf0-45c996cef7bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d254217-500b-4a72-a551-a0dc934d5081
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6cb4c459-1349-491c-bc0a-f7f35f7ad9a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 21779f6c-43c1-4d3b-bf17-ba2752c9327b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 31aac347-b9aa-402f-84dc-4e6d34182efe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 532d922d-0828-448d-a27c-556d4ceaa5ed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e585cb1-da06-4acc-93fe-b7969d217a1f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ffe2165-91db-4310-b3b4-c334de7d9d36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b84df75-c7bc-4034-9e7f-cd5af303e216
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1d89df39-d7df-411f-b9b7-92c06c9d8dd7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d193ef22-12a7-4934-9784-e7ec05bd8da2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:49:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22ef6ef8-2c05-451d-a5fc-4ef3a4c47b42
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0dec82a-939b-4694-89b3-47e588933df4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 445f58f2-47d6-4c69-932f-c0f633a06753
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6e82bc2a-c28e-485e-bf11-a90d2f322cec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dfb0da90-3c49-4462-ae34-153b02bb7bc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8bc7d27c-a342-47cc-8946-293b9fb82518
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7d658480-0e95-452f-a2a3-b2db2f8ef14d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9003f6dd-f355-4738-bd7b-3f7810d138de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - edd049a0-6f06-43b2-9538-01e9a807d7b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 93e64eca-93a3-4dc0-aa5c-0e0a41f87624
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54fb59de-3af5-41b1-9f6e-413b15821f7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:50:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dad03bac-c92a-423a-a0b6-e6d1270be6f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5877721c-f666-4c97-a843-90d566e081d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 64deff67-7df9-44c6-8330-7a089e555ae1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb75178a-725d-4f37-8f65-83241d983f31
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 31a57dfe-10d9-4d0d-8bf6-73dc5ec9f239
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d1189e1f-c155-4593-84e6-9c6e26d1d209
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a771bd9c-8e41-4571-93c5-665285db1a79
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-13T16:45:45.601108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "591"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25097ac9-2e77-4c62-8d1b-759161555b5a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:51:33.564181Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "589"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 559a7506-a57a-4ef8-85d5-4e1e2cf00425
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:48:29.407795Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1458"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 969ad85a-478f-4027-b8e9-897c7a1ec7c0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:51:33.564181Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "589"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e859de0f-4ad5-4bbc-8f4b-4a92d5295e0a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/nodes?order_by=created_at_asc&page=1&pool_id=8c891d59-fcc4-46ac-9fcc-84e7e8b247ac&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-13T16:47:36.066176Z","error_message":null,"id":"41d7c5d8-276b-453c-accc-90e9f963e66c","name":"scw-cluster-for-public-ip-pool-41d7c5d8276b453","pool_id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","provider_id":"scaleway://instance/fr-par-1/183d1401-eb62-4e4f-8b45-651322e1c789","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-13T16:51:33.548328Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82b9aa71-e876-4d34-a61d-ccb0b7b4f2d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:48:29.407795Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1458"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 28bd52d9-d9d3-4673-a399-101a701ac115
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"private-network-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:33.199753Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:45:33.207096Z"}],"tags":[],"updated_at":"2023-10-13T16:45:37.509737Z","vpc_id":"48a1c9ae-c37f-4292-8291-cd07ba8baf8b"}'
+    headers:
+      Content-Length:
+      - "713"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e7dbc93e-64b3-4596-a9da-bd7d770c269d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:51:33.564181Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "589"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6fa11a90-2e9a-452f-9ab3-2e89f14a0dc3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/nodes?order_by=created_at_asc&pool_id=8c891d59-fcc4-46ac-9fcc-84e7e8b247ac&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-13T16:47:36.066176Z","error_message":null,"id":"41d7c5d8-276b-453c-accc-90e9f963e66c","name":"scw-cluster-for-public-ip-pool-41d7c5d8276b453","pool_id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","provider_id":"scaleway://instance/fr-par-1/183d1401-eb62-4e4f-8b45-651322e1c789","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-13T16:51:33.548328Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 98ee9a3a-934e-4261-8244-114a685748a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/183d1401-eb62-4e4f-8b45-651322e1c789
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-10-13T16:47:36.483378+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scw-cluster-for-public-ip-pool-41d7c5d8276b453","id":"183d1401-eb62-4e4f-8b45-651322e1c789","image":{"arch":"x86_64","creation_date":"2023-10-05T10:50:51.838301+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8795d4a3-0918-41f3-b119-03a7effbdd8f","modification_date":"2023-10-05T11:06:46.734414+00:00","name":"k8s_base_node_2023-09-27.6","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"23e4a5ca-9587-4556-8eee-34cafe7b43cc","name":"k8s_base_node_2023-09-27.6","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"5","hypervisor_id":"501","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:28:b1:af","maintenances":[],"modification_date":"2023-10-13T16:47:54.889648+00:00","name":"scw-cluster-for-public-ip-pool-41d7c5d8276b453","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.12.170.7","private_nics":[{"creation_date":"2023-10-13T16:47:37.053756+00:00","id":"2428e42c-da70-4524-b326-06237b4ad7ac","mac_address":"02:00:00:14:3a:55","modification_date":"2023-10-13T16:47:37.963702+00:00","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","server_id":"183d1401-eb62-4e4f-8b45-651322e1c789","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"44e4f345-a9c0-4460-8a89-e19be6040633","name":"kubernetes
+      af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","pool=8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","pool-name=pool","runtime=containerd","managed=true","node=41d7c5d8-276b-453c-accc-90e9f963e66c"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-13T16:47:36.483378+00:00","export_uri":null,"id":"78e64b47-53cd-4c9e-a891-4d4ae61dc97e","modification_date":"2023-10-13T16:47:36.483378+00:00","name":"k8s_base_node_2023-09-27.6","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"183d1401-eb62-4e4f-8b45-651322e1c789","name":"scw-cluster-for-public-ip-pool-41d7c5d8276b453"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3464"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 17c37a22-1f73-4a6e-90aa-6a7c267bb320
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: GET
+  response:
+    body: '{"created_at":"2023-10-13T16:39:47.032043Z","dhcp_enabled":true,"id":"160fa1a0-4945-4225-a3de-df20c40648a7","name":"private-network-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-13T16:39:47.032043Z","id":"40a574e9-4193-498d-ae4f-cdae6d6c76bd","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:33.199753Z"},{"created_at":"2023-10-13T16:39:47.032043Z","id":"731139e3-8cb3-427b-9d08-15d98200d104","subnet":"fd63:256c:45f7:97b7::/64","updated_at":"2023-10-13T16:45:33.207096Z"}],"tags":[],"updated_at":"2023-10-13T16:45:37.509737Z","vpc_id":"48a1c9ae-c37f-4292-8291-cd07ba8baf8b"}'
+    headers:
+      Content-Length:
+      - "713"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ea85397-b801-4ace-96ca-07cddcb47c72
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/8eb8761b-b46c-48a9-bd1a-f9ff5046cfca
+    method: GET
+  response:
+    body: '{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "568"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6c7daf8d-3250-4632-8011-7c6b67ea2e40
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:37.985611Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1895"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 361a5e0e-de57-4eb1-8388-3c4cd68d3e36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eae4cf22-b95e-4d5f-adbe-8de7d5992062
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:37.985611Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1895"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 79109f4f-75df-4748-ad7e-bfa537a52f22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eea37e7a-8825-42f4-8887-8aabc8890d10
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:48:29.407795Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1458"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8bfb0858-0dc6-4ffa-acb0-f7da2f35c886
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogImNsdXN0ZXItZm9yLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhOYWtVeVRYcHJNRTlXYjFoRVZFMTZUVlJCZUUxcVJUSk5lbXN3VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUR1J2Q2s5UE4wTjFlR3hxWW5NM00zSnRTVVpRY2xBMFVVeEtRalozZERGQ2NURkViRmxXTVRKM00weHBiR2Q1ZFRsTmFHRklWV0ZyVGtWRlNFRTVOR2x1UjJRS2NrbExXWGd2UTNOcFprcEhPVkZLWjFac1JXWk1ZbEJDZEM5VGRtSXhPV1Y1TWpkTmRWaFdRa3h2VnpOcVZYVm1hblp0Y21Wc1NtSnljVTVRWkZnMVVncFBORlpxTTB4TldXMXdaVTlaT1Vsc1pIcDNNa28wYXpCdWVHNXZTelJNUzJSblRrdEdWbFEzUnpCalZtVkhhRFpyVmpjMFdWZFFjMEUzYTBob1MyaG1DbTgxUzNGa1lrRkpiVTFhVW1sNE5FdzNLM1prYnpkYVNHTm9kekJZUlZORFdUaHNRWHB0TlM5U1dUaHBaMFV6YXprNVVHWjRXbkJYT0ZjM2JYQjFPVVlLV0RGYVpYaFNlVFI2VUdvclVrdEVPVVZXWkRSQ1JFZDNaemRhVjBGR2VrSmlaV2xPVDJka1JUZzNSWEZwY0dGWldrTkllQzlDU0ZaSU5XTXdRbmhTZFFwcFVtZ3ZjbWxNVjNsb01rYzRaWHAyYlhvNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVIyRTNhVFpMWmtSNlRtdGxkMjVzUXpScVlYUktaRmdyTkVGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlJteHdPVlpzV0VORmNraFRVMmh1WmtGT1NsUk1hM1o0YWpkV2JtZHdkSFo2U1ZsTlJqaE9TM2hrUldsdVJTdHdSQXA0VUZRd2FYWm5OME5SWkdodWJWSTRhbFFyU1ZwTmR5dHhSbHBDYmxaT2RHOUZiMjlzUTNSNWQwVXJVVmd4VmtoNFRrUnVhM0o1T0hGRVpHVTJhM2xaQ21GUWNIVmphWFZDUVVOd1pXWjBiVlZVZUUweGFIUnpOSEJKUkdGalluTlhObVpxUm10eWMzRjBkM0pwUlVneFkxSmliVmRJU0VsaEwxVkZTSEJ0TTNjS1lrMXVTRXhuTTNjelRsRk5VVFZaV25SWk5ERkJiV050WkZaTFRtMUZMMGw2UWxWcE5tUlJkM2hoY21oRVYwWnhOMjVOZVdWWlZqUkljbXRxYlhVNWVRb3hWSFJEUjJSR1ZFdDRWSE42WVd4clMxSkRaMmhrTVZReFFWRnpiWFpRWW5Rd2Jtd3dlRlJ6WjA1SmVXVlVTMlI1VDJOUFZuTmFaM0pLWml0QlVUWnhDa05pVVZGTllsTkVZMFZHV1VoU05XWnpUbVpoTXpSUmNUSmhkekpGUW5aU1VWRmhSZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYWY5YzhjODctODhjMC00MmZhLWFiYWQtYzdkMmI1Y2I4ZDdlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGNsdXN0ZXItZm9yLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiY2x1c3Rlci1mb3ItcHVibGljLWlwIgogICAgdXNlcjogY2x1c3Rlci1mb3ItcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AY2x1c3Rlci1mb3ItcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3Rlci1mb3ItcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpSkF6UWZoc1JMMGwzdWhwWTR4Nkw0WVBxRHlGYTcyc0ZYalZNM1JicUJtaUNpZE93VTZPRHM4bw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2660"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 76073247-9eba-4a65-a213-51d68cac5091
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-13T16:51:33.564181Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "589"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90afde56-bfc6-4e0c-a72a-24a03bebd02a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e/nodes?order_by=created_at_asc&page=1&pool_id=8c891d59-fcc4-46ac-9fcc-84e7e8b247ac&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-13T16:47:36.066176Z","error_message":null,"id":"41d7c5d8-276b-453c-accc-90e9f963e66c","name":"scw-cluster-for-public-ip-pool-41d7c5d8276b453","pool_id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","provider_id":"scaleway://instance/fr-par-1/183d1401-eb62-4e4f-8b45-651322e1c789","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-13T16:51:33.548328Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bfbcc7d2-e0e8-474b-9d28-351129e6ebde
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/8c891d59-fcc4-46ac-9fcc-84e7e8b247ac
+    method: DELETE
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","container_runtime":"containerd","created_at":"2023-10-13T16:45:45.591907Z","id":"8c891d59-fcc4-46ac-9fcc-84e7e8b247ac","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-13T16:51:39.083422474Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "595"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1cef29d7-3671-4b54-a180-6a41a34ecfa1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e?with_additional_resources=true
+    method: DELETE
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:51:39.159510773Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1464"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99273c6e-0bd0-4800-a47e-debe1ef0ddc4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:51:39.159511Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1461"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee9837b2-d64a-49f5-aaad-cc63da4b88aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:51:39.159511Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1461"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 732b4012-900e-43ba-9270-9d6de4249726
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-13T16:39:48.130266Z","created_at":"2023-10-13T16:39:48.130266Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","ingress":"none","name":"cluster-for-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-13T16:51:39.159511Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1461"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - faf9c795-ac37-419b-a294-34e484f2c41d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce74670b-58af-4053-94ac-f730e36d2354
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"ready","updated_at":"2023-10-13T16:45:37.875796Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "947"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8a8b845-7348-4440-8460-c9552a1b0770
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6?cleanup_dhcp=false
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 67b78e91-6c00-46de-8693-97afdeb63b42
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-10-13T16:45:34.211630Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-13T16:45:26.640477Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8eb8761b-b46c-48a9-bd1a-f9ff5046cfca","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-13T16:45:26.640477Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","mac_address":"02:00:00:14:3A:54","private_network_id":"160fa1a0-4945-4225-a3de-df20c40648a7","status":"detaching","updated_at":"2023-10-13T16:51:54.664090Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "951"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6d55a385-d69e-4e8a-9668-2bf798643f47
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/3c8c066e-1871-4cf5-9680-3685a4ff7ed6
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"3c8c066e-1871-4cf5-9680-3685a4ff7ed6","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 49a829af-7f4f-4e95-906f-c486c5fed040
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:37.985611Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "948"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 181136bb-3dca-4fc6-bbb5-a92beb9ba844
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-13T16:45:27.260199Z","gateway_networks":[],"id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","ip":{"address":"163.172.133.160","created_at":"2023-10-13T16:45:27.233768Z","gateway_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","id":"fd3ec228-0dea-47a7-b9cc-51760411f601","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"160-133-172-163.instances.scw.cloud","tags":[],"updated_at":"2023-10-13T16:45:27.233768Z","zone":"fr-par-1"},"name":"public-gateway-for-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-13T16:45:37.985611Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "948"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8664f7e4-f05f-4183-8ad6-d4486391349c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/8eb8761b-b46c-48a9-bd1a-f9ff5046cfca
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:51:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2d2d422a-ae51-4026-aac6-42bdcd0aa9bc
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5?cleanup_dhcp=false
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:52:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8daedecd-a88a-4b49-93e9-98d7a3d94cd5
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"7ddccc3f-323e-4cb4-8f48-9c4d1db5a8d5","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:52:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c5e42ec6-a419-4479-946f-28e68d3d5fa3
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/160fa1a0-4945-4225-a3de-df20c40648a7
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:52:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 018ace84-7311-4f2d-ace2-1b4e47330b90
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"af9c8c87-88c0-42fa-abad-c7d2b5cb8d7e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Oct 2023 16:52:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2cf0c20a-af01-4f06-8342-a287ea985c89
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
The k8s API just got a new field `public_ip_disabled` which allows users to choose if they want their pools to be given a public IP or not. 
It should be integrated to the `scaleway_k8s_pool` resource.